### PR TITLE
Improve Warden token generation and Sage setup resilience

### DIFF
--- a/services/warden/docker/vaultTokens.mjs
+++ b/services/warden/docker/vaultTokens.mjs
@@ -1,0 +1,88 @@
+// services/warden/docker/vaultTokens.mjs
+import crypto from 'node:crypto';
+
+const DEFAULT_TOKENS = {
+    'noona-sage': 'noona-sage-dev-token',
+    'noona-moon': 'noona-moon-dev-token',
+    'noona-oracle': 'noona-oracle-dev-token',
+    'noona-raven': 'noona-raven-dev-token',
+    'noona-portal': 'noona-portal-dev-token',
+    'noona-vault': 'noona-vault-dev-token',
+};
+
+const sanitizeToken = (token) => {
+    if (typeof token !== 'string') {
+        return '';
+    }
+
+    return token.trim();
+};
+
+const normalizeEnvKey = (name) =>
+    `${name.replace(/-/g, '_').toUpperCase()}_VAULT_TOKEN`;
+
+export const __testables__ = {
+    sanitizeToken,
+    normalizeEnvKey,
+};
+
+export function generateVaultToken(name, randomBytes = crypto.randomBytes) {
+    const safeName = typeof name === 'string' ? name : 'noona';
+    const prefix = safeName.replace(/[^a-z0-9]/gi, '').toLowerCase() || 'noona';
+    const trimmedPrefix = prefix.slice(0, 24);
+    const entropy = randomBytes(18).toString('hex');
+    return `${trimmedPrefix}-${entropy}`;
+}
+
+export function buildVaultTokenRegistry(names = [], options = {}) {
+    const {
+        env = process.env,
+        defaults = DEFAULT_TOKENS,
+        generator = (serviceName) => generateVaultToken(serviceName),
+    } = options;
+
+    const tokensByService = {};
+
+    for (const rawName of names) {
+        if (!rawName || typeof rawName !== 'string') {
+            continue;
+        }
+
+        const name = rawName.trim();
+        if (!name) {
+            continue;
+        }
+
+        const envKey = normalizeEnvKey(name);
+        const envToken = sanitizeToken(env?.[envKey]);
+
+        if (envToken) {
+            tokensByService[name] = envToken;
+            continue;
+        }
+
+        const defaultToken = sanitizeToken(defaults?.[name]);
+        if (defaultToken) {
+            tokensByService[name] = defaultToken;
+            continue;
+        }
+
+        tokensByService[name] = generator(name);
+    }
+
+    return tokensByService;
+}
+
+export function stringifyTokenMap(tokensByService = {}) {
+    return Object.entries(tokensByService)
+        .filter(([service, token]) => Boolean(service && sanitizeToken(token)))
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([service, token]) => `${service}:${sanitizeToken(token)}`)
+        .join(',');
+}
+
+export default {
+    buildVaultTokenRegistry,
+    generateVaultToken,
+    stringifyTokenMap,
+};

--- a/services/warden/tests/vaultTokens.test.mjs
+++ b/services/warden/tests/vaultTokens.test.mjs
@@ -1,0 +1,56 @@
+// services/warden/tests/vaultTokens.test.mjs
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    buildVaultTokenRegistry,
+    generateVaultToken,
+    stringifyTokenMap,
+    __testables__,
+} from '../docker/vaultTokens.mjs';
+
+test('generateVaultToken produces deterministic prefix with entropy', () => {
+    const stubRandom = () => Buffer.from('0123456789abcdef0123456789abcdef0123', 'hex');
+    const token = generateVaultToken('noona-sage', stubRandom);
+
+    assert.match(token, /^noonasage-[0-9a-f]+$/);
+    assert.equal(token.split('-')[1], '0123456789abcdef0123456789abcdef0123');
+});
+
+test('buildVaultTokenRegistry prefers environment overrides, then defaults', () => {
+    const registry = buildVaultTokenRegistry(['noona-sage', 'noona-moon', 'custom-service'], {
+        env: { NOONA_SAGE_VAULT_TOKEN: 'env-token' },
+        defaults: { 'custom-service': 'custom-default-token' },
+        generator: () => 'generated-token',
+    });
+
+    assert.deepEqual(registry, {
+        'noona-sage': 'env-token',
+        'noona-moon': 'generated-token',
+        'custom-service': 'custom-default-token',
+    });
+});
+
+test('buildVaultTokenRegistry skips invalid names', () => {
+    const registry = buildVaultTokenRegistry(['', null, undefined, '  ', 'noona-portal'], {
+        generator: () => 'generated-token',
+    });
+
+    assert.deepEqual(registry, { 'noona-portal': 'noona-portal-dev-token' });
+});
+
+test('stringifyTokenMap produces sorted, trimmed pairs', () => {
+    const map = stringifyTokenMap({
+        'noona-zeta': ' token-z ',
+        'noona-alpha': 'token-a',
+        '': 'ignored',
+    });
+
+    assert.equal(map, 'noona-alpha:token-a,noona-zeta:token-z');
+});
+
+test('normalizeEnvKey helper formats service names for env lookup', () => {
+    const { normalizeEnvKey } = __testables__;
+    assert.equal(normalizeEnvKey('noona-sage'), 'NOONA_SAGE_VAULT_TOKEN');
+    assert.equal(normalizeEnvKey('noona-portal'), 'NOONA_PORTAL_VAULT_TOKEN');
+});


### PR DESCRIPTION
## Summary
- add a reusable vault token registry to normalize env overrides, defaults, and generated secrets for every service
- wire the generated tokens and a default Warden base URL into Docker descriptors so Vault and Sage start with consistent credentials
- teach Sage's setup client to try multiple Warden endpoints and cover the new behaviors with unit tests

## Testing
- `cd services/sage && npm test`
- `cd services/warden && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68df2dd1f76c8331a6446c6da3610f64