### PR TITLE
Add nginx proxy from Moon to Sage setup API

### DIFF
--- a/services/moon/nginx.conf
+++ b/services/moon/nginx.conf
@@ -9,6 +9,15 @@ server {
     try_files $uri $uri/ /index.html;
   }
 
+  location /api/ {
+    proxy_pass http://noona-sage:3004/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
   location ~* \.(js|css|png|jpg|jpeg|gif|svg|ico|woff2?|ttf|otf|eot)$ {
     expires 1y;
     access_log off;


### PR DESCRIPTION
## Summary
- route /api requests in Moon's nginx config to the Sage service
- ensure setup wizard receives JSON responses from the backend

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df1971f06c83318b05c13f430f9dc4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an /api/ route that forwards requests to the backend service, enabling API access through the same domain.
  - Simplifies integration and reduces CORS issues by centralizing API calls under the app’s domain.
  - Preserves client and protocol details for more accurate request handling.
  - No changes to existing static asset delivery; current behavior remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->