### PR TITLE
Fix Raven VaultService initialization without WARDENPASS

### DIFF
--- a/services/raven/src/main/java/com/paxkun/raven/service/VaultService.java
+++ b/services/raven/src/main/java/com/paxkun/raven/service/VaultService.java
@@ -28,7 +28,7 @@ public class VaultService {
     @Value("${vault.url:http://noona-vault:3005}")
     private String vaultUrl;
 
-    @Value("${WARDENPASS}")
+    @Value("${vault.wardenPass:${WARDENPASS:}}")
     private String wardenPass;
 
     private String jwtToken;
@@ -39,6 +39,9 @@ public class VaultService {
 
     private void ensureAuth() {
         if (jwtToken == null || jwtToken.isEmpty()) {
+            if (wardenPass == null || wardenPass.isBlank()) {
+                throw new IllegalStateException("WARDENPASS is not configured. Set the WARDENPASS environment variable or the 'vault.wardenPass' property.");
+            }
             log.info("[VaultService] 🔐 Authenticating with Vault...");
             Map<String, String> authRequest = Map.of("password", wardenPass);
 


### PR DESCRIPTION
## Summary
- allow Raven's VaultService to accept a missing WARDENPASS by defaulting to an empty value that can be overridden via the `vault.wardenPass` property
- surface a clear error message if VaultService is used without a configured password so production environments still fail fast

## Testing
- ./gradlew test --stacktrace --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dd1b01b5a0833192b906331bf2732d