### PR TITLE
Refactor vault app for testability and add unit tests

### DIFF
--- a/services/vault/initVault.mjs
+++ b/services/vault/initVault.mjs
@@ -5,106 +5,12 @@
  * Vault microservice for handling secure MongoDB and Redis operations from other Noona services.
  */
 
-import express from 'express';
 import dotenv from 'dotenv';
-import { handlePacket } from '../../utilities/database/packetParser.mjs';
-import { log, errMSG, debugMSG, warn } from '../../utilities/etc/logger.mjs';
+import { log, warn, debugMSG } from '../../utilities/etc/logger.mjs';
+import { createVaultApp } from './shared/vaultApp.mjs';
 
 dotenv.config();
 
-const app = express();
-app.use(express.json());
+const { app, port } = createVaultApp({ logger: { log, warn, debug: debugMSG } });
 
-// ====== ENV CONFIG ======
-const PORT = process.env.PORT || 3005;
-const VAULT_TOKEN_MAP = process.env.VAULT_TOKEN_MAP || '';
-
-// ====== PARSE TOKEN MAP ======
-const tokenPairs = VAULT_TOKEN_MAP.split(',')
-    .map(pair => pair.trim())
-    .filter(Boolean)
-    .map(pair => {
-        const [service, token] = pair.split(':');
-        return [service?.trim(), token?.trim()];
-    })
-    .filter(([service, token]) => Boolean(service && token));
-
-const tokensByService = Object.fromEntries(tokenPairs);
-const serviceByToken = Object.fromEntries(tokenPairs.map(([service, token]) => [token, service]));
-
-if (!tokenPairs.length) {
-    warn('[Vault] ⚠️ No service tokens were loaded. Protected routes will reject all requests.');
-} else {
-    const serviceList = tokenPairs.map(([service]) => service).join(', ');
-    log(`[Vault] Loaded API tokens for: ${serviceList}`);
-}
-
-/**
- * Extracts a Bearer token from the request Authorization header.
- * @param {import('express').Request} req - The incoming HTTP request.
- * @returns {string|null} The token string if a valid `Bearer` Authorization header is present; `null` otherwise.
- */
-function extractBearerToken(req) {
-    const authHeader = req.headers.authorization || '';
-    if (typeof authHeader !== 'string') return null;
-
-    const [scheme, token] = authHeader.split(' ');
-    if (!scheme || scheme.toLowerCase() !== 'bearer' || !token) {
-        return null;
-    }
-
-    return token.trim();
-}
-
-/**
- * Express middleware that authenticates requests using a Bearer token mapped to a service.
- *
- * If the Authorization header is missing or malformed, responds with 401 and
- * `{ error: 'Missing or invalid Authorization header' }`. If the token is not
- * recognized, responds with 401 and `{ error: 'Unauthorized service token' }`.
- * On success, sets `req.serviceName` to the authenticated service name and calls `next()`.
- *
- * @param {import('express').Request & { serviceName?: string }} req - Express request; on success `serviceName` is attached.
- */
-function requireAuth(req, res, next) {
-    const token = extractBearerToken(req);
-    if (!token) {
-        return res.status(401).json({ error: 'Missing or invalid Authorization header' });
-    }
-
-    const serviceName = serviceByToken[token];
-    if (!serviceName) {
-        debugMSG(`[Vault] ❌ Unknown token presented: ${token.slice(0, 6)}***`);
-        return res.status(401).json({ error: 'Unauthorized service token' });
-    }
-
-    req.serviceName = serviceName;
-    next();
-}
-
-// ====== ROUTES ======
-
-/**
- * Health check route
- */
-app.get('/v1/vault/health', (req, res) => {
-    res.send('Vault is up and running');
-});
-
-/**
- * Unified packet handler (secured)
- */
-app.post('/v1/vault/handle', requireAuth, async (req, res) => {
-    const packet = req.body;
-
-    debugMSG(`[Vault] Handling packet from ${req.serviceName}`);
-    const result = await handlePacket(packet);
-    if (result.error) {
-        return res.status(400).json({ error: result.error });
-    }
-
-    res.json(result);
-});
-
-// ====== START SERVER ======
-app.listen(PORT, () => log(`Vault listening on port ${PORT}`));
+app.listen(port, () => log(`Vault listening on port ${port}`));

--- a/services/vault/package.json
+++ b/services/vault/package.json
@@ -2,9 +2,10 @@
   "name": "vault",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "initVault.mjs",
+  "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/services/vault/shared/vaultApp.mjs
+++ b/services/vault/shared/vaultApp.mjs
@@ -1,0 +1,150 @@
+// services/vault/shared/vaultApp.mjs
+import express from 'express';
+
+let cachedHandlePacket = null;
+
+async function getDefaultHandlePacket() {
+    if (!cachedHandlePacket) {
+        const module = await import('../../../utilities/database/packetParser.mjs');
+        cachedHandlePacket = module.handlePacket;
+    }
+
+    return cachedHandlePacket;
+}
+
+const fallbackLogger = {
+    log: (...args) => console.log(...args),
+    warn: (...args) => console.warn(...args),
+    debug: (...args) => (console.debug ? console.debug(...args) : console.log(...args)),
+};
+
+export function parseTokenMap(tokenMapString = '') {
+    const tokenPairs = tokenMapString
+        .split(',')
+        .map(pair => pair.trim())
+        .filter(Boolean)
+        .map(pair => {
+            const [service, token] = pair.split(':');
+            return [service?.trim(), token?.trim()];
+        })
+        .filter(([service, token]) => Boolean(service && token));
+
+    const tokensByService = Object.fromEntries(tokenPairs);
+    const serviceByToken = Object.fromEntries(
+        tokenPairs.map(([service, token]) => [token, service])
+    );
+
+    return { tokenPairs, tokensByService, serviceByToken };
+}
+
+export function extractBearerToken(req) {
+    const authHeader = req.headers?.authorization || '';
+    if (typeof authHeader !== 'string') return null;
+
+    const [scheme, token] = authHeader.split(' ');
+    if (!scheme || scheme.toLowerCase() !== 'bearer' || !token) {
+        return null;
+    }
+
+    return token.trim();
+}
+
+export function createRequireAuth({ serviceByToken = {}, debug = fallbackLogger.debug } = {}) {
+    return function requireAuth(req, res, next) {
+        const token = extractBearerToken(req);
+        if (!token) {
+            return res
+                .status(401)
+                .json({ error: 'Missing or invalid Authorization header' });
+        }
+
+        const serviceName = serviceByToken[token];
+        if (!serviceName) {
+            debug(`[Vault] ❌ Unknown token presented: ${token.slice(0, 6)}***`);
+            return res.status(401).json({ error: 'Unauthorized service token' });
+        }
+
+        req.serviceName = serviceName;
+        next();
+    };
+}
+
+export function createVaultApp(options = {}) {
+    const {
+        env = process.env,
+        handlePacket,
+        expressFactory = express,
+        logger: loggerOption = {},
+        log,
+        warn,
+        debug,
+    } = options;
+
+    const logger = {
+        ...fallbackLogger,
+        ...loggerOption,
+    };
+
+    if (typeof log === 'function') {
+        logger.log = log;
+    }
+
+    if (typeof warn === 'function') {
+        logger.warn = warn;
+    }
+
+    if (typeof debug === 'function') {
+        logger.debug = debug;
+    }
+
+    const { tokenPairs, tokensByService, serviceByToken } = parseTokenMap(
+        env.VAULT_TOKEN_MAP || ''
+    );
+
+    if (!tokenPairs.length) {
+        logger.warn('[Vault] ⚠️ No service tokens were loaded. Protected routes will reject all requests.');
+    } else {
+        const serviceList = tokenPairs.map(([service]) => service).join(', ');
+        logger.log(`[Vault] Loaded API tokens for: ${serviceList}`);
+    }
+
+    const app = expressFactory();
+    app.use(express.json());
+
+    const requireAuth = createRequireAuth({ serviceByToken, debug: logger.debug });
+
+    app.get('/v1/vault/health', (req, res) => {
+        res.send('Vault is up and running');
+    });
+
+    app.post('/v1/vault/handle', requireAuth, async (req, res) => {
+        const packet = req.body;
+
+        logger.debug(`[Vault] Handling packet from ${req.serviceName}`);
+        let handler = handlePacket;
+
+        if (!handler) {
+            handler = await getDefaultHandlePacket();
+        }
+
+        const result = await handler(packet);
+        if (result?.error) {
+            return res.status(400).json({ error: result.error });
+        }
+
+        res.json(result ?? {});
+    });
+
+    const port = env.PORT || 3005;
+
+    return {
+        app,
+        port,
+        requireAuth,
+        tokensByService,
+        serviceByToken,
+        logger,
+    };
+}
+
+export default createVaultApp;

--- a/services/vault/tests/vaultApp.test.mjs
+++ b/services/vault/tests/vaultApp.test.mjs
@@ -1,0 +1,256 @@
+// services/vault/tests/vaultApp.test.mjs
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+
+import {
+    createVaultApp,
+    createRequireAuth,
+    extractBearerToken,
+    parseTokenMap,
+} from '../shared/vaultApp.mjs';
+
+function createMockResponse() {
+    return {
+        statusCode: 200,
+        body: null,
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            return this;
+        },
+    };
+}
+
+test('parseTokenMap builds lookup tables from VAULT_TOKEN_MAP', () => {
+    const { tokenPairs, tokensByService, serviceByToken } = parseTokenMap(
+        'moon:token1, raven:token2, invalid'
+    );
+
+    assert.deepEqual(tokenPairs, [
+        ['moon', 'token1'],
+        ['raven', 'token2'],
+    ]);
+    assert.deepEqual(tokensByService, {
+        moon: 'token1',
+        raven: 'token2',
+    });
+    assert.deepEqual(serviceByToken, {
+        token1: 'moon',
+        token2: 'raven',
+    });
+});
+
+test('extractBearerToken returns the token when Authorization header is valid', () => {
+    const req = { headers: { authorization: 'Bearer secret-token' } };
+    assert.equal(extractBearerToken(req), 'secret-token');
+});
+
+test('extractBearerToken returns null for missing or malformed headers', () => {
+    assert.equal(extractBearerToken({ headers: {} }), null);
+    assert.equal(extractBearerToken({ headers: { authorization: 'Basic abc' } }), null);
+    assert.equal(extractBearerToken({ headers: { authorization: 42 } }), null);
+});
+
+test('createRequireAuth denies requests without valid tokens', () => {
+    const middleware = createRequireAuth({ serviceByToken: {}, debug: () => {} });
+    const req = { headers: {} };
+    const res = createMockResponse();
+    let nextCalled = false;
+
+    middleware(req, res, () => {
+        nextCalled = true;
+    });
+
+    assert.equal(nextCalled, false);
+    assert.equal(res.statusCode, 401);
+    assert.deepEqual(res.body, {
+        error: 'Missing or invalid Authorization header',
+    });
+});
+
+test('createRequireAuth attaches serviceName for known tokens', () => {
+    const debugMessages = [];
+    const middleware = createRequireAuth({
+        serviceByToken: { 'secret-token': 'moon' },
+        debug: message => debugMessages.push(message),
+    });
+    const req = { headers: { authorization: 'Bearer secret-token' } };
+    const res = createMockResponse();
+    let nextCalled = false;
+
+    middleware(req, res, () => {
+        nextCalled = true;
+    });
+
+    assert.equal(nextCalled, true);
+    assert.equal(res.statusCode, 200);
+    assert.equal(req.serviceName, 'moon');
+    assert.equal(debugMessages.length, 0);
+});
+
+test('createRequireAuth logs debug message when token is unknown', () => {
+    const messages = [];
+    const middleware = createRequireAuth({
+        serviceByToken: { known: 'moon' },
+        debug: message => messages.push(message),
+    });
+    const req = { headers: { authorization: 'Bearer unknown' } };
+    const res = createMockResponse();
+
+    middleware(req, res, () => {});
+
+    assert.equal(res.statusCode, 401);
+    assert.equal(messages.length, 1);
+    assert.ok(messages[0].includes('Unknown token'));
+});
+
+test('createVaultApp warns when no tokens are configured', () => {
+    const warnings = [];
+    createVaultApp({
+        env: {},
+        warn: message => warnings.push(message),
+        log: () => {},
+        debug: () => {},
+        handlePacket: async () => ({}),
+    });
+
+    assert.equal(warnings.length, 1);
+    assert.ok(warnings[0].includes('No service tokens'));
+});
+
+test('createVaultApp logs loaded services when tokens exist', () => {
+    const logs = [];
+    createVaultApp({
+        env: { VAULT_TOKEN_MAP: 'moon:abc,raven:def' },
+        warn: () => {},
+        log: message => logs.push(message),
+        debug: () => {},
+        handlePacket: async () => ({}),
+    });
+
+    assert.ok(logs.some(message => message.includes('moon, raven')));
+});
+
+test('POST /v1/vault/handle authorizes valid token and returns result', async () => {
+    const packets = [];
+    const { app } = createVaultApp({
+        env: { VAULT_TOKEN_MAP: 'moon:secret' },
+        warn: () => {},
+        log: () => {},
+        debug: () => {},
+        handlePacket: async packet => {
+            packets.push(packet);
+            return { ok: true };
+        },
+    });
+
+    const server = app.listen(0);
+    await once(server, 'listening');
+    const { port } = server.address();
+
+    const response = await fetch(`http://127.0.0.1:${port}/v1/vault/handle`, {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer secret',
+        },
+        body: JSON.stringify({ action: 'ping' }),
+    });
+
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.deepEqual(body, { ok: true });
+    assert.deepEqual(packets, [{ action: 'ping' }]);
+
+    await new Promise((resolve, reject) =>
+        server.close(err => (err ? reject(err) : resolve()))
+    );
+});
+
+test('POST /v1/vault/handle returns 400 when handler reports error', async () => {
+    const { app } = createVaultApp({
+        env: { VAULT_TOKEN_MAP: 'moon:secret' },
+        warn: () => {},
+        log: () => {},
+        debug: () => {},
+        handlePacket: async () => ({ error: 'bad packet' }),
+    });
+
+    const server = app.listen(0);
+    await once(server, 'listening');
+    const { port } = server.address();
+
+    const response = await fetch(`http://127.0.0.1:${port}/v1/vault/handle`, {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer secret',
+        },
+        body: JSON.stringify({ action: 'ping' }),
+    });
+
+    assert.equal(response.status, 400);
+    const body = await response.json();
+    assert.deepEqual(body, { error: 'bad packet' });
+
+    await new Promise((resolve, reject) =>
+        server.close(err => (err ? reject(err) : resolve()))
+    );
+});
+
+test('POST /v1/vault/handle rejects requests without valid token', async () => {
+    const { app } = createVaultApp({
+        env: { VAULT_TOKEN_MAP: 'moon:secret' },
+        warn: () => {},
+        log: () => {},
+        debug: () => {},
+        handlePacket: async () => ({ ok: true }),
+    });
+
+    const server = app.listen(0);
+    await once(server, 'listening');
+    const { port } = server.address();
+
+    const response = await fetch(`http://127.0.0.1:${port}/v1/vault/handle`, {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json',
+        },
+        body: JSON.stringify({ action: 'ping' }),
+    });
+
+    assert.equal(response.status, 401);
+    const body = await response.json();
+    assert.deepEqual(body, { error: 'Missing or invalid Authorization header' });
+
+    await new Promise((resolve, reject) =>
+        server.close(err => (err ? reject(err) : resolve()))
+    );
+});
+
+test('GET /v1/vault/health responds with status message', async () => {
+    const { app } = createVaultApp({
+        env: {},
+        warn: () => {},
+        log: () => {},
+        debug: () => {},
+        handlePacket: async () => ({}),
+    });
+
+    const server = app.listen(0);
+    await once(server, 'listening');
+    const { port } = server.address();
+
+    const response = await fetch(`http://127.0.0.1:${port}/v1/vault/health`);
+    assert.equal(response.status, 200);
+    const text = await response.text();
+    assert.equal(text, 'Vault is up and running');
+
+    await new Promise((resolve, reject) =>
+        server.close(err => (err ? reject(err) : resolve()))
+    );
+});


### PR DESCRIPTION
## Summary
- extract the vault service setup into a shared module so it can be reused in tests and the entrypoint
- add a comprehensive node:test suite covering token parsing, authentication middleware, and HTTP routes
- configure the vault package for ESM and the built-in test runner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68debafdb1e48331a9a83ec575063bdc