### PR TITLE
Improve Moon setup API endpoint discovery

### DIFF
--- a/services/moon/src/pages/Setup.vue
+++ b/services/moon/src/pages/Setup.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, reactive, ref } from 'vue';
 import Header from '../components/Header.vue';
 import SetupCard from '../components/SetupCard.vue';
+import { buildServiceEndpointCandidates } from '../utils/serviceEndpoints.js';
 
 const state = reactive({
   loading: true,
@@ -79,7 +80,7 @@ const toggleService = (name) => {
   selectedServices.value = Array.from(next);
 };
 
-const SERVICE_ENDPOINTS = ['/api/setup/services', '/api/services?includeInstalled=false'];
+const SERVICE_ENDPOINTS = buildServiceEndpointCandidates();
 
 const loadServicesFromEndpoint = async (endpoint) => {
   const response = await fetch(endpoint);

--- a/services/moon/src/utils/serviceEndpoints.js
+++ b/services/moon/src/utils/serviceEndpoints.js
@@ -1,0 +1,191 @@
+const API_PREFIX = '/api';
+const DEFAULT_SERVICE_PATHS = [
+  '/api/setup/services',
+  '/api/services?includeInstalled=false',
+  '/api/services',
+];
+
+const ENV_BASE_KEYS = [
+  'VITE_API_BASE',
+  'VITE_API_TARGET',
+  'VITE_SAGE_BASE',
+  'VITE_SAGE_URL',
+  'VITE_SETUP_BASE',
+  'VITE_SETUP_URL',
+  'VITE_WARDEN_BASE',
+  'VITE_WARDEN_URL',
+];
+
+const ENV_ENDPOINT_KEYS = [
+  'VITE_SETUP_SERVICES_URL',
+  'VITE_WARDEN_SERVICES_URL',
+];
+
+const STATIC_BASE_CANDIDATES = [
+  'http://localhost:3004',
+  'http://127.0.0.1:3004',
+  'http://host.docker.internal:3004',
+  'http://localhost:4001',
+  'http://127.0.0.1:4001',
+  'http://host.docker.internal:4001',
+];
+
+const ABSOLUTE_URL_REGEX = /^https?:\/\//i;
+
+const normalizeBaseUrl = (candidate) => {
+  if (typeof candidate !== 'string') return null;
+
+  const trimmed = candidate.trim();
+  if (!trimmed) return null;
+
+  if (!ABSOLUTE_URL_REGEX.test(trimmed)) {
+    return null;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    const pathname = url.pathname.replace(/\/+$/, '');
+    if (pathname && pathname !== '/') {
+      return `${url.protocol}//${url.host}${pathname}`;
+    }
+
+    return `${url.protocol}//${url.host}`;
+  } catch (error) {
+    return null;
+  }
+};
+
+const normalizeEndpoint = (candidate) => {
+  if (typeof candidate !== 'string') return null;
+
+  const trimmed = candidate.trim();
+  if (!trimmed) return null;
+
+  if (!ABSOLUTE_URL_REGEX.test(trimmed)) {
+    return null;
+  }
+
+  try {
+    return new URL(trimmed).toString();
+  } catch (error) {
+    return null;
+  }
+};
+
+const joinBaseAndPath = (base, path) => {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+  if (!base) {
+    return normalizedPath;
+  }
+
+  const sanitizedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+
+  if (sanitizedBase.endsWith(API_PREFIX) && normalizedPath.startsWith(API_PREFIX)) {
+    return `${sanitizedBase}${normalizedPath.slice(API_PREFIX.length)}`;
+  }
+
+  return `${sanitizedBase}${normalizedPath}`;
+};
+
+const addUnique = (collection, value) => {
+  if (!value) return;
+  if (collection.seen.has(value)) return;
+  collection.seen.add(value);
+  collection.items.push(value);
+};
+
+const collectEnvCandidates = (collection, baseCandidates) => {
+  for (const key of ENV_BASE_KEYS) {
+    const value = import.meta.env?.[key];
+    if (!value) continue;
+
+    if (/\/services\b/i.test(value)) {
+      const endpoint = normalizeEndpoint(value);
+      if (endpoint) {
+        addUnique(collection, endpoint);
+      }
+      continue;
+    }
+
+    const normalized = normalizeBaseUrl(value);
+    if (normalized) {
+      baseCandidates.add(normalized);
+    }
+  }
+
+  for (const key of ENV_ENDPOINT_KEYS) {
+    const value = import.meta.env?.[key];
+    if (!value) continue;
+
+    const normalized = normalizeEndpoint(value);
+    if (normalized) {
+      addUnique(collection, normalized);
+    }
+  }
+};
+
+const collectWindowCandidates = (baseCandidates) => {
+  if (typeof window === 'undefined') {
+    for (const candidate of STATIC_BASE_CANDIDATES) {
+      const normalized = normalizeBaseUrl(candidate);
+      if (normalized) {
+        baseCandidates.add(normalized);
+      }
+    }
+    return;
+  }
+
+  const { origin, protocol, hostname, port } = window.location;
+
+  if (origin) {
+    const normalizedOrigin = normalizeBaseUrl(origin);
+    if (normalizedOrigin) {
+      baseCandidates.add(normalizedOrigin);
+    }
+  }
+
+  const scheme = protocol === 'https:' ? 'https:' : 'http:';
+  const hostnames = new Set([hostname, 'localhost', '127.0.0.1']);
+  const preferredPorts = new Set(['3004', '4001']);
+
+  if (port) {
+    if (port === '3000' || port === '4173') {
+      preferredPorts.add('3004');
+      preferredPorts.add('4001');
+    }
+  }
+
+  for (const host of hostnames) {
+    if (!host) continue;
+    for (const preferredPort of preferredPorts) {
+      const normalized = normalizeBaseUrl(`${scheme}//${host}:${preferredPort}`);
+      if (normalized) {
+        baseCandidates.add(normalized);
+      }
+    }
+  }
+
+  for (const candidate of STATIC_BASE_CANDIDATES) {
+    const normalized = normalizeBaseUrl(candidate);
+    if (normalized) {
+      baseCandidates.add(normalized);
+    }
+  }
+};
+
+export const buildServiceEndpointCandidates = () => {
+  const collection = { items: [], seen: new Set() };
+  const baseCandidates = new Set(['']);
+
+  collectEnvCandidates(collection, baseCandidates);
+  collectWindowCandidates(baseCandidates);
+
+  for (const base of baseCandidates) {
+    for (const path of DEFAULT_SERVICE_PATHS) {
+      addUnique(collection, joinBaseAndPath(base, path));
+    }
+  }
+
+  return collection.items;
+};


### PR DESCRIPTION
## Summary
- add a browser-side helper that assembles likely Sage and Warden base URLs from env values and common localhost ports
- update the Moon setup wizard to use the generated endpoint list when loading installable services so it can fall back across ports and hosts

## Testing
- npm run build (services/moon)


------
https://chatgpt.com/codex/tasks/task_e_68df365d47b883319034783ff1f8c0d4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Setup now discovers service endpoints dynamically at runtime, combining environment variables, browser-provided values, and sensible defaults.
  - Endpoints are automatically normalized and deduplicated, improving reliability and reducing manual configuration.
  - Fallback behavior ensures the app can connect even when some values are missing or invalid.
  - Existing load/refresh flows are preserved, providing a smoother setup experience without changing user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->