### PR TITLE
Filter installed services from setup wizard

### DIFF
--- a/services/sage/shared/sageApp.mjs
+++ b/services/sage/shared/sageApp.mjs
@@ -17,8 +17,12 @@ const resolveLogger = (overrides = {}) => ({
 })
 
 const createSetupClient = ({ baseUrl = defaultWardenBaseUrl(), fetchImpl = fetch, logger, serviceName }) => ({
-    async listServices() {
-        const response = await fetchImpl(`${baseUrl}/api/services`)
+    async listServices(options = {}) {
+        const includeInstalled = options.includeInstalled ?? false
+        const requestUrl = new URL('/api/services', baseUrl)
+        requestUrl.searchParams.set('includeInstalled', includeInstalled ? 'true' : 'false')
+
+        const response = await fetchImpl(requestUrl.toString())
 
         if (!response.ok) {
             throw new Error(`Warden responded with status ${response.status}`)

--- a/services/warden/shared/wardenServer.mjs
+++ b/services/warden/shared/wardenServer.mjs
@@ -83,7 +83,12 @@ export const startWardenServer = ({
 
         if (req.method === 'GET' && url.pathname === '/api/services') {
             try {
-                const services = warden.listServices();
+                const includeParam = url.searchParams.get('includeInstalled');
+                const includeInstalled = includeParam
+                    ? ['1', 'true', 'yes', 'all'].includes(includeParam.trim().toLowerCase())
+                    : false;
+
+                const services = await warden.listServices({ includeInstalled });
                 sendJson(res, 200, { services });
             } catch (error) {
                 logger.error(`[Warden API] Failed to list services: ${error.message}`);


### PR DESCRIPTION
## Summary
- detect already-installed Docker services in Warden and expose an option to include them in API responses
- update Sage to request only installable services from Warden and cover the behavior with tests
- refresh the Moon setup wizard to display only services that still need installation and react to completed installs

## Testing
- npm test (services/warden)
- npm test (services/sage)


------
https://chatgpt.com/codex/tasks/task_e_68df2876f15c8331b54fe403408ce236