### PR TITLE
Fix Raven Docker build by invoking Gradle binary

### DIFF
--- a/deployment/raven.Dockerfile
+++ b/deployment/raven.Dockerfile
@@ -8,11 +8,15 @@ WORKDIR /app
 # Copy your Raven service source code into the build context
 COPY services/raven /app
 
-# Ensure gradlew is executable
+# Ensure gradlew is executable for local development consistency
 RUN chmod +x ./gradlew
 
-# Build the Shadow fat jar
-RUN ./gradlew shadowJar
+# Build the Shadow fat jar using the Gradle distribution provided by the image.
+# On some hosts (notably Windows), the copied gradlew script may retain CRLF
+# line endings and become unusable during the Docker build stage. Invoking the
+# Gradle runtime directly avoids those line-ending issues while still
+# respecting the project configuration.
+RUN gradle --no-daemon shadowJar
 
 # ────────────────────────────────────────────────
 # 🦅 Noona Raven - Runtime Stage with Chrome installed


### PR DESCRIPTION
## Summary
- run the Raven service build with the Gradle binary provided by the base image to avoid Windows line-ending issues
- document the rationale for using the bundled Gradle CLI during Docker builds

## Testing
- not run (docker not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68de59a99b4483319ea553c17229756d