### PR TITLE
Add Sage app factory and tests

### DIFF
--- a/services/sage/initSage.mjs
+++ b/services/sage/initSage.mjs
@@ -1,52 +1,5 @@
-﻿// services/sage/initSage.mjs
+// services/sage/initSage.mjs
 
-/**
- * @fileoverview
- * Sage is the backend service for Noona, providing API routes for Moon.
- * Dynamic page logic has been deprecated.
- */
+import { startSage } from './shared/sageApp.mjs'
 
-import express from 'express'
-import cors from 'cors'
-
-import { debugMSG, errMSG, log } from '../../utilities/etc/logger.mjs'
-
-const PORT = process.env.API_PORT || 3004
-const SERVICE_NAME = process.env.SERVICE_NAME || 'noona-sage'
-
-const app = express()
-
-// Enable CORS so Moon can safely call this backend within the Docker network
-app.use(cors())
-
-// Enable JSON body parsing
-app.use(express.json())
-
-/**
- * GET /health
- * Used by Warden to confirm Sage is running.
- */
-app.get('/health', (req, res) => {
-    debugMSG(`[${SERVICE_NAME}] ✅ Healthcheck OK`)
-    res.status(200).send('Sage is live!')
-})
-
-/**
- * GET /api/pages
- * (Static placeholder route)
- * Returns a predefined set of page slugs for Moon to render setup/dashboard content.
- */
-app.get('/api/pages', (req, res) => {
-    const pages = [
-        { name: 'Setup', path: '/setup' },
-        { name: 'Dashboard', path: '/dashboard' },
-    ]
-
-    debugMSG(`[${SERVICE_NAME}] 🗂️ Serving ${pages.length} static page entries`)
-    res.json(pages)
-})
-
-// Start the Express server
-app.listen(PORT, () => {
-    log(`[${SERVICE_NAME}] 🧠 Sage is live on port ${PORT}`)
-})
+startSage()

--- a/services/sage/package.json
+++ b/services/sage/package.json
@@ -5,7 +5,8 @@
   "main": "initSage.mjs",
   "type": "module",
   "scripts": {
-    "start": "node initSage.mjs"
+    "start": "node initSage.mjs",
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/services/sage/shared/sageApp.mjs
+++ b/services/sage/shared/sageApp.mjs
@@ -1,0 +1,55 @@
+// services/sage/shared/sageApp.mjs
+
+import express from 'express'
+import cors from 'cors'
+
+import { debugMSG, errMSG, log } from '../../../utilities/etc/logger.mjs'
+
+const defaultServiceName = () => process.env.SERVICE_NAME || 'noona-sage'
+const defaultPort = () => process.env.API_PORT || 3004
+
+const resolveLogger = (overrides = {}) => ({
+    debug: debugMSG,
+    error: errMSG,
+    info: log,
+    ...overrides,
+})
+
+export const createSageApp = ({ serviceName = defaultServiceName(), logger: loggerOverrides } = {}) => {
+    const logger = resolveLogger(loggerOverrides)
+    const app = express()
+
+    app.use(cors())
+    app.use(express.json())
+
+    app.get('/health', (req, res) => {
+        logger.debug(`[${serviceName}] ✅ Healthcheck OK`)
+        res.status(200).send('Sage is live!')
+    })
+
+    app.get('/api/pages', (req, res) => {
+        const pages = [
+            { name: 'Setup', path: '/setup' },
+            { name: 'Dashboard', path: '/dashboard' },
+        ]
+
+        logger.debug(`[${serviceName}] 🗂️ Serving ${pages.length} static page entries`)
+        res.json(pages)
+    })
+
+    return app
+}
+
+export const startSage = ({
+    port = defaultPort(),
+    serviceName = defaultServiceName(),
+    logger: loggerOverrides,
+} = {}) => {
+    const logger = resolveLogger(loggerOverrides)
+    const app = createSageApp({ serviceName, logger })
+    const server = app.listen(port, () => {
+        logger.info(`[${serviceName}] 🧠 Sage is live on port ${port}`)
+    })
+
+    return { app, server }
+}

--- a/services/sage/tests/sageApp.test.mjs
+++ b/services/sage/tests/sageApp.test.mjs
@@ -1,0 +1,99 @@
+// services/sage/tests/sageApp.test.mjs
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { once } from 'node:events'
+
+import { createSageApp, startSage } from '../shared/sageApp.mjs'
+
+const listen = (app) => new Promise((resolve) => {
+    const server = app.listen(0, () => {
+        const address = server.address()
+        if (!address || typeof address !== 'object') {
+            throw new Error('Expected numeric address info')
+        }
+
+        const port = address.port
+        resolve({
+            server,
+            baseUrl: `http://127.0.0.1:${port}`,
+        })
+    })
+})
+
+const closeServer = (server) => new Promise((resolve, reject) => {
+    server.close((error) => {
+        if (error) {
+            reject(error)
+        } else {
+            resolve()
+        }
+    })
+})
+
+test('GET /health responds with success message', async (t) => {
+    const debugMessages = []
+    const app = createSageApp({
+        serviceName: 'test-sage',
+        logger: {
+            debug: (message) => debugMessages.push(message),
+        },
+    })
+
+    const { server, baseUrl } = await listen(app)
+    t.after(() => closeServer(server))
+
+    const response = await fetch(`${baseUrl}/health`)
+    assert.equal(response.status, 200)
+    assert.equal(await response.text(), 'Sage is live!')
+    assert.ok(debugMessages.some((line) => line.includes('Healthcheck OK')))
+})
+
+test('GET /api/pages returns static page definitions', async (t) => {
+    const debugMessages = []
+    const app = createSageApp({
+        serviceName: 'test-sage',
+        logger: {
+            debug: (message) => debugMessages.push(message),
+        },
+    })
+
+    const { server, baseUrl } = await listen(app)
+    t.after(() => closeServer(server))
+
+    const response = await fetch(`${baseUrl}/api/pages`)
+    assert.equal(response.status, 200)
+    const payload = await response.json()
+
+    assert.deepEqual(payload, [
+        { name: 'Setup', path: '/setup' },
+        { name: 'Dashboard', path: '/dashboard' },
+    ])
+    assert.ok(debugMessages.some((line) => line.includes('Serving 2 static page entries')))
+})
+
+test('startSage starts server on provided port and logs startup message', async (t) => {
+    const infoMessages = []
+    const debugMessages = []
+
+    const { server } = startSage({
+        port: 0,
+        serviceName: 'test-sage',
+        logger: {
+            debug: (message) => debugMessages.push(message),
+            info: (message) => infoMessages.push(message),
+        },
+    })
+
+    t.after(() => closeServer(server))
+    await once(server, 'listening')
+
+    const address = server.address()
+    if (!address || typeof address !== 'object') {
+        throw new Error('Expected numeric address info')
+    }
+
+    assert.ok(address.port > 0)
+    assert.ok(infoMessages.some((line) => line.includes('test-sage')))
+    assert.equal(debugMessages.length, 0)
+})


### PR DESCRIPTION
## Summary
- extract Sage Express app creation into a shared helper that wires logging and startup
- add node:test unit coverage for the health and pages endpoints plus server bootstrap logic
- expose a package script to run the Sage test suite with node --test

## Testing
- npm test (from services/sage)


------
https://chatgpt.com/codex/tasks/task_e_68debb371a148331910d36c0269e3636