### PR TITLE
Implement setup wizard orchestration

### DIFF
--- a/services/moon/src/components/SetupCard.vue
+++ b/services/moon/src/components/SetupCard.vue
@@ -1,11 +1,163 @@
-﻿<script lang="ts" setup>
+<script lang="ts" setup>
+import { computed } from 'vue';
 
+type ServiceCategory = 'core' | 'addon' | string;
+
+interface ServiceOption {
+  name: string;
+  category?: ServiceCategory;
+  image?: string | null;
+  description?: string | null;
+  hostServiceUrl?: string | null;
+  port?: number | null;
+  health?: string | null;
+}
+
+const props = defineProps<{
+  service: ServiceOption;
+  selected?: boolean;
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (event: 'toggle', name: string): void;
+}>();
+
+const categoryLabel = computed(() => {
+  const category = props.service.category ?? 'service';
+
+  if (category === 'core') return 'Core Service';
+  if (category === 'addon') return 'Addon';
+
+  return category
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+});
+
+const chipColor = computed(() => {
+  if (props.service.category === 'core') return 'deep-purple';
+  if (props.service.category === 'addon') return 'teal';
+  return 'primary';
+});
+
+const handleToggle = () => {
+  if (props.disabled) return;
+  emit('toggle', props.service.name);
+};
+
+const descriptionText = computed(() => {
+  if (props.service.description) {
+    return props.service.description;
+  }
+
+  if (props.service.category === 'core') {
+    return 'Essential Noona component.';
+  }
+
+  if (props.service.category === 'addon') {
+    return 'Optional add-on service.';
+  }
+
+  return 'Service configuration';
+});
 </script>
 
 <template>
+  <v-card
+    :elevation="selected ? 8 : 2"
+    class="setup-card"
+    :class="{
+      'setup-card--selected': selected,
+      'setup-card--disabled': disabled,
+    }"
+    role="checkbox"
+    :aria-checked="selected"
+    :aria-disabled="disabled"
+    tabindex="0"
+    @click="handleToggle"
+    @keydown.enter.prevent="handleToggle"
+    @keydown.space.prevent="handleToggle"
+  >
+    <v-card-item class="pb-0">
+      <div class="d-flex align-center justify-space-between">
+        <div>
+          <div class="text-subtitle-1 font-weight-medium mb-1">
+            {{ service.name }}
+          </div>
+          <v-chip :color="chipColor" size="small" variant="tonal" class="text-uppercase font-weight-bold">
+            {{ categoryLabel }}
+          </v-chip>
+        </div>
+        <v-checkbox-btn
+          :model-value="selected"
+          :disabled="disabled"
+          color="primary"
+          @click.stop="handleToggle"
+          @update:modelValue="handleToggle"
+        />
+      </div>
+    </v-card-item>
 
+    <v-card-text class="pt-3">
+      <p class="text-body-2 text-medium-emphasis mb-3">
+        {{ descriptionText }}
+      </p>
+
+      <div class="text-body-2 text-medium-emphasis">
+        <span class="font-weight-medium">Image:</span>
+        <span class="ml-1">{{ service.image ?? 'Unknown' }}</span>
+      </div>
+
+      <div v-if="service.hostServiceUrl" class="text-body-2 text-medium-emphasis mt-1">
+        <span class="font-weight-medium">Host URL:</span>
+        <a
+          :href="service.hostServiceUrl"
+          target="_blank"
+          rel="noopener"
+          class="setup-card__link ml-1"
+          @click.stop
+        >
+          {{ service.hostServiceUrl }}
+        </a>
+      </div>
+      <div v-else-if="service.port != null" class="text-body-2 text-medium-emphasis mt-1">
+        <span class="font-weight-medium">Port:</span>
+        <span class="ml-1">{{ service.port }}</span>
+      </div>
+
+      <div v-if="service.health" class="text-body-2 text-medium-emphasis mt-1">
+        <span class="font-weight-medium">Health:</span>
+        <span class="ml-1">{{ service.health }}</span>
+      </div>
+    </v-card-text>
+  </v-card>
 </template>
 
 <style scoped>
+.setup-card {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+}
 
+.setup-card:focus-visible {
+  outline: 2px solid var(--v-theme-primary);
+  outline-offset: 4px;
+}
+
+.setup-card--selected {
+  border: 2px solid rgba(var(--v-theme-primary), 0.4);
+}
+
+.setup-card--disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.setup-card__link {
+  text-decoration: none;
+}
+
+.setup-card__link:hover {
+  text-decoration: underline;
+}
 </style>

--- a/services/moon/src/pages/Setup.vue
+++ b/services/moon/src/pages/Setup.vue
@@ -1,14 +1,303 @@
-﻿<script setup>
+<script setup>
+import { computed, onMounted, reactive, ref } from 'vue';
 import Header from '../components/Header.vue';
+import SetupCard from '../components/SetupCard.vue';
+
+const state = reactive({
+  loading: true,
+  services: [],
+  loadError: '',
+});
+
+const selectedServices = ref([]);
+const installing = ref(false);
+const installError = ref('');
+const installResults = ref(null);
+
+const groupedServices = computed(() => {
+  return state.services.reduce((groups, service) => {
+    const category = service.category || 'other';
+    if (!groups[category]) {
+      groups[category] = [];
+    }
+
+    groups[category].push(service);
+    return groups;
+  }, {});
+});
+
+const sortedCategoryEntries = computed(() => {
+  const entries = Object.entries(groupedServices.value).map(([category, services]) => {
+    return [
+      category,
+      [...services].sort((a, b) => a.name.localeCompare(b.name)),
+    ];
+  });
+
+  const order = ['core', 'addon'];
+  entries.sort((a, b) => {
+    const aIndex = order.indexOf(a[0]);
+    const bIndex = order.indexOf(b[0]);
+
+    if (aIndex === -1 && bIndex === -1) {
+      return a[0].localeCompare(b[0]);
+    }
+
+    if (aIndex === -1) return 1;
+    if (bIndex === -1) return -1;
+    return aIndex - bIndex;
+  });
+
+  return entries;
+});
+
+const selectedSet = computed(() => new Set(selectedServices.value));
+const hasSelection = computed(() => selectedServices.value.length > 0);
+const selectedCount = computed(() => selectedServices.value.length);
+
+const categoryLabel = (category) => {
+  if (category === 'core') return 'Core Services';
+  if (category === 'addon') return 'Add-ons';
+  return category.replace(/-/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
+};
+
+const toggleService = (name) => {
+  if (installing.value) return;
+
+  const next = new Set(selectedServices.value);
+  if (next.has(name)) {
+    next.delete(name);
+  } else {
+    next.add(name);
+  }
+
+  selectedServices.value = Array.from(next);
+};
+
+const refreshServices = async () => {
+  state.loading = true;
+  state.loadError = '';
+
+  try {
+    const response = await fetch('/api/setup/services');
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+
+    const payload = await response.json();
+    const services = Array.isArray(payload.services) ? payload.services : [];
+    services.sort((a, b) => a.name.localeCompare(b.name));
+    state.services = services;
+  } catch (error) {
+    state.loadError = error instanceof Error ? error.message : String(error);
+  } finally {
+    state.loading = false;
+  }
+};
+
+const submitSelection = async () => {
+  if (!hasSelection.value || installing.value) return;
+
+  installing.value = true;
+  installError.value = '';
+  installResults.value = null;
+
+  const services = [...selectedServices.value];
+
+  try {
+    const response = await fetch('/api/setup/install', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ services }),
+    });
+
+    const payload = await response.json().catch(() => ({}));
+    const results = Array.isArray(payload.results) ? payload.results : [];
+    installResults.value = {
+      status: response.status,
+      results,
+    };
+
+    if (response.ok) {
+      const successful = new Set(results.filter((item) => item.status === 'installed').map((item) => item.name));
+      const remaining = services.filter((name) => !successful.has(name));
+      selectedServices.value = remaining;
+    }
+  } catch (error) {
+    installError.value = error instanceof Error ? error.message : String(error);
+  } finally {
+    installing.value = false;
+  }
+};
+
+onMounted(() => {
+  void refreshServices();
+});
 </script>
 
 <template>
   <Header>
-    <v-container class="mt-10">
-      <v-card>
-        <v-card-title class="text-h5">Setup Page</v-card-title>
-        <v-card-text>This is where your setup wizard UI will go!</v-card-text>
-      </v-card>
+    <v-container class="py-10">
+      <v-row justify="center">
+        <v-col cols="12" lg="10">
+          <v-card variant="elevated" class="pa-6">
+            <v-card-title class="text-h5 font-weight-bold pb-2">
+              Moon Setup Wizard
+            </v-card-title>
+            <v-card-subtitle class="text-body-2 pb-4">
+              Choose the services you want Warden to install and launch.
+            </v-card-subtitle>
+
+            <v-card-text>
+              <div v-if="state.loading" class="d-flex justify-center py-10">
+                <v-progress-circular color="primary" size="64" indeterminate />
+              </div>
+
+              <v-alert
+                v-else-if="state.loadError"
+                type="error"
+                variant="tonal"
+                class="mb-6"
+                border="start"
+              >
+                Unable to load services: {{ state.loadError }}
+                <template #append>
+                  <v-btn color="error" variant="text" @click="refreshServices">
+                    Retry
+                  </v-btn>
+                </template>
+              </v-alert>
+
+              <div v-else>
+                <div class="d-flex justify-space-between align-center mb-4">
+                  <div class="text-subtitle-1 font-weight-medium">
+                    Available services ({{ state.services.length }})
+                  </div>
+                  <v-btn
+                    variant="text"
+                    color="primary"
+                    :loading="state.loading"
+                    @click="refreshServices"
+                  >
+                    Refresh
+                  </v-btn>
+                </div>
+
+                <v-alert
+                  v-if="!state.services.length"
+                  type="info"
+                  variant="tonal"
+                  border="start"
+                  class="mb-6"
+                >
+                  No services are available for installation yet.
+                </v-alert>
+
+                <div v-else>
+                  <div
+                    v-for="([category, services], index) in sortedCategoryEntries"
+                    :key="category"
+                    :class="index > 0 ? 'mt-8' : ''"
+                  >
+                    <div class="d-flex align-center mb-3">
+                      <v-chip color="primary" variant="tonal" class="text-uppercase font-weight-bold">
+                        {{ categoryLabel(category) }}
+                      </v-chip>
+                      <span class="text-body-2 text-medium-emphasis ml-3">
+                        {{ services.length }} service{{ services.length === 1 ? '' : 's' }}
+                      </span>
+                    </div>
+
+                    <v-row>
+                      <v-col
+                        v-for="service in services"
+                        :key="service.name"
+                        cols="12"
+                        md="6"
+                        class="d-flex"
+                      >
+                        <SetupCard
+                          :service="service"
+                          :selected="selectedSet.has(service.name)"
+                          :disabled="installing"
+                          class="flex-grow-1"
+                          @toggle="toggleService"
+                        />
+                      </v-col>
+                    </v-row>
+                  </div>
+                </div>
+              </div>
+            </v-card-text>
+
+            <v-divider class="my-4" />
+
+            <v-card-actions class="flex-column flex-sm-row justify-space-between align-stretch gap-4">
+              <div class="flex-grow-1">
+                <v-alert
+                  v-if="installError"
+                  type="error"
+                  variant="tonal"
+                  border="start"
+                  class="mb-2"
+                >
+                  Failed to submit install request: {{ installError }}
+                </v-alert>
+
+                <v-alert
+                  v-else-if="installResults"
+                  :type="installResults.status === 200 ? 'success' : 'warning'"
+                  variant="tonal"
+                  border="start"
+                  class="mb-2"
+                >
+                  <div class="font-weight-medium mb-2">
+                    Installation summary (status {{ installResults.status }}):
+                  </div>
+                  <ul class="pl-4 mb-0">
+                    <li
+                      v-for="result in installResults.results"
+                      :key="result.name"
+                      class="text-body-2"
+                    >
+                      <span class="font-weight-medium">{{ result.name }}</span>
+                      —
+                      <span
+                        :class="result.status === 'installed' ? 'text-success' : 'text-warning'"
+                      >
+                        {{ result.status }}
+                      </span>
+                      <span v-if="result.error" class="text-medium-emphasis">
+                        : {{ result.error }}
+                      </span>
+                      <span v-else-if="result.hostServiceUrl" class="text-medium-emphasis">
+                        ({{ result.hostServiceUrl }})
+                      </span>
+                    </li>
+                  </ul>
+                </v-alert>
+              </div>
+
+              <v-btn
+                color="primary"
+                size="large"
+                class="align-self-stretch"
+                :disabled="!hasSelection || installing"
+                @click="submitSelection"
+              >
+                <template v-if="installing">
+                  <v-progress-circular size="22" width="3" color="white" indeterminate class="mr-3" />
+                  Installing...
+                </template>
+                <template v-else>
+                  Install Selected
+                  <span class="ml-2 font-weight-bold">({{ selectedCount }})</span>
+                </template>
+              </v-btn>
+            </v-card-actions>
+          </v-card>
+        </v-col>
+      </v-row>
     </v-container>
   </Header>
 </template>

--- a/services/moon/vite.config.js
+++ b/services/moon/vite.config.js
@@ -6,6 +6,12 @@ export default defineConfig({
   server: {
     port: 3000,
     // 👇 THIS is the correct setting for SPA routing
-    historyApiFallback: true
+    historyApiFallback: true,
+    proxy: {
+      '/api': {
+        target: process.env.VITE_API_TARGET ?? 'http://localhost:3004',
+        changeOrigin: true,
+      },
+    },
   }
 });

--- a/services/sage/shared/sageApp.mjs
+++ b/services/sage/shared/sageApp.mjs
@@ -7,6 +7,7 @@ import { debugMSG, errMSG, log } from '../../../utilities/etc/logger.mjs'
 
 const defaultServiceName = () => process.env.SERVICE_NAME || 'noona-sage'
 const defaultPort = () => process.env.API_PORT || 3004
+const defaultWardenBaseUrl = () => process.env.WARDEN_BASE_URL || 'http://localhost:4001'
 
 const resolveLogger = (overrides = {}) => ({
     debug: debugMSG,
@@ -15,8 +16,52 @@ const resolveLogger = (overrides = {}) => ({
     ...overrides,
 })
 
-export const createSageApp = ({ serviceName = defaultServiceName(), logger: loggerOverrides } = {}) => {
+const createSetupClient = ({ baseUrl = defaultWardenBaseUrl(), fetchImpl = fetch, logger, serviceName }) => ({
+    async listServices() {
+        const response = await fetchImpl(`${baseUrl}/api/services`)
+
+        if (!response.ok) {
+            throw new Error(`Warden responded with status ${response.status}`)
+        }
+
+        const payload = await response.json()
+        const services = Array.isArray(payload.services) ? payload.services : []
+
+        logger.debug?.(`[${serviceName}] 📦 Retrieved ${services.length} services from Warden`)
+        return services
+    },
+
+    async installServices(services) {
+        const response = await fetchImpl(`${baseUrl}/api/services/install`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ services }),
+        })
+
+        const payload = await response.json().catch(() => ({}))
+        const results = Array.isArray(payload.results) ? payload.results : []
+        const status = response.status || 200
+
+        logger.info?.(`[${serviceName}] 🚀 Installation request forwarded for ${services.length} services (status: ${status})`)
+        return { status, results }
+    },
+})
+
+export const createSageApp = ({
+    serviceName = defaultServiceName(),
+    logger: loggerOverrides,
+    setupClient: setupClientOverride,
+    setup: setupOptions = {},
+} = {}) => {
     const logger = resolveLogger(loggerOverrides)
+    const setupClient =
+        setupClientOverride ||
+        createSetupClient({
+            baseUrl: setupOptions.baseUrl ?? defaultWardenBaseUrl(),
+            fetchImpl: setupOptions.fetchImpl ?? setupOptions.fetch ?? fetch,
+            logger,
+            serviceName,
+        })
     const app = express()
 
     app.use(cors())
@@ -37,6 +82,33 @@ export const createSageApp = ({ serviceName = defaultServiceName(), logger: logg
         res.json(pages)
     })
 
+    app.get('/api/setup/services', async (req, res) => {
+        try {
+            const services = await setupClient.listServices()
+            res.json({ services })
+        } catch (error) {
+            logger.error(`[${serviceName}] ⚠️ Failed to load installable services: ${error.message}`)
+            res.status(502).json({ error: 'Unable to retrieve installable services.' })
+        }
+    })
+
+    app.post('/api/setup/install', async (req, res) => {
+        const services = req.body?.services
+
+        if (!Array.isArray(services) || services.length === 0) {
+            res.status(400).json({ error: 'Body must include a non-empty "services" array.' })
+            return
+        }
+
+        try {
+            const { status, results } = await setupClient.installServices(services)
+            res.status(status ?? 200).json({ results })
+        } catch (error) {
+            logger.error(`[${serviceName}] ❌ Failed to install services: ${error.message}`)
+            res.status(502).json({ error: 'Failed to install services.' })
+        }
+    })
+
     return app
 }
 
@@ -44,9 +116,11 @@ export const startSage = ({
     port = defaultPort(),
     serviceName = defaultServiceName(),
     logger: loggerOverrides,
+    setupClient,
+    setup,
 } = {}) => {
     const logger = resolveLogger(loggerOverrides)
-    const app = createSageApp({ serviceName, logger })
+    const app = createSageApp({ serviceName, logger, setupClient, setup })
     const server = app.listen(port, () => {
         logger.info(`[${serviceName}] 🧠 Sage is live on port ${port}`)
     })

--- a/services/warden/initWarden.mjs
+++ b/services/warden/initWarden.mjs
@@ -1,14 +1,25 @@
 // services/warden/initWarden.mjs
 import { createWarden } from './shared/wardenCore.mjs';
+import { startWardenServer } from './shared/wardenServer.mjs';
 import { errMSG } from '../../utilities/etc/logger.mjs';
 
 const warden = createWarden();
+const apiPort = Number.parseInt(process.env.WARDEN_API_PORT ?? '4001', 10);
+const { server: apiServer } = startWardenServer({ warden, port: apiPort });
+
+const closeApiServer = () => {
+    if (apiServer.listening) {
+        apiServer.close();
+    }
+};
 
 process.on('SIGINT', () => {
+    closeApiServer();
     void warden.shutdownAll();
 });
 
 process.on('SIGTERM', () => {
+    closeApiServer();
     void warden.shutdownAll();
 });
 

--- a/services/warden/shared/wardenServer.mjs
+++ b/services/warden/shared/wardenServer.mjs
@@ -1,0 +1,135 @@
+// services/warden/shared/wardenServer.mjs
+import http from 'node:http';
+import { URL } from 'node:url';
+
+import { errMSG, log, warn } from '../../../utilities/etc/logger.mjs';
+
+const defaultPort = () => Number.parseInt(process.env.WARDEN_API_PORT ?? '4001', 10);
+
+const DEFAULT_HEADERS = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+};
+
+const resolveLogger = (overrides = {}) => ({
+    error: errMSG,
+    log,
+    warn,
+    ...overrides,
+});
+
+const sendJson = (res, statusCode, payload) => {
+    res.writeHead(statusCode, {
+        ...DEFAULT_HEADERS,
+        'Content-Type': 'application/json',
+    });
+    res.end(JSON.stringify(payload));
+};
+
+const parseJsonBody = (req) => new Promise((resolve, reject) => {
+    const chunks = [];
+
+    req.on('data', (chunk) => {
+        chunks.push(chunk);
+    });
+
+    req.on('end', () => {
+        if (chunks.length === 0) {
+            resolve(null);
+            return;
+        }
+
+        try {
+            const parsed = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+            resolve(parsed);
+        } catch (error) {
+            reject(error);
+        }
+    });
+
+    req.on('error', (error) => reject(error));
+});
+
+export const startWardenServer = ({
+    warden,
+    port = defaultPort(),
+    logger: loggerOverrides,
+} = {}) => {
+    if (!warden) {
+        throw new Error('Warden instance is required to start the API server.');
+    }
+
+    const logger = resolveLogger(loggerOverrides);
+
+    const server = http.createServer(async (req, res) => {
+        if (!req.url) {
+            sendJson(res, 400, { error: 'Invalid request URL.' });
+            return;
+        }
+
+        if (req.method === 'OPTIONS') {
+            res.writeHead(204, DEFAULT_HEADERS);
+            res.end();
+            return;
+        }
+
+        const url = new URL(req.url, `http://${req.headers.host ?? 'localhost'}`);
+
+        if (req.method === 'GET' && url.pathname === '/health') {
+            sendJson(res, 200, { status: 'ok' });
+            return;
+        }
+
+        if (req.method === 'GET' && url.pathname === '/api/services') {
+            try {
+                const services = warden.listServices();
+                sendJson(res, 200, { services });
+            } catch (error) {
+                logger.error(`[Warden API] Failed to list services: ${error.message}`);
+                sendJson(res, 500, { error: 'Unable to list services.' });
+            }
+            return;
+        }
+
+        if (req.method === 'POST' && url.pathname === '/api/services/install') {
+            let body;
+
+            try {
+                body = await parseJsonBody(req);
+            } catch (error) {
+                sendJson(res, 400, { error: 'Request body must be valid JSON.' });
+                return;
+            }
+
+            const services = body?.services;
+
+            if (!Array.isArray(services) || services.length === 0) {
+                sendJson(res, 400, { error: 'Body must include a non-empty "services" array.' });
+                return;
+            }
+
+            try {
+                const results = await warden.installServices(services);
+                const hasErrors = results.some((entry) => entry.status === 'error');
+                const statusCode = hasErrors ? 207 : 200;
+                sendJson(res, statusCode, { results });
+            } catch (error) {
+                logger.error(`[Warden API] Failed to install services: ${error.message}`);
+                sendJson(res, 500, { error: 'Failed to install requested services.' });
+            }
+            return;
+        }
+
+        logger.warn(`[Warden API] Route not found: ${req.method} ${url.pathname}`);
+        sendJson(res, 404, { error: 'Not Found' });
+    });
+
+    server.listen(port, () => {
+        logger.log(`[Warden API] Listening on port ${server.address().port}`);
+    });
+
+    return { server };
+};
+
+export default startWardenServer;

--- a/services/warden/tests/wardenServer.test.mjs
+++ b/services/warden/tests/wardenServer.test.mjs
@@ -1,0 +1,114 @@
+// services/warden/tests/wardenServer.test.mjs
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+
+import { startWardenServer } from '../shared/wardenServer.mjs';
+
+const listen = async (options = {}) => {
+    const { server } = startWardenServer({
+        warden: options.warden,
+        port: 0,
+        logger: options.logger,
+    });
+
+    await once(server, 'listening');
+    const address = server.address();
+
+    if (!address || typeof address !== 'object') {
+        throw new Error('Expected server address info.');
+    }
+
+    return {
+        server,
+        baseUrl: `http://127.0.0.1:${address.port}`,
+    };
+};
+
+const closeServer = (server) => new Promise((resolve, reject) => {
+    server.close((error) => {
+        if (error) {
+            reject(error);
+        } else {
+            resolve();
+        }
+    });
+});
+
+test('GET /api/services returns list of services', async (t) => {
+    const warden = {
+        listServices: () => [
+            { name: 'noona-sage', category: 'core' },
+            { name: 'noona-redis', category: 'addon' },
+        ],
+        installServices: async () => {
+            throw new Error('installServices should not be called');
+        },
+    };
+
+    const { server, baseUrl } = await listen({ warden });
+    t.after(() => closeServer(server));
+
+    const response = await fetch(`${baseUrl}/api/services`);
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+        services: [
+            { name: 'noona-sage', category: 'core' },
+            { name: 'noona-redis', category: 'addon' },
+        ],
+    });
+});
+
+test('POST /api/services/install returns results and status code for errors', async (t) => {
+    const installCalls = [];
+    const warden = {
+        listServices: () => [],
+        installServices: async (services) => {
+            installCalls.push(services);
+            return [
+                { name: 'noona-sage', status: 'installed', category: 'core' },
+                { name: 'noona-bad', status: 'error', error: 'boom' },
+            ];
+        },
+    };
+
+    const { server, baseUrl } = await listen({ warden });
+    t.after(() => closeServer(server));
+
+    const response = await fetch(`${baseUrl}/api/services/install`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ services: ['noona-sage', 'noona-bad'] }),
+    });
+
+    assert.equal(response.status, 207);
+    assert.deepEqual(await response.json(), {
+        results: [
+            { name: 'noona-sage', status: 'installed', category: 'core' },
+            { name: 'noona-bad', status: 'error', error: 'boom' },
+        ],
+    });
+    assert.deepEqual(installCalls, [['noona-sage', 'noona-bad']]);
+});
+
+test('POST /api/services/install validates payload', async (t) => {
+    const warden = {
+        listServices: () => [],
+        installServices: async () => {
+            throw new Error('installServices should not be called');
+        },
+    };
+
+    const { server, baseUrl } = await listen({ warden });
+    t.after(() => closeServer(server));
+
+    const response = await fetch(`${baseUrl}/api/services/install`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ services: [] }),
+    });
+
+    assert.equal(response.status, 400);
+    const payload = await response.json();
+    assert.ok(payload.error.includes('non-empty'));
+});


### PR DESCRIPTION
## Summary
- build Moon's setup wizard with selectable services, install submission, and Vuetify cards
- expose setup orchestration endpoints in Sage that proxy to a Warden API
- extend Warden with service catalog helpers, remote control server, and supporting tests, plus add a Moon dev proxy for /api calls

## Testing
- npm test (services/warden)
- npm test (services/sage)

------
https://chatgpt.com/codex/tasks/task_e_68df0fd8143c8331aa8e32c0b7e6439b