### PR TITLE
Add modular warden core with unit tests

### DIFF
--- a/services/warden/initWarden.mjs
+++ b/services/warden/initWarden.mjs
@@ -1,134 +1,19 @@
 // services/warden/initWarden.mjs
-import Docker from 'dockerode';
-import noonaDockers from './docker/noonaDockers.mjs';
-import addonDockers from './docker/addonDockers.mjs';
-import {
-    attachSelfToNetwork,
-    containerExists,
-    ensureNetwork,
-    pullImageIfNeeded,
-    runContainerWithLogs,
-    waitForHealthyStatus
-} from './docker/dockerUtilties.mjs';
-import { errMSG, log, warn } from '../../utilities/etc/logger.mjs';
+import { createWarden } from './shared/wardenCore.mjs';
+import { errMSG } from '../../utilities/etc/logger.mjs';
 
-const docker = new Docker();
-const networkName = 'noona-network';
-const trackedContainers = new Set();
+const warden = createWarden();
 
-const DEBUG = process.env.DEBUG || 'false';
-const SUPER_MODE = DEBUG === 'super';
-const HOST_SERVICE_URL = process.env.HOST_SERVICE_URL || 'http://localhost';
+process.on('SIGINT', () => {
+    void warden.shutdownAll();
+});
 
-function resolveHostServiceUrl(service) {
-    if (service.hostServiceUrl) {
-        return service.hostServiceUrl;
-    }
+process.on('SIGTERM', () => {
+    void warden.shutdownAll();
+});
 
-    if (service.port) {
-        return `${HOST_SERVICE_URL}:${service.port}`;
-    }
-
-    return null;
-}
-
-async function startService(service, healthUrl = null) {
-    const hostServiceUrl = resolveHostServiceUrl(service);
-    const alreadyRunning = await containerExists(service.name);
-
-    if (!alreadyRunning) {
-        await pullImageIfNeeded(service.image);
-        await runContainerWithLogs(service, networkName, trackedContainers, DEBUG);
-    } else {
-        log(`${service.name} already running.`);
-    }
-
-    if (healthUrl) {
-        await waitForHealthyStatus(service.name, healthUrl);
-    }
-
-    if (hostServiceUrl) {
-        log(`[${service.name}] ✅ Ready (host_service_url: ${hostServiceUrl})`);
-    } else {
-        log(`[${service.name}] ✅ Ready.`);
-    }
-}
-
-async function bootMinimal() {
-    const redis = addonDockers['noona-redis'];
-    const moon = noonaDockers['noona-moon'];
-    const sage = noonaDockers['noona-sage'];
-
-    await startService(redis, 'http://noona-redis:8001/');
-    await startService(sage, 'http://noona-sage:3004/health');
-    await startService(moon, 'http://noona-moon:3000/');
-}
-
-async function bootFull() {
-    const services = {
-        ...addonDockers,
-        ...noonaDockers
-    };
-
-    const superBootOrder = [
-        'noona-redis',
-        'noona-mongo',
-        'noona-sage',
-        'noona-moon',
-        'noona-vault',
-        'noona-raven'
-    ];
-
-    for (const name of superBootOrder) {
-        const svc = services[name];
-        if (!svc) {
-            warn(`Service ${name} not found in addonDockers or noonaDockers.`);
-            continue;
-        }
-
-        let healthUrl =
-            name === 'noona-redis'
-                ? 'http://noona-redis:8001/'
-                : name === 'noona-sage'
-                    ? 'http://noona-sage:3004/health'
-                    : svc.health || null;
-
-        await startService(svc, healthUrl);
-    }
-}
-
-async function shutdownAll() {
-    warn(`Shutting down all containers...`);
-    for (const name of trackedContainers) {
-        try {
-            const container = docker.getContainer(name);
-            await container.stop();
-            await container.remove();
-            log(`Stopped & removed ${name}`);
-        } catch (err) {
-            warn(`Error stopping ${name}: ${err.message}`);
-        }
-    }
-    process.exit(0);
-}
-
-process.on('SIGINT', shutdownAll);
-process.on('SIGTERM', shutdownAll);
-
-async function init() {
-    await ensureNetwork(docker, networkName);
-    await attachSelfToNetwork(docker, networkName);
-
-    if (SUPER_MODE) {
-        log('[Warden] 💥 DEBUG=super — launching full stack in superBootOrder...');
-        await bootFull();
-    } else {
-        log('[Warden] 🧪 Minimal mode — launching redis, sage, moon only');
-        await bootMinimal();
-    }
-
-    log(`✅ Warden is ready.`);
-    setInterval(() => process.stdout.write('.'), 60000);
-}
-
-init().catch(err => errMSG(`[Warden Init] ❌ Fatal: ${err.message}`));
+warden.init()
+    .then(() => {
+        setInterval(() => process.stdout.write('.'), 60000);
+    })
+    .catch(err => errMSG(`[Warden Init] ❌ Fatal: ${err.message}`));

--- a/services/warden/package.json
+++ b/services/warden/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "start": "node initWarden.mjs",
-    "dev": "nodemon initWarden.mjs"
+    "dev": "nodemon initWarden.mjs",
+    "test": "node --test"
   },
   "dependencies": {
     "dockerode": "^4.0.7",

--- a/services/warden/shared/wardenCore.mjs
+++ b/services/warden/shared/wardenCore.mjs
@@ -1,0 +1,190 @@
+// services/warden/shared/wardenCore.mjs
+import Docker from 'dockerode';
+import addonDockers from '../docker/addonDockers.mjs';
+import noonaDockers from '../docker/noonaDockers.mjs';
+import {
+    attachSelfToNetwork,
+    containerExists,
+    ensureNetwork,
+    pullImageIfNeeded,
+    runContainerWithLogs,
+    waitForHealthyStatus,
+} from '../docker/dockerUtilties.mjs';
+import { log, warn } from '../../../utilities/etc/logger.mjs';
+
+function normalizeServices(servicesOption = {}) {
+    const { addon = addonDockers, core = noonaDockers } = servicesOption;
+    return { addon, core };
+}
+
+function normalizeDockerUtils(utilsOption = {}) {
+    return {
+        attachSelfToNetwork,
+        containerExists,
+        ensureNetwork,
+        pullImageIfNeeded,
+        runContainerWithLogs,
+        waitForHealthyStatus,
+        ...utilsOption,
+    };
+}
+
+function createDefaultLogger(loggerOption = {}) {
+    return {
+        log,
+        warn,
+        ...loggerOption,
+    };
+}
+
+export function createWarden(options = {}) {
+    const {
+        dockerInstance = new Docker(),
+        services: servicesOption,
+        dockerUtils: dockerUtilsOption,
+        logger: loggerOption,
+        env = process.env,
+        processExit = (code) => process.exit(code),
+        networkName: networkNameOption,
+        trackedContainers: trackedContainersOption,
+        superBootOrder: superBootOrderOption,
+    } = options;
+
+    const services = normalizeServices(servicesOption);
+    const dockerUtils = normalizeDockerUtils(dockerUtilsOption);
+    const logger = createDefaultLogger(loggerOption);
+
+    const trackedContainers = trackedContainersOption || new Set();
+    const networkName = networkNameOption || 'noona-network';
+    const DEBUG = env.DEBUG ?? 'false';
+    const SUPER_MODE = DEBUG === 'super';
+    const hostServiceBase = env.HOST_SERVICE_URL ?? 'http://localhost';
+    const bootOrder = superBootOrderOption || [
+        'noona-redis',
+        'noona-mongo',
+        'noona-sage',
+        'noona-moon',
+        'noona-vault',
+        'noona-raven',
+    ];
+
+    const api = {
+        trackedContainers,
+        networkName,
+        DEBUG,
+        SUPER_MODE,
+    };
+
+    api.resolveHostServiceUrl = function resolveHostServiceUrl(service) {
+        if (!service) {
+            return null;
+        }
+
+        if (service.hostServiceUrl) {
+            return service.hostServiceUrl;
+        }
+
+        if (service.port) {
+            return `${hostServiceBase}:${service.port}`;
+        }
+
+        return null;
+    };
+
+    api.startService = async function startService(service, healthUrl = null) {
+        if (!service) {
+            throw new Error('Service descriptor is required.');
+        }
+
+        const hostServiceUrl = api.resolveHostServiceUrl(service);
+        const alreadyRunning = await dockerUtils.containerExists(service.name);
+
+        if (!alreadyRunning) {
+            await dockerUtils.pullImageIfNeeded(service.image);
+            await dockerUtils.runContainerWithLogs(service, networkName, trackedContainers, DEBUG);
+        } else {
+            logger.log(`${service.name} already running.`);
+        }
+
+        if (healthUrl) {
+            await dockerUtils.waitForHealthyStatus(service.name, healthUrl);
+        }
+
+        if (hostServiceUrl) {
+            logger.log(`[${service.name}] ✅ Ready (host_service_url: ${hostServiceUrl})`);
+        } else {
+            logger.log(`[${service.name}] ✅ Ready.`);
+        }
+    };
+
+    api.bootMinimal = async function bootMinimal() {
+        const redis = services.addon['noona-redis'];
+        const moon = services.core['noona-moon'];
+        const sage = services.core['noona-sage'];
+
+        await api.startService(redis, 'http://noona-redis:8001/');
+        await api.startService(sage, 'http://noona-sage:3004/health');
+        await api.startService(moon, 'http://noona-moon:3000/');
+    };
+
+    api.bootFull = async function bootFull() {
+        const servicesMap = {
+            ...services.addon,
+            ...services.core,
+        };
+
+        for (const name of bootOrder) {
+            const svc = servicesMap[name];
+            if (!svc) {
+                logger.warn(`Service ${name} not found in addonDockers or noonaDockers.`);
+                continue;
+            }
+
+            const healthUrl =
+                name === 'noona-redis'
+                    ? 'http://noona-redis:8001/'
+                    : name === 'noona-sage'
+                        ? 'http://noona-sage:3004/health'
+                        : svc.health || null;
+
+            await api.startService(svc, healthUrl);
+        }
+    };
+
+    api.shutdownAll = async function shutdownAll() {
+        logger.warn(`Shutting down all containers...`);
+        for (const name of trackedContainers) {
+            try {
+                const container = dockerInstance.getContainer(name);
+                await container.stop();
+                await container.remove();
+                logger.log(`Stopped & removed ${name}`);
+            } catch (err) {
+                logger.warn(`Error stopping ${name}: ${err.message}`);
+            }
+        }
+
+        trackedContainers.clear();
+        processExit(0);
+    };
+
+    api.init = async function init() {
+        await dockerUtils.ensureNetwork(dockerInstance, networkName);
+        await dockerUtils.attachSelfToNetwork(dockerInstance, networkName);
+
+        if (SUPER_MODE) {
+            logger.log('[Warden] 💥 DEBUG=super — launching full stack in superBootOrder...');
+            await api.bootFull();
+        } else {
+            logger.log('[Warden] 🧪 Minimal mode — launching redis, sage, moon only');
+            await api.bootMinimal();
+        }
+
+        logger.log(`✅ Warden is ready.`);
+        return { mode: SUPER_MODE ? 'super' : 'minimal' };
+    };
+
+    return api;
+}
+
+export default createWarden;

--- a/services/warden/tests/wardenCore.test.mjs
+++ b/services/warden/tests/wardenCore.test.mjs
@@ -1,0 +1,231 @@
+// services/warden/tests/wardenCore.test.mjs
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWarden } from '../shared/wardenCore.mjs';
+
+test('resolveHostServiceUrl prefers explicit hostServiceUrl', () => {
+    const warden = createWarden({ services: { addon: {}, core: {} } });
+    const service = { hostServiceUrl: 'http://custom.local' };
+
+    assert.equal(warden.resolveHostServiceUrl(service), 'http://custom.local');
+});
+
+test('resolveHostServiceUrl falls back to HOST_SERVICE_URL and port', () => {
+    const warden = createWarden({
+        services: { addon: {}, core: {} },
+        env: { HOST_SERVICE_URL: 'http://host.example' },
+    });
+    const service = { port: 8080 };
+
+    assert.equal(warden.resolveHostServiceUrl(service), 'http://host.example:8080');
+});
+
+test('startService pulls, runs, waits, and logs when container is absent', async () => {
+    const calls = [];
+    const dockerUtils = {
+        ensureNetwork: async () => {},
+        attachSelfToNetwork: async () => {},
+        containerExists: async () => false,
+        pullImageIfNeeded: async (image) => {
+            calls.push(['pull', image]);
+        },
+        runContainerWithLogs: async (service, networkName, trackedContainers, debug) => {
+            trackedContainers.add(service.name);
+            calls.push(['run', service.name, networkName, debug]);
+        },
+        waitForHealthyStatus: async (name, url) => {
+            calls.push(['wait', name, url]);
+        },
+    };
+    const logs = [];
+    const warden = createWarden({
+        dockerUtils,
+        services: { addon: {}, core: {} },
+        logger: { log: (message) => logs.push(message), warn: () => {} },
+        env: { HOST_SERVICE_URL: 'http://host', DEBUG: 'true' },
+    });
+
+    const service = { name: 'noona-test', image: 'noona/test:latest', port: 1234 };
+    await warden.startService(service, 'http://health.local');
+
+    assert.deepEqual(calls, [
+        ['pull', 'noona/test:latest'],
+        ['run', 'noona-test', 'noona-network', 'true'],
+        ['wait', 'noona-test', 'http://health.local'],
+    ]);
+    assert.ok(warden.trackedContainers.has('noona-test'));
+    assert.ok(logs.some(line => line.includes('host_service_url: http://host:1234')));
+});
+
+test('startService skips pull and run when container already exists', async () => {
+    const dockerUtils = {
+        ensureNetwork: async () => {},
+        attachSelfToNetwork: async () => {},
+        containerExists: async () => true,
+        pullImageIfNeeded: async () => {
+            throw new Error('pullImageIfNeeded should not be called');
+        },
+        runContainerWithLogs: async () => {
+            throw new Error('runContainerWithLogs should not be called');
+        },
+        waitForHealthyStatus: async () => {},
+    };
+    const logs = [];
+    const warden = createWarden({
+        dockerUtils,
+        services: { addon: {}, core: {} },
+        logger: { log: (message) => logs.push(message), warn: () => {} },
+    });
+
+    await warden.startService({ name: 'noona-test', image: 'ignored', hostServiceUrl: 'http://custom' });
+
+    assert.ok(logs.some(line => line.includes('already running')));
+    assert.ok(logs.some(line => line.includes('host_service_url: http://custom')));
+});
+
+test('bootFull launches services in super boot order with correct health URLs', async () => {
+    const dockerUtils = {
+        ensureNetwork: async () => {},
+        attachSelfToNetwork: async () => {},
+        containerExists: async () => true,
+        pullImageIfNeeded: async () => {},
+        runContainerWithLogs: async () => {},
+        waitForHealthyStatus: async () => {},
+    };
+    const warnings = [];
+    const warden = createWarden({
+        dockerUtils,
+        services: {
+            addon: {
+                'noona-redis': { name: 'noona-redis' },
+            },
+            core: {
+                'noona-mongo': { name: 'noona-mongo', health: 'http://mongo/health' },
+                'noona-sage': { name: 'noona-sage' },
+                'noona-moon': { name: 'noona-moon', health: 'http://moon/health' },
+                'noona-vault': { name: 'noona-vault', health: 'http://vault/health' },
+                'noona-raven': { name: 'noona-raven' },
+            },
+        },
+        logger: { log: () => {}, warn: (message) => warnings.push(message) },
+    });
+
+    const order = [];
+    warden.startService = async (service, healthUrl) => {
+        order.push([service.name, healthUrl]);
+    };
+
+    await warden.bootFull();
+
+    assert.deepEqual(order, [
+        ['noona-redis', 'http://noona-redis:8001/'],
+        ['noona-mongo', 'http://mongo/health'],
+        ['noona-sage', 'http://noona-sage:3004/health'],
+        ['noona-moon', 'http://moon/health'],
+        ['noona-vault', 'http://vault/health'],
+        ['noona-raven', null],
+    ]);
+    assert.equal(warnings.length, 0);
+});
+
+test('init ensures network, attaches, and runs minimal boot sequence by default', async () => {
+    const events = [];
+    const dockerUtils = {
+        ensureNetwork: async () => events.push('ensure'),
+        attachSelfToNetwork: async () => events.push('attach'),
+        containerExists: async () => {
+            throw new Error('containerExists should not be invoked when startService is stubbed');
+        },
+        pullImageIfNeeded: async () => {},
+        runContainerWithLogs: async () => {},
+        waitForHealthyStatus: async () => {},
+    };
+    const logger = {
+        log: (message) => events.push(message),
+        warn: (message) => events.push(`warn:${message}`),
+    };
+    const warden = createWarden({
+        dockerUtils,
+        services: {
+            addon: {
+                'noona-redis': { name: 'noona-redis' },
+            },
+            core: {
+                'noona-moon': { name: 'noona-moon' },
+                'noona-sage': { name: 'noona-sage' },
+            },
+        },
+        logger,
+    });
+
+    warden.startService = async (service, healthUrl) => {
+        events.push(`start:${service.name}:${healthUrl}`);
+    };
+
+    const result = await warden.init();
+
+    assert.equal(result.mode, 'minimal');
+    assert.ok(events.includes('ensure'));
+    assert.ok(events.includes('attach'));
+    assert.ok(events.some(event => event.includes('Minimal mode')));
+    assert.ok(events.includes('start:noona-redis:http://noona-redis:8001/'));
+    assert.ok(events.includes('start:noona-sage:http://noona-sage:3004/health'));
+    assert.ok(events.includes('start:noona-moon:http://noona-moon:3000/'));
+    assert.ok(events.includes('✅ Warden is ready.'));
+});
+
+test('shutdownAll stops, removes, clears tracked containers and exits with code 0', async () => {
+    const operations = [];
+    const containers = {
+        'svc-1': {
+            stop: async () => operations.push('stop:svc-1'),
+            remove: async () => operations.push('remove:svc-1'),
+        },
+        'svc-2': {
+            stop: async () => operations.push('stop:svc-2'),
+            remove: async () => operations.push('remove:svc-2'),
+        },
+    };
+    const dockerInstance = {
+        getContainer: (name) => containers[name],
+    };
+    const trackedContainers = new Set(['svc-1', 'svc-2']);
+    let exitCode = null;
+    const dockerUtils = {
+        ensureNetwork: async () => {},
+        attachSelfToNetwork: async () => {},
+        containerExists: async () => true,
+        pullImageIfNeeded: async () => {},
+        runContainerWithLogs: async () => {},
+        waitForHealthyStatus: async () => {},
+    };
+    const logger = {
+        log: (message) => operations.push(message),
+        warn: (message) => operations.push(`warn:${message}`),
+    };
+
+    const warden = createWarden({
+        dockerInstance,
+        trackedContainers,
+        dockerUtils,
+        logger,
+        processExit: (code) => {
+            exitCode = code;
+        },
+    });
+
+    await warden.shutdownAll();
+
+    assert.deepEqual(operations, [
+        'warn:Shutting down all containers...',
+        'stop:svc-1',
+        'remove:svc-1',
+        'Stopped & removed svc-1',
+        'stop:svc-2',
+        'remove:svc-2',
+        'Stopped & removed svc-2',
+    ]);
+    assert.equal(trackedContainers.size, 0);
+    assert.equal(exitCode, 0);
+});


### PR DESCRIPTION
## Summary
- refactor the warden entrypoint to consume a shared core module for orchestration logic
- add a reusable `createWarden` helper in the shared folder with dependency injection for easier testing
- introduce a Node test suite that exercises host resolution, startup flows, shutdown handling, and expose an npm test script

## Testing
- npm test --prefix services/warden

------
https://chatgpt.com/codex/tasks/task_e_68deb92413dc8331bfdb330d2c304d19