### PR TITLE
Add script to generate combined JS and Java documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,8 @@ This is a passion project that doubles as a testbed for new technologies. Contri
 3. **Join the conversation** by opening issues, suggesting features, or sharing how you're using Noona with your Kavita instance.
 
 Thanks for checking out Noona. This project is growing quickly, and I hope it becomes a powerful companion for the Kavita community.
+
+## Documentation
+
+- Run `npm install` at the repository root (if you haven't already) to set up the shared tooling dependencies.
+- Execute `npm run docs` to regenerate `docs/docs.json`, which now aggregates both the JSDoc output from the Node.js services and parsed Javadoc comments from the Raven (Java) service.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,0 +1,31861 @@
+{
+  "generatedAt": "2025-10-03T12:50:35.791Z",
+  "jsdoc": [
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          173,
+          240
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 8,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000028",
+          "name": "defaultServiceName",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "defaultServiceName",
+      "longname": "defaultServiceName",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          247,
+          295
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 9,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000039",
+          "name": "defaultPort",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "defaultPort",
+      "longname": "defaultPort",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          302,
+          603
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 10,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000050",
+          "name": "normalizeUrl",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "trimmed": "normalizeUrl~trimmed"
+        }
+      },
+      "undocumented": true,
+      "name": "normalizeUrl",
+      "longname": "normalizeUrl",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          426,
+          452
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 15,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000067",
+          "name": "trimmed",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "trimmed",
+      "longname": "normalizeUrl~trimmed",
+      "kind": "constant",
+      "memberof": "normalizeUrl",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          611,
+          1496
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 27,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000094",
+          "name": "resolveDefaultWardenUrls",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "candidates": "resolveDefaultWardenUrls~candidates",
+          "hostCandidates": "resolveDefaultWardenUrls~hostCandidates",
+          "host": "resolveDefaultWardenUrls~host",
+          "port": "resolveDefaultWardenUrls~port",
+          "normalizedHost": "resolveDefaultWardenUrls~normalizedHost",
+          "normalized": "resolveDefaultWardenUrls~normalized"
+        }
+      },
+      "undocumented": true,
+      "name": "resolveDefaultWardenUrls",
+      "longname": "resolveDefaultWardenUrls",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          673,
+          794
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 28,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000104",
+          "name": "candidates",
+          "type": "ArrayExpression",
+          "value": "[\"\",\"\",\"\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "candidates",
+      "longname": "resolveDefaultWardenUrls~candidates",
+      "kind": "constant",
+      "memberof": "resolveDefaultWardenUrls",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          806,
+          890
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 34,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000111",
+          "name": "hostCandidates",
+          "type": "ArrayExpression",
+          "value": "[\"\",\"\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "hostCandidates",
+      "longname": "resolveDefaultWardenUrls~hostCandidates",
+      "kind": "constant",
+      "memberof": "resolveDefaultWardenUrls",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          907,
+          911
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 39,
+        "columnno": 15,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000118",
+          "name": "host"
+        }
+      },
+      "undocumented": true,
+      "name": "host",
+      "longname": "resolveDefaultWardenUrls~host",
+      "kind": "constant",
+      "memberof": "resolveDefaultWardenUrls",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1006,
+          1039
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 41,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000134",
+          "name": "port",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "resolveDefaultWardenUrls~port",
+      "kind": "constant",
+      "memberof": "resolveDefaultWardenUrls",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1058,
+          1086
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 42,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000140",
+          "name": "normalizedHost",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "normalizedHost",
+      "longname": "resolveDefaultWardenUrls~normalizedHost",
+      "kind": "constant",
+      "memberof": "resolveDefaultWardenUrls",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1375,
+          1450
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 55,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000168",
+          "name": "normalized",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "normalized",
+      "longname": "resolveDefaultWardenUrls~normalized",
+      "kind": "constant",
+      "memberof": "resolveDefaultWardenUrls",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1504,
+          1647
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 62,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000188",
+          "name": "defaultWardenBaseUrl",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "undefined": null
+        }
+      },
+      "undocumented": true,
+      "name": "defaultWardenBaseUrl",
+      "longname": "defaultWardenBaseUrl",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1655,
+          1769
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 67,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000208",
+          "name": "resolveLogger",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "resolveLogger",
+      "longname": "resolveLogger",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1698,
+          1713
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 68,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000215",
+          "name": "debug",
+          "type": "Identifier",
+          "value": "debugMSG"
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "debug",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1719,
+          1732
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 69,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000217",
+          "name": "error",
+          "type": "Identifier",
+          "value": "errMSG"
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1738,
+          1747
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 70,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000219",
+          "name": "info",
+          "type": "Identifier",
+          "value": "log"
+        }
+      },
+      "undocumented": true,
+      "name": "info",
+      "longname": "info",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1777,
+          4571
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 74,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000224",
+          "name": "createSetupClient",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "defaults": "createSetupClient~defaults",
+          "deduped": "createSetupClient~deduped",
+          "preferredBaseUrl": "createSetupClient~preferredBaseUrl",
+          "fetchFromWarden": "createSetupClient~fetchFromWarden",
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "createSetupClient",
+      "longname": "createSetupClient",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1804,
+          1811
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 75,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000229",
+          "name": "baseUrl",
+          "type": "Identifier",
+          "value": "baseUrl"
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrl",
+      "longname": "baseUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1817,
+          1830
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 76,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000231",
+          "name": "baseUrls",
+          "type": "AssignmentPattern",
+          "value": "baseUrls"
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrls",
+      "longname": "baseUrls",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1836,
+          1853
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 77,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000235",
+          "name": "fetchImpl",
+          "type": "AssignmentPattern",
+          "value": "fetchImpl"
+        }
+      },
+      "undocumented": true,
+      "name": "fetchImpl",
+      "longname": "fetchImpl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1859,
+          1865
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 78,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000239",
+          "name": "logger",
+          "type": "Identifier",
+          "value": "logger"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1871,
+          1882
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 79,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000241",
+          "name": "serviceName",
+          "type": "Identifier",
+          "value": "serviceName"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceName",
+      "longname": "serviceName",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1888,
+          1905
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 80,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000243",
+          "name": "env",
+          "type": "AssignmentPattern",
+          "value": "env"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1930,
+          1970
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 82,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000252",
+          "name": "defaults",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "defaults",
+      "longname": "createSetupClient~defaults",
+      "kind": "constant",
+      "memberof": "createSetupClient",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1981,
+          2157
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 83,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000258",
+          "name": "deduped",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "deduped",
+      "longname": "createSetupClient~deduped",
+      "kind": "constant",
+      "memberof": "createSetupClient",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2252,
+          2281
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 95,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000296",
+          "name": "preferredBaseUrl",
+          "type": "MemberExpression",
+          "value": "deduped[0]"
+        }
+      },
+      "undocumented": true,
+      "name": "preferredBaseUrl",
+      "longname": "createSetupClient~preferredBaseUrl",
+      "kind": "member",
+      "memberof": "createSetupClient",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2293,
+          3225
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 97,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000302",
+          "name": "fetchFromWarden",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "errors": "createSetupClient~fetchFromWarden~errors",
+          "candidates": "createSetupClient~fetchFromWarden~candidates",
+          "": null,
+          "candidate": "createSetupClient~fetchFromWarden~candidate",
+          "requestUrl": "createSetupClient~fetchFromWarden~requestUrl",
+          "response": "createSetupClient~fetchFromWarden~response",
+          "preferredBaseUrl": "createSetupClient~fetchFromWarden~preferredBaseUrl",
+          "message": "createSetupClient~fetchFromWarden~message"
+        }
+      },
+      "undocumented": true,
+      "name": "fetchFromWarden",
+      "longname": "createSetupClient~fetchFromWarden",
+      "kind": "function",
+      "memberof": "createSetupClient",
+      "scope": "inner",
+      "params": [],
+      "async": true
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2352,
+          2363
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 98,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000309",
+          "name": "errors",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "errors",
+      "longname": "createSetupClient~fetchFromWarden~errors",
+      "kind": "constant",
+      "memberof": "createSetupClient~fetchFromWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2378,
+          2516
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 99,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000313",
+          "name": "candidates",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "candidates",
+      "longname": "createSetupClient~fetchFromWarden~candidates",
+      "kind": "constant",
+      "memberof": "createSetupClient~fetchFromWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2537,
+          2546
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 103,
+        "columnno": 19,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000332",
+          "name": "candidate"
+        }
+      },
+      "undocumented": true,
+      "name": "candidate",
+      "longname": "createSetupClient~fetchFromWarden~candidate",
+      "kind": "constant",
+      "memberof": "createSetupClient~fetchFromWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2604,
+          2641
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 105,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000339",
+          "name": "requestUrl",
+          "type": "NewExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "requestUrl",
+      "longname": "createSetupClient~fetchFromWarden~requestUrl",
+      "kind": "constant",
+      "memberof": "createSetupClient~fetchFromWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2664,
+          2722
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 106,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000346",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "createSetupClient~fetchFromWarden~response",
+      "kind": "constant",
+      "memberof": "createSetupClient~fetchFromWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2882,
+          2910
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 112,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000372",
+          "name": "preferredBaseUrl",
+          "type": "Identifier",
+          "funcscope": "createSetupClient~fetchFromWarden",
+          "value": "candidate",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "preferredBaseUrl",
+      "longname": "createSetupClient~fetchFromWarden~preferredBaseUrl",
+      "kind": "member",
+      "memberof": "createSetupClient~fetchFromWarden",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2995,
+          3059
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 115,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000379",
+          "name": "message",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "message",
+      "longname": "createSetupClient~fetchFromWarden~message",
+      "kind": "constant",
+      "memberof": "createSetupClient~fetchFromWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3248,
+          3838
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 124,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000415",
+          "name": "listServices",
+          "type": "FunctionExpression"
+        },
+        "vars": {
+          "includeInstalled": "listServices~includeInstalled",
+          "response": "listServices~response",
+          "payload": "listServices~payload",
+          "services": "listServices~services"
+        }
+      },
+      "undocumented": true,
+      "name": "listServices",
+      "longname": "listServices",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3301,
+          3353
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 125,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000422",
+          "name": "includeInstalled",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "includeInstalled",
+      "longname": "listServices~includeInstalled",
+      "kind": "constant",
+      "memberof": "listServices",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3372,
+          3508
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 126,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000430",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "listServices~response",
+      "kind": "constant",
+      "memberof": "listServices",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3528,
+          3559
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 130,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000443",
+          "name": "payload",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "payload",
+      "longname": "listServices~payload",
+      "kind": "constant",
+      "memberof": "listServices",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3578,
+          3644
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 131,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000451",
+          "name": "services",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "listServices~services",
+      "kind": "constant",
+      "memberof": "listServices",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3849,
+          4562
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 139,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000469",
+          "name": "installServices",
+          "type": "FunctionExpression"
+        },
+        "vars": {
+          "response": "installServices~response",
+          "payload": "installServices~payload",
+          "": null,
+          "results": "installServices~results",
+          "status": "installServices~status"
+        }
+      },
+      "undocumented": true,
+      "name": "installServices",
+      "longname": "installServices",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3901,
+          4124
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 140,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000474",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "installServices~response",
+      "kind": "constant",
+      "memberof": "installServices",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3977,
+          3991
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 141,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000481",
+          "name": "method",
+          "type": "Literal",
+          "value": "POST"
+        }
+      },
+      "undocumented": true,
+      "name": "method",
+      "longname": "method",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4009,
+          4056
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 142,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000483",
+          "name": "headers",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"application/json\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "headers",
+      "longname": "headers",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4020,
+          4054
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 142,
+        "columnno": 27,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000485",
+          "name": "\"Content-Type\"",
+          "type": "Literal",
+          "value": "application/json"
+        }
+      },
+      "undocumented": true,
+      "name": "\"Content-Type\"",
+      "longname": "headers.\"Content-Type\"",
+      "kind": "member",
+      "memberof": "headers",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4074,
+          4108
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 143,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000487",
+          "name": "body",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "body",
+      "longname": "body",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4097,
+          4105
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 143,
+        "columnno": 39,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000493",
+          "name": "services",
+          "type": "Identifier",
+          "value": "services"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4144,
+          4193
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 146,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000496",
+          "name": "payload",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "payload",
+      "longname": "installServices~payload",
+      "kind": "constant",
+      "memberof": "installServices",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4212,
+          4275
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 147,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000509",
+          "name": "results",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "results",
+      "longname": "installServices~results",
+      "kind": "constant",
+      "memberof": "installServices",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4294,
+          4325
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 148,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000524",
+          "name": "status",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "installServices~status",
+      "kind": "constant",
+      "memberof": "installServices",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4535,
+          4541
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 153,
+        "columnno": 21,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000535",
+          "name": "status",
+          "type": "Identifier",
+          "value": "status"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4543,
+          4550
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 153,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000537",
+          "name": "results",
+          "type": "Identifier",
+          "value": "results"
+        }
+      },
+      "undocumented": true,
+      "name": "results",
+      "longname": "results",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4573,
+          6794
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 158,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000539",
+          "name": "exports.createSageApp",
+          "type": "VariableDeclaration"
+        }
+      },
+      "undocumented": true,
+      "name": "createSageApp",
+      "longname": "createSageApp",
+      "kind": "constant",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4586,
+          6794
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 158,
+        "columnno": 13,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000541",
+          "name": "createSageApp",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "logger": "createSageApp~logger",
+          "setupClient": "createSageApp~setupClient",
+          "app": "createSageApp~app",
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "createSageApp",
+      "longname": "createSageApp",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4609,
+          4643
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 159,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000546",
+          "name": "serviceName",
+          "type": "AssignmentPattern",
+          "value": "serviceName"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceName",
+      "longname": "serviceName",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4649,
+          4672
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 160,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000551",
+          "name": "logger",
+          "type": "Identifier",
+          "value": "loggerOverrides"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4678,
+          4710
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 161,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000553",
+          "name": "setupClient",
+          "type": "Identifier",
+          "value": "setupClientOverride"
+        }
+      },
+      "undocumented": true,
+      "name": "setupClient",
+      "longname": "setupClient",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4716,
+          4740
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 162,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000555",
+          "name": "setup",
+          "type": "AssignmentPattern",
+          "value": "setupOptions"
+        }
+      },
+      "undocumented": true,
+      "name": "setup",
+      "longname": "setup",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4765,
+          4804
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 164,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000562",
+          "name": "logger",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "createSageApp~logger",
+      "kind": "constant",
+      "memberof": "createSageApp",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4815,
+          5191
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 165,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000568",
+          "name": "setupClient",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "setupClient",
+      "longname": "createSageApp~setupClient",
+      "kind": "constant",
+      "memberof": "createSageApp",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4900,
+          4955
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 168,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000575",
+          "name": "baseUrl",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrl",
+      "longname": "baseUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4969,
+          5006
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 169,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000582",
+          "name": "baseUrls",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrls",
+      "longname": "baseUrls",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5020,
+          5084
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 170,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000588",
+          "name": "fetchImpl",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "fetchImpl",
+      "longname": "fetchImpl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5098,
+          5104
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 171,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000598",
+          "name": "logger",
+          "type": "Identifier",
+          "value": "logger"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5118,
+          5129
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 172,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000600",
+          "name": "serviceName",
+          "type": "Identifier",
+          "value": "serviceName"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceName",
+      "longname": "serviceName",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5143,
+          5179
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 173,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000602",
+          "name": "env",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5202,
+          5217
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 175,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000611",
+          "name": "app",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "app",
+      "longname": "createSageApp~app",
+      "kind": "constant",
+      "memberof": "createSageApp",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5475,
+          5596
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 186,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000671",
+          "name": "pages",
+          "type": "ArrayExpression",
+          "value": "[\"{\\\"name\\\":\\\"Setup\\\",\\\"path\\\":\\\"/setup\\\"}\",\"{\\\"name\\\":\\\"Dashboard\\\",\\\"path\\\":\\\"/dashboard\\\"}\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "pages",
+      "longname": "<anonymous>~pages",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5499,
+          5512
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 187,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000675",
+          "name": "name",
+          "type": "Literal",
+          "value": "Setup"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5514,
+          5528
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 187,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000677",
+          "name": "path",
+          "type": "Literal",
+          "value": "/setup"
+        }
+      },
+      "undocumented": true,
+      "name": "path",
+      "longname": "path",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5546,
+          5563
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 188,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000680",
+          "name": "name",
+          "type": "Literal",
+          "value": "Dashboard"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5565,
+          5583
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 188,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000682",
+          "name": "path",
+          "type": "Literal",
+          "value": "/dashboard"
+        }
+      },
+      "undocumented": true,
+      "name": "path",
+      "longname": "path",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5808,
+          5851
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 197,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000716",
+          "name": "services",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "<anonymous>~services",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5875,
+          5883
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 198,
+        "columnno": 23,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000729",
+          "name": "services",
+          "type": "Identifier",
+          "value": "services"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6050,
+          6099
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 201,
+        "columnno": 35,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000755",
+          "name": "error",
+          "type": "Literal",
+          "value": "Unable to retrieve installable services."
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6192,
+          6221
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 206,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000768",
+          "name": "services",
+          "type": "ChainExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "<anonymous>~services",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6323,
+          6379
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 209,
+        "columnno": 35,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000795",
+          "name": "error",
+          "type": "Literal",
+          "value": "Body must include a non-empty \"services\" array."
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6447,
+          6453
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 214,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000803",
+          "name": "status",
+          "type": "Identifier",
+          "value": "status"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6455,
+          6462
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 214,
+        "columnno": 28,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000805",
+          "name": "results",
+          "type": "Identifier",
+          "value": "results"
+        }
+      },
+      "undocumented": true,
+      "name": "results",
+      "longname": "results",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6556,
+          6563
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 215,
+        "columnno": 45,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000825",
+          "name": "results",
+          "type": "Identifier",
+          "value": "results"
+        }
+      },
+      "undocumented": true,
+      "name": "results",
+      "longname": "results",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6720,
+          6756
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 218,
+        "columnno": 35,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000851",
+          "name": "error",
+          "type": "Literal",
+          "value": "Failed to install services."
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6796,
+          7237
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 225,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000855",
+          "name": "exports.startSage",
+          "type": "VariableDeclaration"
+        }
+      },
+      "undocumented": true,
+      "name": "startSage",
+      "longname": "startSage",
+      "kind": "constant",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6809,
+          7237
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 225,
+        "columnno": 13,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000857",
+          "name": "startSage",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "logger": "startSage~logger",
+          "app": "startSage~app",
+          "server": "startSage~server",
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "startSage",
+      "longname": "startSage",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6828,
+          6848
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 226,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000862",
+          "name": "port",
+          "type": "AssignmentPattern",
+          "value": "port"
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6854,
+          6888
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 227,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000867",
+          "name": "serviceName",
+          "type": "AssignmentPattern",
+          "value": "serviceName"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceName",
+      "longname": "serviceName",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6894,
+          6917
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 228,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000872",
+          "name": "logger",
+          "type": "Identifier",
+          "value": "loggerOverrides"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6923,
+          6934
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 229,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000874",
+          "name": "setupClient",
+          "type": "Identifier",
+          "value": "setupClient"
+        }
+      },
+      "undocumented": true,
+      "name": "setupClient",
+      "longname": "setupClient",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6940,
+          6945
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 230,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000876",
+          "name": "setup",
+          "type": "Identifier",
+          "value": "setup"
+        }
+      },
+      "undocumented": true,
+      "name": "setup",
+      "longname": "setup",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6970,
+          7009
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 232,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000881",
+          "name": "logger",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "startSage~logger",
+      "kind": "constant",
+      "memberof": "startSage",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7020,
+          7084
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 233,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000887",
+          "name": "app",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "app",
+      "longname": "startSage~app",
+      "kind": "constant",
+      "memberof": "startSage",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7042,
+          7053
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 233,
+        "columnno": 32,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000892",
+          "name": "serviceName",
+          "type": "Identifier",
+          "value": "serviceName"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceName",
+      "longname": "serviceName",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7055,
+          7061
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 233,
+        "columnno": 45,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000894",
+          "name": "logger",
+          "type": "Identifier",
+          "value": "logger"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7063,
+          7074
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 233,
+        "columnno": 53,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000896",
+          "name": "setupClient",
+          "type": "Identifier",
+          "value": "setupClient"
+        }
+      },
+      "undocumented": true,
+      "name": "setupClient",
+      "longname": "setupClient",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7076,
+          7081
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 233,
+        "columnno": 66,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000898",
+          "name": "setup",
+          "type": "Identifier",
+          "value": "setup"
+        }
+      },
+      "undocumented": true,
+      "name": "setup",
+      "longname": "setup",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7095,
+          7207
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 234,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000901",
+          "name": "server",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "startSage~server",
+      "kind": "constant",
+      "memberof": "startSage",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7222,
+          7225
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 238,
+        "columnno": 13,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000923",
+          "name": "app",
+          "type": "Identifier",
+          "value": "app"
+        }
+      },
+      "undocumented": true,
+      "name": "app",
+      "longname": "app",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7227,
+          7233
+        ],
+        "filename": "sageApp.mjs",
+        "lineno": 238,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/sage/shared",
+        "code": {
+          "id": "astnode100000925",
+          "name": "server",
+          "type": "Identifier",
+          "value": "server"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          218,
+          613
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 9,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100000948",
+          "name": "listen",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "listen",
+      "longname": "listen",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          273,
+          610
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 10,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100000958",
+          "name": "server",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "<anonymous>~server",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          318,
+          344
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 11,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100000968",
+          "name": "address",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "address",
+      "longname": "<anonymous>~address",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          486,
+          505
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 16,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100000988",
+          "name": "port",
+          "type": "MemberExpression",
+          "value": "address.port"
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "<anonymous>~port",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          536,
+          542
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 18,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100000997",
+          "name": "server",
+          "type": "Identifier",
+          "value": "server"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          556,
+          591
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 19,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100000999",
+          "name": "baseUrl",
+          "type": "TemplateLiteral",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrl",
+      "longname": "baseUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          621,
+          817
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 24,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001005",
+          "name": "closeServer",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "closeServer",
+      "longname": "closeServer",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          894,
+          912
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 35,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001042",
+          "name": "debugMessages",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "debugMessages",
+      "longname": "<anonymous>~debugMessages",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          923,
+          1075
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 36,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001046",
+          "name": "app",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "app",
+      "longname": "<anonymous>~app",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          953,
+          977
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 37,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001051",
+          "name": "serviceName",
+          "type": "Literal",
+          "value": "test-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceName",
+      "longname": "serviceName",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          987,
+          1067
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 38,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001053",
+          "name": "logger",
+          "type": "ObjectExpression",
+          "value": "{\"debug\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1009,
+          1056
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 39,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001055",
+          "name": "debug",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "logger.debug",
+      "kind": "function",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1089,
+          1095
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 43,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001066",
+          "name": "server",
+          "type": "Identifier",
+          "value": "server"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1097,
+          1104
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 43,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001068",
+          "name": "baseUrl",
+          "type": "Identifier",
+          "value": "baseUrl"
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrl",
+      "longname": "baseUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1177,
+          1220
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 46,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001084",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "<anonymous>~response",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1478,
+          1496
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 53,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001137",
+          "name": "debugMessages",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "debugMessages",
+      "longname": "<anonymous>~debugMessages",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1507,
+          1659
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 54,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001141",
+          "name": "app",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "app",
+      "longname": "<anonymous>~app",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1537,
+          1561
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 55,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001146",
+          "name": "serviceName",
+          "type": "Literal",
+          "value": "test-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceName",
+      "longname": "serviceName",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1571,
+          1651
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 56,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001148",
+          "name": "logger",
+          "type": "ObjectExpression",
+          "value": "{\"debug\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1593,
+          1640
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 57,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001150",
+          "name": "debug",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "logger.debug",
+      "kind": "function",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1673,
+          1679
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 61,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001161",
+          "name": "server",
+          "type": "Identifier",
+          "value": "server"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1681,
+          1688
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 61,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001163",
+          "name": "baseUrl",
+          "type": "Identifier",
+          "value": "baseUrl"
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrl",
+      "longname": "baseUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1761,
+          1807
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 64,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001179",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "<anonymous>~response",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1857,
+          1888
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 66,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001198",
+          "name": "payload",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "payload",
+      "longname": "<anonymous>~payload",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1932,
+          1945
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 69,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001213",
+          "name": "name",
+          "type": "Literal",
+          "value": "Setup"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1947,
+          1961
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 69,
+        "columnno": 25,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001215",
+          "name": "path",
+          "type": "Literal",
+          "value": "/setup"
+        }
+      },
+      "undocumented": true,
+      "name": "path",
+      "longname": "path",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1975,
+          1992
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 70,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001218",
+          "name": "name",
+          "type": "Literal",
+          "value": "Dashboard"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1994,
+          2012
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 70,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001220",
+          "name": "path",
+          "type": "Literal",
+          "value": "/dashboard"
+        }
+      },
+      "undocumented": true,
+      "name": "path",
+      "longname": "path",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2218,
+          2235
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 76,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001246",
+          "name": "infoMessages",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "infoMessages",
+      "longname": "<anonymous>~infoMessages",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2246,
+          2264
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 77,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001250",
+          "name": "debugMessages",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "debugMessages",
+      "longname": "<anonymous>~debugMessages",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2278,
+          2284
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 79,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001256",
+          "name": "server",
+          "type": "Identifier",
+          "value": "server"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2309,
+          2316
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 80,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001261",
+          "name": "port",
+          "type": "Literal",
+          "value": 0
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2326,
+          2350
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 81,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001263",
+          "name": "serviceName",
+          "type": "Literal",
+          "value": "test-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceName",
+      "longname": "serviceName",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2360,
+          2499
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 82,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001265",
+          "name": "logger",
+          "type": "ObjectExpression",
+          "value": "{\"debug\":\"\",\"info\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2382,
+          2429
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 83,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001267",
+          "name": "debug",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "logger.debug",
+      "kind": "function",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2443,
+          2488
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 84,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001275",
+          "name": "info",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "info",
+      "longname": "logger.info",
+      "kind": "function",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2595,
+          2621
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 91,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001299",
+          "name": "address",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "address",
+      "longname": "<anonymous>~address",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2967,
+          2977
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 102,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001361",
+          "name": "calls",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "calls",
+      "longname": "<anonymous>~calls",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2988,
+          3342
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 103,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001365",
+          "name": "app",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "app",
+      "longname": "<anonymous>~app",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3018,
+          3042
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 104,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001370",
+          "name": "serviceName",
+          "type": "Literal",
+          "value": "test-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceName",
+      "longname": "serviceName",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3052,
+          3334
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 105,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001372",
+          "name": "setupClient",
+          "type": "ObjectExpression",
+          "value": "{\"listServices\":\"\",\"installServices\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "setupClient",
+      "longname": "setupClient",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3079,
+          3198
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 106,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001374",
+          "name": "listServices",
+          "type": "FunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "listServices",
+      "longname": "setupClient.listServices",
+      "kind": "function",
+      "memberof": "setupClient",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3163,
+          3181
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 108,
+        "columnno": 26,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001386",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-moon"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3212,
+          3323
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 110,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001388",
+          "name": "installServices",
+          "type": "FunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "installServices",
+      "longname": "setupClient.installServices",
+      "kind": "function",
+      "memberof": "setupClient",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3356,
+          3362
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 116,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001398",
+          "name": "server",
+          "type": "Identifier",
+          "value": "server"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3364,
+          3371
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 116,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001400",
+          "name": "baseUrl",
+          "type": "Identifier",
+          "value": "baseUrl"
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrl",
+      "longname": "baseUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3444,
+          3499
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 119,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001416",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "<anonymous>~response",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3585,
+          3619
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 121,
+        "columnno": 46,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001445",
+          "name": "services",
+          "type": "ArrayExpression",
+          "value": "[\"{\\\"name\\\":\\\"noona-moon\\\"}\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3598,
+          3616
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 121,
+        "columnno": 59,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001448",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-moon"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3770,
+          3785
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 126,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001466",
+          "name": "fetchCalls",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "fetchCalls",
+      "longname": "<anonymous>~fetchCalls",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3796,
+          4201
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 127,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001470",
+          "name": "app",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "app",
+      "longname": "<anonymous>~app",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3826,
+          3850
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 128,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001475",
+          "name": "serviceName",
+          "type": "Literal",
+          "value": "test-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceName",
+      "longname": "serviceName",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3860,
+          4193
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 129,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001477",
+          "name": "setup",
+          "type": "ObjectExpression",
+          "value": "{\"baseUrl\":\"http://warden.local\",\"fetchImpl\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "setup",
+      "longname": "setup",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3881,
+          3911
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 130,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001479",
+          "name": "baseUrl",
+          "type": "Literal",
+          "value": "http://warden.local"
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrl",
+      "longname": "setup.baseUrl",
+      "kind": "member",
+      "memberof": "setup",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3925,
+          4182
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 131,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001481",
+          "name": "fetchImpl",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "fetchImpl",
+      "longname": "setup.fetchImpl",
+      "kind": "function",
+      "memberof": "setup",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4035,
+          4043
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 134,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001493",
+          "name": "ok",
+          "type": "Literal",
+          "value": true
+        }
+      },
+      "undocumented": true,
+      "name": "ok",
+      "longname": "ok",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4065,
+          4149
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 135,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001495",
+          "name": "json",
+          "type": "FunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "json",
+      "longname": "json",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4113,
+          4125
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 136,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001500",
+          "name": "services",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4215,
+          4221
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 143,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001505",
+          "name": "server",
+          "type": "Identifier",
+          "value": "server"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4223,
+          4230
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 143,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001507",
+          "name": "baseUrl",
+          "type": "Identifier",
+          "value": "baseUrl"
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrl",
+      "longname": "baseUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4303,
+          4358
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 146,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001523",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "<anonymous>~response",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4615,
+          4630
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 154,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001563",
+          "name": "fetchCalls",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "fetchCalls",
+      "longname": "<anonymous>~fetchCalls",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4641,
+          5306
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 155,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001567",
+          "name": "app",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "app",
+      "longname": "<anonymous>~app",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4671,
+          4695
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 156,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001572",
+          "name": "serviceName",
+          "type": "Literal",
+          "value": "test-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceName",
+      "longname": "serviceName",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4705,
+          5298
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 157,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001574",
+          "name": "setup",
+          "type": "ObjectExpression",
+          "value": "{\"baseUrl\":\"http://unreachable.local:4001\",\"baseUrls\":\"\",\"fetchImpl\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "setup",
+      "longname": "setup",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4726,
+          4766
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 158,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001576",
+          "name": "baseUrl",
+          "type": "Literal",
+          "value": "http://unreachable.local:4001"
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrl",
+      "longname": "setup.baseUrl",
+      "kind": "member",
+      "memberof": "setup",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4780,
+          4821
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 159,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001578",
+          "name": "baseUrls",
+          "type": "ArrayExpression",
+          "value": "[\"http://warden-ok.local:4001\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrls",
+      "longname": "setup.baseUrls",
+      "kind": "member",
+      "memberof": "setup",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4835,
+          5287
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 160,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001581",
+          "name": "fetchImpl",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "fetchImpl",
+      "longname": "setup.fetchImpl",
+      "kind": "function",
+      "memberof": "setup",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5001,
+          5010
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 164,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001600",
+          "name": "ok",
+          "type": "Literal",
+          "value": false
+        }
+      },
+      "undocumented": true,
+      "name": "ok",
+      "longname": "ok",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5012,
+          5023
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 164,
+        "columnno": 40,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001602",
+          "name": "status",
+          "type": "Literal",
+          "value": 404
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5025,
+          5051
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 164,
+        "columnno": 53,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001604",
+          "name": "json",
+          "type": "FunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "json",
+      "longname": "json",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5118,
+          5126
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 168,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001611",
+          "name": "ok",
+          "type": "Literal",
+          "value": true
+        }
+      },
+      "undocumented": true,
+      "name": "ok",
+      "longname": "ok",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5148,
+          5254
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 169,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001613",
+          "name": "json",
+          "type": "FunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "json",
+      "longname": "json",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5196,
+          5230
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 170,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001618",
+          "name": "services",
+          "type": "ArrayExpression",
+          "value": "[\"{\\\"name\\\":\\\"noona-moon\\\"}\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5209,
+          5227
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 170,
+        "columnno": 46,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001621",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-moon"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5320,
+          5326
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 177,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001626",
+          "name": "server",
+          "type": "Identifier",
+          "value": "server"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5328,
+          5335
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 177,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001628",
+          "name": "baseUrl",
+          "type": "Identifier",
+          "value": "baseUrl"
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrl",
+      "longname": "baseUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5408,
+          5463
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 180,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001644",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "<anonymous>~response",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5513,
+          5544
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 182,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001663",
+          "name": "payload",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "payload",
+      "longname": "<anonymous>~payload",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5587,
+          5605
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 183,
+        "columnno": 42,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001680",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-moon"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5901,
+          6140
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 192,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001699",
+          "name": "app",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "app",
+      "longname": "<anonymous>~app",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5931,
+          5955
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 193,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001704",
+          "name": "serviceName",
+          "type": "Literal",
+          "value": "test-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceName",
+      "longname": "serviceName",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5965,
+          6132
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 194,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001706",
+          "name": "setup",
+          "type": "ObjectExpression",
+          "value": "{\"baseUrls\":\"\",\"fetchImpl\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "setup",
+      "longname": "setup",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5986,
+          6029
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 195,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001708",
+          "name": "baseUrls",
+          "type": "ArrayExpression",
+          "value": "[\"http://unreachable.local:4001\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrls",
+      "longname": "setup.baseUrls",
+      "kind": "member",
+      "memberof": "setup",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6043,
+          6121
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 196,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001711",
+          "name": "fetchImpl",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "fetchImpl",
+      "longname": "setup.fetchImpl",
+      "kind": "function",
+      "memberof": "setup",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6154,
+          6160
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 202,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001721",
+          "name": "server",
+          "type": "Identifier",
+          "value": "server"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6162,
+          6169
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 202,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001723",
+          "name": "baseUrl",
+          "type": "Identifier",
+          "value": "baseUrl"
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrl",
+      "longname": "baseUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6242,
+          6297
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 205,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001739",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "<anonymous>~response",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6347,
+          6378
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 207,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001758",
+          "name": "payload",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "payload",
+      "longname": "<anonymous>~payload",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6554,
+          6564
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 212,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001785",
+          "name": "calls",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "calls",
+      "longname": "<anonymous>~calls",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6575,
+          6940
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 213,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001789",
+          "name": "app",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "app",
+      "longname": "<anonymous>~app",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6605,
+          6629
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 214,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001794",
+          "name": "serviceName",
+          "type": "Literal",
+          "value": "test-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceName",
+      "longname": "serviceName",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6639,
+          6932
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 215,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001796",
+          "name": "setupClient",
+          "type": "ObjectExpression",
+          "value": "{\"listServices\":\"\",\"installServices\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "setupClient",
+      "longname": "setupClient",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6666,
+          6728
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 216,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001798",
+          "name": "listServices",
+          "type": "FunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "listServices",
+      "longname": "setupClient.listServices",
+      "kind": "function",
+      "memberof": "setupClient",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6742,
+          6921
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 219,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001803",
+          "name": "installServices",
+          "type": "FunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "installServices",
+      "longname": "setupClient.installServices",
+      "kind": "function",
+      "memberof": "setupClient",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6838,
+          6849
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 221,
+        "columnno": 25,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001815",
+          "name": "status",
+          "type": "Literal",
+          "value": 207
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6851,
+          6905
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 221,
+        "columnno": 38,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001817",
+          "name": "results",
+          "type": "ArrayExpression",
+          "value": "[\"{\\\"name\\\":\\\"noona-sage\\\",\\\"status\\\":\\\"installed\\\"}\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "results",
+      "longname": "results",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6863,
+          6881
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 221,
+        "columnno": 50,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001820",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6883,
+          6902
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 221,
+        "columnno": 70,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001822",
+          "name": "status",
+          "type": "Literal",
+          "value": "installed"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6954,
+          6960
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 226,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001827",
+          "name": "server",
+          "type": "Identifier",
+          "value": "server"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6962,
+          6969
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 226,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001829",
+          "name": "baseUrl",
+          "type": "Identifier",
+          "value": "baseUrl"
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrl",
+      "longname": "baseUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7042,
+          7246
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 229,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001845",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "<anonymous>~response",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7107,
+          7121
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 230,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001855",
+          "name": "method",
+          "type": "Literal",
+          "value": "POST"
+        }
+      },
+      "undocumented": true,
+      "name": "method",
+      "longname": "method",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7131,
+          7178
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 231,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001857",
+          "name": "headers",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"application/json\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "headers",
+      "longname": "headers",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7142,
+          7176
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 231,
+        "columnno": 19,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001859",
+          "name": "\"Content-Type\"",
+          "type": "Literal",
+          "value": "application/json"
+        }
+      },
+      "undocumented": true,
+      "name": "\"Content-Type\"",
+      "longname": "headers.\"Content-Type\"",
+      "kind": "member",
+      "memberof": "headers",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7188,
+          7238
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 232,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001861",
+          "name": "body",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "body",
+      "longname": "body",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7211,
+          7235
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 232,
+        "columnno": 31,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001867",
+          "name": "services",
+          "type": "ArrayExpression",
+          "value": "[\"noona-sage\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7333,
+          7387
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 236,
+        "columnno": 46,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001890",
+          "name": "results",
+          "type": "ArrayExpression",
+          "value": "[\"{\\\"name\\\":\\\"noona-sage\\\",\\\"status\\\":\\\"installed\\\"}\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "results",
+      "longname": "results",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7345,
+          7363
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 236,
+        "columnno": 58,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001893",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7365,
+          7384
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 236,
+        "columnno": 78,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001895",
+          "name": "status",
+          "type": "Literal",
+          "value": "installed"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7516,
+          7813
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 241,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001914",
+          "name": "app",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "app",
+      "longname": "<anonymous>~app",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7546,
+          7570
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 242,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001919",
+          "name": "serviceName",
+          "type": "Literal",
+          "value": "test-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceName",
+      "longname": "serviceName",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7580,
+          7805
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 243,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001921",
+          "name": "setupClient",
+          "type": "ObjectExpression",
+          "value": "{\"listServices\":\"\",\"installServices\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "setupClient",
+      "longname": "setupClient",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7607,
+          7669
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 244,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001923",
+          "name": "listServices",
+          "type": "FunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "listServices",
+      "longname": "setupClient.listServices",
+      "kind": "function",
+      "memberof": "setupClient",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7683,
+          7794
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 247,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001928",
+          "name": "installServices",
+          "type": "FunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "installServices",
+      "longname": "setupClient.installServices",
+      "kind": "function",
+      "memberof": "setupClient",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7827,
+          7833
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 253,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001938",
+          "name": "server",
+          "type": "Identifier",
+          "value": "server"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7835,
+          7842
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 253,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001940",
+          "name": "baseUrl",
+          "type": "Identifier",
+          "value": "baseUrl"
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrl",
+      "longname": "baseUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7915,
+          8107
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 256,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001956",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "<anonymous>~response",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7980,
+          7994
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 257,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001966",
+          "name": "method",
+          "type": "Literal",
+          "value": "POST"
+        }
+      },
+      "undocumented": true,
+      "name": "method",
+      "longname": "method",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8004,
+          8051
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 258,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001968",
+          "name": "headers",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"application/json\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "headers",
+      "longname": "headers",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8015,
+          8049
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 258,
+        "columnno": 19,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001970",
+          "name": "\"Content-Type\"",
+          "type": "Literal",
+          "value": "application/json"
+        }
+      },
+      "undocumented": true,
+      "name": "\"Content-Type\"",
+      "longname": "headers.\"Content-Type\"",
+      "kind": "member",
+      "memberof": "headers",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8061,
+          8099
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 259,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001972",
+          "name": "body",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "body",
+      "longname": "body",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8084,
+          8096
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 259,
+        "columnno": 31,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001978",
+          "name": "services",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8158,
+          8189
+        ],
+        "filename": "sageApp.test.mjs",
+        "lineno": 263,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/sage/tests",
+        "code": {
+          "id": "astnode100001990",
+          "name": "payload",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "payload",
+      "longname": "<anonymous>~payload",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "/**\n * @fileoverview\n * Vault microservice for handling secure MongoDB and Redis operations from other Noona services.\n */",
+      "meta": {
+        "filename": "initVault.mjs",
+        "lineno": 3,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/vault",
+        "code": {}
+      },
+      "name": "vault/initVault.mjs",
+      "kind": "file",
+      "description": "Vault microservice for handling secure MongoDB and Redis operations from other Noona services.",
+      "preserveName": true,
+      "longname": "vault/initVault.mjs",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          339,
+          342
+        ],
+        "filename": "initVault.mjs",
+        "lineno": 14,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault",
+        "code": {
+          "id": "astnode100002035",
+          "name": "app",
+          "type": "Identifier",
+          "value": "app"
+        }
+      },
+      "undocumented": true,
+      "name": "app",
+      "longname": "app",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          344,
+          348
+        ],
+        "filename": "initVault.mjs",
+        "lineno": 14,
+        "columnno": 13,
+        "path": "/workspace/Noona/services/vault",
+        "code": {
+          "id": "astnode100002037",
+          "name": "port",
+          "type": "Identifier",
+          "value": "port"
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          370,
+          408
+        ],
+        "filename": "initVault.mjs",
+        "lineno": 14,
+        "columnno": 39,
+        "path": "/workspace/Noona/services/vault",
+        "code": {
+          "id": "astnode100002042",
+          "name": "logger",
+          "type": "ObjectExpression",
+          "value": "{\"log\":\"\",\"warn\":\"\",\"debug\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          380,
+          383
+        ],
+        "filename": "initVault.mjs",
+        "lineno": 14,
+        "columnno": 49,
+        "path": "/workspace/Noona/services/vault",
+        "code": {
+          "id": "astnode100002044",
+          "name": "log",
+          "type": "Identifier",
+          "value": "log"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "logger.log",
+      "kind": "member",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          385,
+          389
+        ],
+        "filename": "initVault.mjs",
+        "lineno": 14,
+        "columnno": 54,
+        "path": "/workspace/Noona/services/vault",
+        "code": {
+          "id": "astnode100002046",
+          "name": "warn",
+          "type": "Identifier",
+          "value": "warn"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "logger.warn",
+      "kind": "member",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          391,
+          406
+        ],
+        "filename": "initVault.mjs",
+        "lineno": 14,
+        "columnno": 60,
+        "path": "/workspace/Noona/services/vault",
+        "code": {
+          "id": "astnode100002048",
+          "name": "debug",
+          "type": "Identifier",
+          "value": "debugMSG"
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "logger.debug",
+      "kind": "member",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          74,
+          99
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 4,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002070",
+          "name": "cachedHandlePacket",
+          "type": "Literal",
+          "value": null
+        }
+      },
+      "undocumented": true,
+      "name": "cachedHandlePacket",
+      "longname": "cachedHandlePacket",
+      "kind": "member",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          102,
+          349
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 6,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002073",
+          "name": "getDefaultHandlePacket",
+          "type": "FunctionDeclaration",
+          "paramnames": []
+        },
+        "vars": {
+          "module": "getDefaultHandlePacket~module",
+          "cachedHandlePacket": "getDefaultHandlePacket~cachedHandlePacket"
+        }
+      },
+      "undocumented": true,
+      "name": "getDefaultHandlePacket",
+      "longname": "getDefaultHandlePacket",
+      "kind": "function",
+      "scope": "global",
+      "params": [],
+      "async": true
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          189,
+          258
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 8,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002081",
+          "name": "module",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "module",
+      "longname": "getDefaultHandlePacket~module",
+      "kind": "constant",
+      "memberof": "getDefaultHandlePacket",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          268,
+          308
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 9,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002086",
+          "name": "cachedHandlePacket",
+          "type": "MemberExpression",
+          "funcscope": "getDefaultHandlePacket",
+          "value": "module.handlePacket",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "cachedHandlePacket",
+      "longname": "getDefaultHandlePacket~cachedHandlePacket",
+      "kind": "member",
+      "memberof": "getDefaultHandlePacket",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          357,
+          556
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 15,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002094",
+          "name": "fallbackLogger",
+          "type": "ObjectExpression",
+          "value": "{\"log\":\"\",\"warn\":\"\",\"debug\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "fallbackLogger",
+      "longname": "fallbackLogger",
+      "kind": "constant",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          380,
+          418
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 16,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002097",
+          "name": "log",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "fallbackLogger.log",
+      "kind": "function",
+      "memberof": "fallbackLogger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          424,
+          464
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 17,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002107",
+          "name": "warn",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "fallbackLogger.warn",
+      "kind": "function",
+      "memberof": "fallbackLogger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          470,
+          553
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 18,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002117",
+          "name": "debug",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "fallbackLogger.debug",
+      "kind": "function",
+      "memberof": "fallbackLogger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          559,
+          1176
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 21,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002137",
+          "name": "exports.parseTokenMap",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "tokenMapString"
+          ]
+        }
+      },
+      "undocumented": true,
+      "name": "parseTokenMap",
+      "longname": "parseTokenMap",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          566,
+          1176
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 21,
+        "columnno": 7,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002138",
+          "name": "parseTokenMap",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "tokenMapString"
+          ]
+        },
+        "vars": {
+          "tokenPairs": "parseTokenMap~tokenPairs",
+          "": null,
+          "tokensByService": "parseTokenMap~tokensByService",
+          "serviceByToken": "parseTokenMap~serviceByToken"
+        }
+      },
+      "undocumented": true,
+      "name": "parseTokenMap",
+      "longname": "parseTokenMap",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          622,
+          934
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 22,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002145",
+          "name": "tokenPairs",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "tokenPairs",
+      "longname": "parseTokenMap~tokenPairs",
+      "kind": "constant",
+      "memberof": "parseTokenMap",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          947,
+          995
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 32,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002194",
+          "name": "tokensByService",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "tokensByService",
+      "longname": "parseTokenMap~tokensByService",
+      "kind": "constant",
+      "memberof": "parseTokenMap",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1007,
+          1112
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 33,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002202",
+          "name": "serviceByToken",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "serviceByToken",
+      "longname": "parseTokenMap~serviceByToken",
+      "kind": "constant",
+      "memberof": "parseTokenMap",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1128,
+          1138
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 37,
+        "columnno": 13,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002219",
+          "name": "tokenPairs",
+          "type": "Identifier",
+          "value": "tokenPairs"
+        }
+      },
+      "undocumented": true,
+      "name": "tokenPairs",
+      "longname": "tokenPairs",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1140,
+          1155
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 37,
+        "columnno": 25,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002221",
+          "name": "tokensByService",
+          "type": "Identifier",
+          "value": "tokensByService"
+        }
+      },
+      "undocumented": true,
+      "name": "tokensByService",
+      "longname": "tokensByService",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1157,
+          1171
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 37,
+        "columnno": 42,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002223",
+          "name": "serviceByToken",
+          "type": "Identifier",
+          "value": "serviceByToken"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceByToken",
+      "longname": "serviceByToken",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1178,
+          1502
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 40,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002225",
+          "name": "exports.extractBearerToken",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "req"
+          ]
+        }
+      },
+      "undocumented": true,
+      "name": "extractBearerToken",
+      "longname": "extractBearerToken",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1185,
+          1502
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 40,
+        "columnno": 7,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002226",
+          "name": "extractBearerToken",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "req"
+          ]
+        },
+        "vars": {
+          "authHeader": "extractBearerToken~authHeader",
+          "undefined": null
+        }
+      },
+      "undocumented": true,
+      "name": "extractBearerToken",
+      "longname": "extractBearerToken",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1230,
+          1275
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 41,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002231",
+          "name": "authHeader",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "authHeader",
+      "longname": "extractBearerToken~authHeader",
+      "kind": "constant",
+      "memberof": "extractBearerToken",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1504,
+          2175
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 52,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002272",
+          "name": "exports.createRequireAuth",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            ""
+          ]
+        }
+      },
+      "undocumented": true,
+      "name": "createRequireAuth",
+      "longname": "createRequireAuth",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1511,
+          2175
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 52,
+        "columnno": 7,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002273",
+          "name": "createRequireAuth",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            ""
+          ]
+        },
+        "vars": {
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "createRequireAuth",
+      "longname": "createRequireAuth",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1540,
+          1559
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 52,
+        "columnno": 36,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002277",
+          "name": "serviceByToken",
+          "type": "AssignmentPattern",
+          "value": "serviceByToken"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceByToken",
+      "longname": "serviceByToken",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1561,
+          1589
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 52,
+        "columnno": 57,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002281",
+          "name": "debug",
+          "type": "AssignmentPattern",
+          "value": "debug"
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "debug",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1664,
+          1695
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 54,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002297",
+          "name": "token",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "token",
+      "longname": "<anonymous>~token",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1795,
+          1843
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 58,
+        "columnno": 24,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002316",
+          "name": "error",
+          "type": "Literal",
+          "value": "Missing or invalid Authorization header"
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1873,
+          1908
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 61,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002319",
+          "name": "serviceName",
+          "type": "MemberExpression",
+          "value": "serviceByToken[undefined]"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceName",
+      "longname": "<anonymous>~serviceName",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2061,
+          2096
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 64,
+        "columnno": 42,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002350",
+          "name": "error",
+          "type": "Literal",
+          "value": "Unauthorized service token"
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2120,
+          2149
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 67,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002353",
+          "name": "req.serviceName",
+          "type": "Identifier",
+          "value": "serviceName",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "serviceName",
+      "longname": "req.serviceName",
+      "kind": "member",
+      "memberof": "req",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2177,
+          4053
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 72,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002361",
+          "name": "exports.createVaultApp",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "options"
+          ]
+        }
+      },
+      "undocumented": true,
+      "name": "createVaultApp",
+      "longname": "createVaultApp",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2184,
+          4053
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 72,
+        "columnno": 7,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002362",
+          "name": "createVaultApp",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "options"
+          ]
+        },
+        "vars": {
+          "undefined": null,
+          "logger": "createVaultApp~logger",
+          "logger.log": "createVaultApp~logger.log",
+          "logger.warn": "createVaultApp~logger.warn",
+          "logger.debug": "createVaultApp~logger.debug",
+          "serviceList": "createVaultApp~serviceList",
+          "": null,
+          "app": "createVaultApp~app",
+          "requireAuth": "createVaultApp~requireAuth",
+          "port": "createVaultApp~port"
+        }
+      },
+      "undocumented": true,
+      "name": "createVaultApp",
+      "longname": "createVaultApp",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2244,
+          2261
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 74,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002371",
+          "name": "env",
+          "type": "AssignmentPattern",
+          "value": "env"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2271,
+          2283
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 75,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002377",
+          "name": "handlePacket",
+          "type": "Identifier",
+          "value": "handlePacket"
+        }
+      },
+      "undocumented": true,
+      "name": "handlePacket",
+      "longname": "handlePacket",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2293,
+          2317
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 76,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002379",
+          "name": "expressFactory",
+          "type": "AssignmentPattern",
+          "value": "expressFactory"
+        }
+      },
+      "undocumented": true,
+      "name": "expressFactory",
+      "longname": "expressFactory",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2327,
+          2352
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 77,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002383",
+          "name": "logger",
+          "type": "AssignmentPattern",
+          "value": "loggerOption"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2362,
+          2365
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 78,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002387",
+          "name": "log",
+          "type": "Identifier",
+          "value": "log"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "log",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2375,
+          2379
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 79,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002389",
+          "name": "warn",
+          "type": "Identifier",
+          "value": "warn"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "warn",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2389,
+          2394
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 80,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002391",
+          "name": "debug",
+          "type": "Identifier",
+          "value": "debug"
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "debug",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2424,
+          2492
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 83,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002395",
+          "name": "logger",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "createVaultApp~logger",
+      "kind": "constant",
+      "memberof": "createVaultApp",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2540,
+          2556
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 89,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002409",
+          "name": "logger.log",
+          "type": "Identifier",
+          "funcscope": "createVaultApp",
+          "value": "log",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "createVaultApp~logger.log",
+      "kind": "member",
+      "memberof": "createVaultApp~logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2611,
+          2629
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 93,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002421",
+          "name": "logger.warn",
+          "type": "Identifier",
+          "funcscope": "createVaultApp",
+          "value": "warn",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "createVaultApp~logger.warn",
+      "kind": "member",
+      "memberof": "createVaultApp~logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2685,
+          2705
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 97,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002433",
+          "name": "logger.debug",
+          "type": "Identifier",
+          "funcscope": "createVaultApp",
+          "value": "debug",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "createVaultApp~logger.debug",
+      "kind": "member",
+      "memberof": "createVaultApp~logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2726,
+          2736
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 100,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002441",
+          "name": "tokenPairs",
+          "type": "Identifier",
+          "value": "tokenPairs"
+        }
+      },
+      "undocumented": true,
+      "name": "tokenPairs",
+      "longname": "tokenPairs",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2738,
+          2753
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 100,
+        "columnno": 24,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002443",
+          "name": "tokensByService",
+          "type": "Identifier",
+          "value": "tokensByService"
+        }
+      },
+      "undocumented": true,
+      "name": "tokensByService",
+      "longname": "tokensByService",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2755,
+          2769
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 100,
+        "columnno": 41,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002445",
+          "name": "serviceByToken",
+          "type": "Identifier",
+          "value": "serviceByToken"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceByToken",
+      "longname": "serviceByToken",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2997,
+          3060
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 107,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002468",
+          "name": "serviceList",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "serviceList",
+      "longname": "createVaultApp~serviceList",
+      "kind": "constant",
+      "memberof": "createVaultApp",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3148,
+          3170
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 111,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002491",
+          "name": "app",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "app",
+      "longname": "createVaultApp~app",
+      "kind": "constant",
+      "memberof": "createVaultApp",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3212,
+          3284
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 114,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002505",
+          "name": "requireAuth",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "requireAuth",
+      "longname": "createVaultApp~requireAuth",
+      "kind": "constant",
+      "memberof": "createVaultApp",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3246,
+          3260
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 114,
+        "columnno": 44,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002510",
+          "name": "serviceByToken",
+          "type": "Identifier",
+          "value": "serviceByToken"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceByToken",
+      "longname": "serviceByToken",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3262,
+          3281
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 114,
+        "columnno": 60,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002512",
+          "name": "debug",
+          "type": "MemberExpression",
+          "value": "logger.debug"
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "debug",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3471,
+          3488
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 121,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002544",
+          "name": "packet",
+          "type": "MemberExpression",
+          "value": "req.body"
+        }
+      },
+      "undocumented": true,
+      "name": "packet",
+      "longname": "<anonymous>~packet",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3576,
+          3598
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 124,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002561",
+          "name": "handler",
+          "type": "Identifier",
+          "value": "handlePacket"
+        }
+      },
+      "undocumented": true,
+      "name": "handler",
+      "longname": "<anonymous>~handler",
+      "kind": "member",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3637,
+          3677
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 127,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002569",
+          "name": "handler",
+          "type": "AwaitExpression",
+          "funcscope": "<anonymous>",
+          "value": "",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "handler",
+      "longname": "<anonymous>~handler",
+      "kind": "member",
+      "memberof": "<anonymous>",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3704,
+          3734
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 130,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002575",
+          "name": "result",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "result",
+      "longname": "<anonymous>~result",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3807,
+          3826
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 132,
+        "columnno": 42,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002594",
+          "name": "error",
+          "type": "MemberExpression",
+          "value": "result.error"
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3893,
+          3916
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 138,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002607",
+          "name": "port",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "createVaultApp~port",
+      "kind": "constant",
+      "memberof": "createVaultApp",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3940,
+          3943
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 141,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002616",
+          "name": "app",
+          "type": "Identifier",
+          "value": "app"
+        }
+      },
+      "undocumented": true,
+      "name": "app",
+      "longname": "app",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3953,
+          3957
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 142,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002618",
+          "name": "port",
+          "type": "Identifier",
+          "value": "port"
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3967,
+          3978
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 143,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002620",
+          "name": "requireAuth",
+          "type": "Identifier",
+          "value": "requireAuth"
+        }
+      },
+      "undocumented": true,
+      "name": "requireAuth",
+      "longname": "requireAuth",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3988,
+          4003
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 144,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002622",
+          "name": "tokensByService",
+          "type": "Identifier",
+          "value": "tokensByService"
+        }
+      },
+      "undocumented": true,
+      "name": "tokensByService",
+      "longname": "tokensByService",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4013,
+          4027
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 145,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002624",
+          "name": "serviceByToken",
+          "type": "Identifier",
+          "value": "serviceByToken"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceByToken",
+      "longname": "serviceByToken",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4037,
+          4043
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 146,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002626",
+          "name": "logger",
+          "type": "Identifier",
+          "value": "logger"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4055,
+          4085
+        ],
+        "filename": "vaultApp.mjs",
+        "lineno": 150,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/vault/shared",
+        "code": {
+          "id": "astnode100002628",
+          "name": "module.exports",
+          "type": "Identifier"
+        }
+      },
+      "undocumented": true,
+      "name": "exports",
+      "longname": "module.exports",
+      "kind": "member",
+      "memberof": "module",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          279,
+          565
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 13,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002654",
+          "name": "createMockResponse",
+          "type": "FunctionDeclaration",
+          "paramnames": []
+        },
+        "vars": {
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "createMockResponse",
+      "longname": "createMockResponse",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          332,
+          347
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 15,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002659",
+          "name": "statusCode",
+          "type": "Literal",
+          "value": 200
+        }
+      },
+      "undocumented": true,
+      "name": "statusCode",
+      "longname": "statusCode",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          357,
+          367
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 16,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002661",
+          "name": "body",
+          "type": "Literal",
+          "value": null
+        }
+      },
+      "undocumented": true,
+      "name": "body",
+      "longname": "body",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          377,
+          462
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 17,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002663",
+          "name": "status",
+          "type": "FunctionExpression"
+        },
+        "vars": {
+          "this.statusCode": null
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          404,
+          426
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 18,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002668",
+          "name": "this.statusCode",
+          "type": "Identifier",
+          "value": "code",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "statusCode",
+      "longname": "statusCode",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          472,
+          555
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 21,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002675",
+          "name": "json",
+          "type": "FunctionExpression"
+        },
+        "vars": {
+          "this.body": null
+        }
+      },
+      "undocumented": true,
+      "name": "json",
+      "longname": "json",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          500,
+          519
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 22,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002680",
+          "name": "this.body",
+          "type": "Identifier",
+          "value": "payload",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "body",
+      "longname": "body",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          651,
+          661
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 29,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002696",
+          "name": "tokenPairs",
+          "type": "Identifier",
+          "value": "tokenPairs"
+        }
+      },
+      "undocumented": true,
+      "name": "tokenPairs",
+      "longname": "tokenPairs",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          663,
+          678
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 29,
+        "columnno": 24,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002698",
+          "name": "tokensByService",
+          "type": "Identifier",
+          "value": "tokensByService"
+        }
+      },
+      "undocumented": true,
+      "name": "tokensByService",
+      "longname": "tokensByService",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          680,
+          694
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 29,
+        "columnno": 41,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002700",
+          "name": "serviceByToken",
+          "type": "Identifier",
+          "value": "serviceByToken"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceByToken",
+      "longname": "serviceByToken",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          915,
+          929
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 38,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002725",
+          "name": "moon",
+          "type": "Literal",
+          "value": "token1"
+        }
+      },
+      "undocumented": true,
+      "name": "moon",
+      "longname": "moon",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          939,
+          954
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 39,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002727",
+          "name": "raven",
+          "type": "Literal",
+          "value": "token2"
+        }
+      },
+      "undocumented": true,
+      "name": "raven",
+      "longname": "raven",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1011,
+          1025
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 42,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002736",
+          "name": "token1",
+          "type": "Literal",
+          "value": "moon"
+        }
+      },
+      "undocumented": true,
+      "name": "token1",
+      "longname": "token1",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1035,
+          1050
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 43,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002738",
+          "name": "token2",
+          "type": "Literal",
+          "value": "raven"
+        }
+      },
+      "undocumented": true,
+      "name": "token2",
+      "longname": "token2",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1163,
+          1222
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 48,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002747",
+          "name": "req",
+          "type": "ObjectExpression",
+          "value": "{\"headers\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "req",
+      "longname": "<anonymous>~req",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1171,
+          1220
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 48,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002750",
+          "name": "headers",
+          "type": "ObjectExpression",
+          "value": "{\"authorization\":\"Bearer secret-token\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "headers",
+      "longname": "<anonymous>~req.headers",
+      "kind": "member",
+      "memberof": "<anonymous>~req",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1182,
+          1218
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 48,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002752",
+          "name": "authorization",
+          "type": "Literal",
+          "value": "Bearer secret-token"
+        }
+      },
+      "undocumented": true,
+      "name": "authorization",
+      "longname": "<anonymous>~req.headers.authorization",
+      "kind": "member",
+      "memberof": "<anonymous>~req.headers",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1407,
+          1418
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 53,
+        "columnno": 38,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002777",
+          "name": "headers",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "headers",
+      "longname": "headers",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1468,
+          1507
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 54,
+        "columnno": 38,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002788",
+          "name": "headers",
+          "type": "ObjectExpression",
+          "value": "{\"authorization\":\"Basic abc\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "headers",
+      "longname": "headers",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1479,
+          1505
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 54,
+        "columnno": 49,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002790",
+          "name": "authorization",
+          "type": "Literal",
+          "value": "Basic abc"
+        }
+      },
+      "undocumented": true,
+      "name": "authorization",
+      "longname": "headers.authorization",
+      "kind": "member",
+      "memberof": "headers",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1557,
+          1587
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 55,
+        "columnno": 38,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002801",
+          "name": "headers",
+          "type": "ObjectExpression",
+          "value": "{\"authorization\":42}"
+        }
+      },
+      "undocumented": true,
+      "name": "headers",
+      "longname": "headers",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1568,
+          1585
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 55,
+        "columnno": 49,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002803",
+          "name": "authorization",
+          "type": "Literal",
+          "value": 42
+        }
+      },
+      "undocumented": true,
+      "name": "authorization",
+      "longname": "headers.authorization",
+      "kind": "member",
+      "memberof": "headers",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1685,
+          1756
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 59,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002813",
+          "name": "middleware",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "middleware",
+      "longname": "<anonymous>~middleware",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1718,
+          1736
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 59,
+        "columnno": 43,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002818",
+          "name": "serviceByToken",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceByToken",
+      "longname": "serviceByToken",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1738,
+          1753
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 59,
+        "columnno": 63,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002820",
+          "name": "debug",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "debug",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1768,
+          1789
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 60,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002824",
+          "name": "req",
+          "type": "ObjectExpression",
+          "value": "{\"headers\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "req",
+      "longname": "<anonymous>~req",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1776,
+          1787
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 60,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002827",
+          "name": "headers",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "headers",
+      "longname": "<anonymous>~req.headers",
+      "kind": "member",
+      "memberof": "<anonymous>~req",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1801,
+          1827
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 61,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002830",
+          "name": "res",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "res",
+      "longname": "<anonymous>~res",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1837,
+          1855
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 62,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002835",
+          "name": "nextCalled",
+          "type": "Literal",
+          "value": false
+        }
+      },
+      "undocumented": true,
+      "name": "nextCalled",
+      "longname": "<anonymous>~nextCalled",
+      "kind": "member",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1899,
+          1916
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 65,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002846",
+          "name": "nextCalled",
+          "type": "Literal",
+          "funcscope": "<anonymous>",
+          "value": true,
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "nextCalled",
+      "longname": "<anonymous>~nextCalled",
+      "kind": "member",
+      "memberof": "<anonymous>",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2044,
+          2092
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 71,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002874",
+          "name": "error",
+          "type": "Literal",
+          "value": "Missing or invalid Authorization header"
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2189,
+          2207
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 76,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002883",
+          "name": "debugMessages",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "debugMessages",
+      "longname": "<anonymous>~debugMessages",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2219,
+          2365
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 77,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002887",
+          "name": "middleware",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "middleware",
+      "longname": "<anonymous>~middleware",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2260,
+          2302
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 78,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002892",
+          "name": "serviceByToken",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"moon\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceByToken",
+      "longname": "serviceByToken",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2278,
+          2300
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 78,
+        "columnno": 26,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002894",
+          "name": "\"secret-token\"",
+          "type": "Literal",
+          "value": "moon"
+        }
+      },
+      "undocumented": true,
+      "name": "\"secret-token\"",
+      "longname": "serviceByToken.\"secret-token\"",
+      "kind": "member",
+      "memberof": "serviceByToken",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2312,
+          2357
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 79,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002896",
+          "name": "debug",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "debug",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2377,
+          2436
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 81,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002905",
+          "name": "req",
+          "type": "ObjectExpression",
+          "value": "{\"headers\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "req",
+      "longname": "<anonymous>~req",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2385,
+          2434
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 81,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002908",
+          "name": "headers",
+          "type": "ObjectExpression",
+          "value": "{\"authorization\":\"Bearer secret-token\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "headers",
+      "longname": "<anonymous>~req.headers",
+      "kind": "member",
+      "memberof": "<anonymous>~req",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2396,
+          2432
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 81,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002910",
+          "name": "authorization",
+          "type": "Literal",
+          "value": "Bearer secret-token"
+        }
+      },
+      "undocumented": true,
+      "name": "authorization",
+      "longname": "<anonymous>~req.headers.authorization",
+      "kind": "member",
+      "memberof": "<anonymous>~req.headers",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2448,
+          2474
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 82,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002913",
+          "name": "res",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "res",
+      "longname": "<anonymous>~res",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2484,
+          2502
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 83,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002918",
+          "name": "nextCalled",
+          "type": "Literal",
+          "value": false
+        }
+      },
+      "undocumented": true,
+      "name": "nextCalled",
+      "longname": "<anonymous>~nextCalled",
+      "kind": "member",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2546,
+          2563
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 86,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002929",
+          "name": "nextCalled",
+          "type": "Literal",
+          "funcscope": "<anonymous>",
+          "value": true,
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "nextCalled",
+      "longname": "<anonymous>~nextCalled",
+      "kind": "member",
+      "memberof": "<anonymous>",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2825,
+          2838
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 96,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002973",
+          "name": "messages",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "messages",
+      "longname": "<anonymous>~messages",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2850,
+          2982
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 97,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002977",
+          "name": "middleware",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "middleware",
+      "longname": "<anonymous>~middleware",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2891,
+          2924
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 98,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002982",
+          "name": "serviceByToken",
+          "type": "ObjectExpression",
+          "value": "{\"known\":\"moon\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceByToken",
+      "longname": "serviceByToken",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2909,
+          2922
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 98,
+        "columnno": 26,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002984",
+          "name": "known",
+          "type": "Literal",
+          "value": "moon"
+        }
+      },
+      "undocumented": true,
+      "name": "known",
+      "longname": "serviceByToken.known",
+      "kind": "member",
+      "memberof": "serviceByToken",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2934,
+          2974
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 99,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002986",
+          "name": "debug",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "debug",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2994,
+          3048
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 101,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002995",
+          "name": "req",
+          "type": "ObjectExpression",
+          "value": "{\"headers\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "req",
+      "longname": "<anonymous>~req",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3002,
+          3046
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 101,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100002998",
+          "name": "headers",
+          "type": "ObjectExpression",
+          "value": "{\"authorization\":\"Bearer unknown\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "headers",
+      "longname": "<anonymous>~req.headers",
+      "kind": "member",
+      "memberof": "<anonymous>~req",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3013,
+          3044
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 101,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003000",
+          "name": "authorization",
+          "type": "Literal",
+          "value": "Bearer unknown"
+        }
+      },
+      "undocumented": true,
+      "name": "authorization",
+      "longname": "<anonymous>~req.headers.authorization",
+      "kind": "member",
+      "memberof": "<anonymous>~req.headers",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3060,
+          3086
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 102,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003003",
+          "name": "res",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "res",
+      "longname": "<anonymous>~res",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3339,
+          3352
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 112,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003051",
+          "name": "warnings",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "warnings",
+      "longname": "<anonymous>~warnings",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3383,
+          3390
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 114,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003058",
+          "name": "env",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3400,
+          3439
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 115,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003060",
+          "name": "warn",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "warn",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3449,
+          3462
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 116,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003068",
+          "name": "log",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "log",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3472,
+          3487
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 117,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003071",
+          "name": "debug",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "debug",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3497,
+          3527
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 118,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003074",
+          "name": "handlePacket",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "handlePacket",
+      "longname": "handlePacket",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3719,
+          3728
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 126,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003105",
+          "name": "logs",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "logs",
+      "longname": "<anonymous>~logs",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3759,
+          3805
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 128,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003112",
+          "name": "env",
+          "type": "ObjectExpression",
+          "value": "{\"VAULT_TOKEN_MAP\":\"moon:abc,raven:def\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3766,
+          3803
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 128,
+        "columnno": 15,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003114",
+          "name": "VAULT_TOKEN_MAP",
+          "type": "Literal",
+          "value": "moon:abc,raven:def"
+        }
+      },
+      "undocumented": true,
+      "name": "VAULT_TOKEN_MAP",
+      "longname": "env.VAULT_TOKEN_MAP",
+      "kind": "member",
+      "memberof": "env",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3815,
+          3829
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 129,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003116",
+          "name": "warn",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "warn",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3839,
+          3873
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 130,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003119",
+          "name": "log",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "log",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3883,
+          3898
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 131,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003127",
+          "name": "debug",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "debug",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3908,
+          3938
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 132,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003130",
+          "name": "handlePacket",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "handlePacket",
+      "longname": "handlePacket",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4120,
+          4132
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 139,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003156",
+          "name": "packets",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "packets",
+      "longname": "<anonymous>~packets",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4146,
+          4149
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 140,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003162",
+          "name": "app",
+          "type": "Identifier",
+          "value": "app"
+        }
+      },
+      "undocumented": true,
+      "name": "app",
+      "longname": "app",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4179,
+          4218
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 141,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003167",
+          "name": "env",
+          "type": "ObjectExpression",
+          "value": "{\"VAULT_TOKEN_MAP\":\"moon:secret\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4186,
+          4216
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 141,
+        "columnno": 15,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003169",
+          "name": "VAULT_TOKEN_MAP",
+          "type": "Literal",
+          "value": "moon:secret"
+        }
+      },
+      "undocumented": true,
+      "name": "VAULT_TOKEN_MAP",
+      "longname": "env.VAULT_TOKEN_MAP",
+      "kind": "member",
+      "memberof": "env",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4228,
+          4242
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 142,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003171",
+          "name": "warn",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "warn",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4252,
+          4265
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 143,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003174",
+          "name": "log",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "log",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4275,
+          4290
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 144,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003177",
+          "name": "debug",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "debug",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4300,
+          4408
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 145,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003180",
+          "name": "handlePacket",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "handlePacket",
+      "longname": "handlePacket",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4387,
+          4395
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 147,
+        "columnno": 21,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003192",
+          "name": "ok",
+          "type": "Literal",
+          "value": true
+        }
+      },
+      "undocumented": true,
+      "name": "ok",
+      "longname": "ok",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4429,
+          4451
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 151,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003195",
+          "name": "server",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "<anonymous>~server",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4502,
+          4506
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 153,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003211",
+          "name": "port",
+          "type": "Identifier",
+          "value": "port"
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4540,
+          4811
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 155,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003218",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "<anonymous>~response",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4617,
+          4631
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 156,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003228",
+          "name": "method",
+          "type": "Literal",
+          "value": "POST"
+        }
+      },
+      "undocumented": true,
+      "name": "method",
+      "longname": "method",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4641,
+          4753
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 157,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003230",
+          "name": "headers",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"application/json\",\"authorization\":\"Bearer secret\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "headers",
+      "longname": "headers",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4664,
+          4698
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 158,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003232",
+          "name": "\"content-type\"",
+          "type": "Literal",
+          "value": "application/json"
+        }
+      },
+      "undocumented": true,
+      "name": "\"content-type\"",
+      "longname": "headers.\"content-type\"",
+      "kind": "member",
+      "memberof": "headers",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4712,
+          4742
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 159,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003234",
+          "name": "authorization",
+          "type": "Literal",
+          "value": "Bearer secret"
+        }
+      },
+      "undocumented": true,
+      "name": "authorization",
+      "longname": "headers.authorization",
+      "kind": "member",
+      "memberof": "headers",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4763,
+          4803
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 161,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003236",
+          "name": "body",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "body",
+      "longname": "body",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4786,
+          4800
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 161,
+        "columnno": 31,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003242",
+          "name": "action",
+          "type": "Literal",
+          "value": "ping"
+        }
+      },
+      "undocumented": true,
+      "name": "action",
+      "longname": "action",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4864,
+          4892
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 165,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003254",
+          "name": "body",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "body",
+      "longname": "<anonymous>~body",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4923,
+          4931
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 166,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003268",
+          "name": "ok",
+          "type": "Literal",
+          "value": true
+        }
+      },
+      "undocumented": true,
+      "name": "ok",
+      "longname": "ok",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4969,
+          4983
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 167,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003278",
+          "name": "action",
+          "type": "Literal",
+          "value": "ping"
+        }
+      },
+      "undocumented": true,
+      "name": "action",
+      "longname": "action",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5201,
+          5204
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 175,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003309",
+          "name": "app",
+          "type": "Identifier",
+          "value": "app"
+        }
+      },
+      "undocumented": true,
+      "name": "app",
+      "longname": "app",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5234,
+          5273
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 176,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003314",
+          "name": "env",
+          "type": "ObjectExpression",
+          "value": "{\"VAULT_TOKEN_MAP\":\"moon:secret\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5241,
+          5271
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 176,
+        "columnno": 15,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003316",
+          "name": "VAULT_TOKEN_MAP",
+          "type": "Literal",
+          "value": "moon:secret"
+        }
+      },
+      "undocumented": true,
+      "name": "VAULT_TOKEN_MAP",
+      "longname": "env.VAULT_TOKEN_MAP",
+      "kind": "member",
+      "memberof": "env",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5283,
+          5297
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 177,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003318",
+          "name": "warn",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "warn",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5307,
+          5320
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 178,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003321",
+          "name": "log",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "log",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5330,
+          5345
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 179,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003324",
+          "name": "debug",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "debug",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5355,
+          5406
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 180,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003327",
+          "name": "handlePacket",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "handlePacket",
+      "longname": "handlePacket",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5384,
+          5403
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 180,
+        "columnno": 37,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003330",
+          "name": "error",
+          "type": "Literal",
+          "value": "bad packet"
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5427,
+          5449
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 183,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003333",
+          "name": "server",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "<anonymous>~server",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5500,
+          5504
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 185,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003349",
+          "name": "port",
+          "type": "Identifier",
+          "value": "port"
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5538,
+          5809
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 187,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003356",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "<anonymous>~response",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5615,
+          5629
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 188,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003366",
+          "name": "method",
+          "type": "Literal",
+          "value": "POST"
+        }
+      },
+      "undocumented": true,
+      "name": "method",
+      "longname": "method",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5639,
+          5751
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 189,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003368",
+          "name": "headers",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"application/json\",\"authorization\":\"Bearer secret\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "headers",
+      "longname": "headers",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5662,
+          5696
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 190,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003370",
+          "name": "\"content-type\"",
+          "type": "Literal",
+          "value": "application/json"
+        }
+      },
+      "undocumented": true,
+      "name": "\"content-type\"",
+      "longname": "headers.\"content-type\"",
+      "kind": "member",
+      "memberof": "headers",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5710,
+          5740
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 191,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003372",
+          "name": "authorization",
+          "type": "Literal",
+          "value": "Bearer secret"
+        }
+      },
+      "undocumented": true,
+      "name": "authorization",
+      "longname": "headers.authorization",
+      "kind": "member",
+      "memberof": "headers",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5761,
+          5801
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 193,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003374",
+          "name": "body",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "body",
+      "longname": "body",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5784,
+          5798
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 193,
+        "columnno": 31,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003380",
+          "name": "action",
+          "type": "Literal",
+          "value": "ping"
+        }
+      },
+      "undocumented": true,
+      "name": "action",
+      "longname": "action",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5862,
+          5890
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 197,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003392",
+          "name": "body",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "body",
+      "longname": "<anonymous>~body",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5921,
+          5940
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 198,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003406",
+          "name": "error",
+          "type": "Literal",
+          "value": "bad packet"
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6155,
+          6158
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 206,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003437",
+          "name": "app",
+          "type": "Identifier",
+          "value": "app"
+        }
+      },
+      "undocumented": true,
+      "name": "app",
+      "longname": "app",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6188,
+          6227
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 207,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003442",
+          "name": "env",
+          "type": "ObjectExpression",
+          "value": "{\"VAULT_TOKEN_MAP\":\"moon:secret\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6195,
+          6225
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 207,
+        "columnno": 15,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003444",
+          "name": "VAULT_TOKEN_MAP",
+          "type": "Literal",
+          "value": "moon:secret"
+        }
+      },
+      "undocumented": true,
+      "name": "VAULT_TOKEN_MAP",
+      "longname": "env.VAULT_TOKEN_MAP",
+      "kind": "member",
+      "memberof": "env",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6237,
+          6251
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 208,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003446",
+          "name": "warn",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "warn",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6261,
+          6274
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 209,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003449",
+          "name": "log",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "log",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6284,
+          6299
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 210,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003452",
+          "name": "debug",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "debug",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6309,
+          6349
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 211,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003455",
+          "name": "handlePacket",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "handlePacket",
+      "longname": "handlePacket",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6338,
+          6346
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 211,
+        "columnno": 37,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003458",
+          "name": "ok",
+          "type": "Literal",
+          "value": true
+        }
+      },
+      "undocumented": true,
+      "name": "ok",
+      "longname": "ok",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6370,
+          6392
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 214,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003461",
+          "name": "server",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "<anonymous>~server",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6443,
+          6447
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 216,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003477",
+          "name": "port",
+          "type": "Identifier",
+          "value": "port"
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6481,
+          6708
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 218,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003484",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "<anonymous>~response",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6558,
+          6572
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 219,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003494",
+          "name": "method",
+          "type": "Literal",
+          "value": "POST"
+        }
+      },
+      "undocumented": true,
+      "name": "method",
+      "longname": "method",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6582,
+          6650
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 220,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003496",
+          "name": "headers",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"application/json\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "headers",
+      "longname": "headers",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6605,
+          6639
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 221,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003498",
+          "name": "\"content-type\"",
+          "type": "Literal",
+          "value": "application/json"
+        }
+      },
+      "undocumented": true,
+      "name": "\"content-type\"",
+      "longname": "headers.\"content-type\"",
+      "kind": "member",
+      "memberof": "headers",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6660,
+          6700
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 223,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003500",
+          "name": "body",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "body",
+      "longname": "body",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6683,
+          6697
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 223,
+        "columnno": 31,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003506",
+          "name": "action",
+          "type": "Literal",
+          "value": "ping"
+        }
+      },
+      "undocumented": true,
+      "name": "action",
+      "longname": "action",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6761,
+          6789
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 227,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003518",
+          "name": "body",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "body",
+      "longname": "<anonymous>~body",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6820,
+          6868
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 228,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003532",
+          "name": "error",
+          "type": "Literal",
+          "value": "Missing or invalid Authorization header"
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7074,
+          7077
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 236,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003563",
+          "name": "app",
+          "type": "Identifier",
+          "value": "app"
+        }
+      },
+      "undocumented": true,
+      "name": "app",
+      "longname": "app",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7107,
+          7114
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 237,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003568",
+          "name": "env",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7124,
+          7138
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 238,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003570",
+          "name": "warn",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "warn",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7148,
+          7161
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 239,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003573",
+          "name": "log",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "log",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7171,
+          7186
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 240,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003576",
+          "name": "debug",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "debug",
+      "longname": "debug",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7196,
+          7226
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 241,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003579",
+          "name": "handlePacket",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "handlePacket",
+      "longname": "handlePacket",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7247,
+          7269
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 244,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003583",
+          "name": "server",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "<anonymous>~server",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7320,
+          7324
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 246,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003599",
+          "name": "port",
+          "type": "Identifier",
+          "value": "port"
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7358,
+          7424
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 248,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003606",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "<anonymous>~response",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7476,
+          7504
+        ],
+        "filename": "vaultApp.test.mjs",
+        "lineno": 250,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/vault/tests",
+        "code": {
+          "id": "astnode100003625",
+          "name": "text",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "text",
+      "longname": "<anonymous>~text",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          51,
+          120
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 3,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003662",
+          "name": "HOST_SERVICE_URL",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "HOST_SERVICE_URL",
+      "longname": "HOST_SERVICE_URL",
+      "kind": "constant",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          129,
+          1253
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 5,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003672",
+          "name": "rawList",
+          "type": "ArrayExpression",
+          "value": "[\"{\\\"name\\\":\\\"noona-redis\\\",\\\"image\\\":\\\"redis/redis-stack:latest\\\",\\\"port\\\":8001,\\\"internalPort\\\":8001,\\\"ports\\\":\\\"\\\",\\\"exposed\\\":\\\"\\\",\\\"env\\\":\\\"\\\",\\\"volumes\\\":\\\"\\\",\\\"health\\\":\\\"http://noona-redis:8001/\\\",\\\"hostServiceUrl\\\":\\\"\\\"}\",\"{\\\"name\\\":\\\"noona-mongo\\\",\\\"image\\\":\\\"mongo:7\\\",\\\"port\\\":27017,\\\"internalPort\\\":27017,\\\"ports\\\":\\\"\\\",\\\"exposed\\\":\\\"\\\",\\\"env\\\":\\\"\\\",\\\"volumes\\\":\\\"\\\",\\\"health\\\":null,\\\"hostServiceUrl\\\":\\\"\\\"}\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "rawList",
+      "longname": "rawList",
+      "kind": "constant",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          155,
+          174
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 7,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003676",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-redis"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          184,
+          217
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 8,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003678",
+          "name": "image",
+          "type": "Literal",
+          "value": "redis/redis-stack:latest"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          227,
+          237
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 9,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003680",
+          "name": "port",
+          "type": "Literal",
+          "value": 8001
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          247,
+          265
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 10,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003682",
+          "name": "internalPort",
+          "type": "Literal",
+          "value": 8001
+        }
+      },
+      "undocumented": true,
+      "name": "internalPort",
+      "longname": "internalPort",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          275,
+          389
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 11,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003684",
+          "name": "ports",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "ports",
+      "longname": "ports",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          296,
+          330
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 12,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003686",
+          "name": "\"6379/tcp\"",
+          "type": "ArrayExpression",
+          "value": "[\"{\\\"HostPort\\\":\\\"6379\\\"}\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "\"6379/tcp\"",
+      "longname": "ports.\"6379/tcp\"",
+      "kind": "member",
+      "memberof": "ports",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          311,
+          327
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 12,
+        "columnno": 27,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003689",
+          "name": "HostPort",
+          "type": "Literal",
+          "value": "6379"
+        }
+      },
+      "undocumented": true,
+      "name": "HostPort",
+      "longname": "HostPort",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          344,
+          378
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 13,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003691",
+          "name": "\"8001/tcp\"",
+          "type": "ArrayExpression",
+          "value": "[\"{\\\"HostPort\\\":\\\"8001\\\"}\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "\"8001/tcp\"",
+      "longname": "ports.\"8001/tcp\"",
+      "kind": "member",
+      "memberof": "ports",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          359,
+          375
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 13,
+        "columnno": 27,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003694",
+          "name": "HostPort",
+          "type": "Literal",
+          "value": "8001"
+        }
+      },
+      "undocumented": true,
+      "name": "HostPort",
+      "longname": "HostPort",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          399,
+          475
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 15,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003696",
+          "name": "exposed",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "exposed",
+      "longname": "exposed",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          422,
+          436
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 16,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003698",
+          "name": "\"6379/tcp\"",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"6379/tcp\"",
+      "longname": "exposed.\"6379/tcp\"",
+      "kind": "member",
+      "memberof": "exposed",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          450,
+          464
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 17,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003700",
+          "name": "\"8001/tcp\"",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"8001/tcp\"",
+      "longname": "exposed.\"8001/tcp\"",
+      "kind": "member",
+      "memberof": "exposed",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          485,
+          518
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 19,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003702",
+          "name": "env",
+          "type": "ArrayExpression",
+          "value": "[\"SERVICE_NAME=noona-redis\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          528,
+          564
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 20,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003705",
+          "name": "volumes",
+          "type": "ArrayExpression",
+          "value": "[\"/noona-redis-data:/data\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "volumes",
+      "longname": "volumes",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          574,
+          608
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 21,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003708",
+          "name": "health",
+          "type": "Literal",
+          "value": "http://noona-redis:8001/"
+        }
+      },
+      "undocumented": true,
+      "name": "health",
+      "longname": "health",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          618,
+          660
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 22,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003710",
+          "name": "hostServiceUrl",
+          "type": "TemplateLiteral",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "hostServiceUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          683,
+          702
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 25,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003716",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-mongo"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          712,
+          728
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 26,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003718",
+          "name": "image",
+          "type": "Literal",
+          "value": "mongo:7"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          738,
+          749
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 27,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003720",
+          "name": "port",
+          "type": "Literal",
+          "value": 27017
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          759,
+          778
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 28,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003722",
+          "name": "internalPort",
+          "type": "Literal",
+          "value": 27017
+        }
+      },
+      "undocumented": true,
+      "name": "internalPort",
+      "longname": "internalPort",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          788,
+          856
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 29,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003724",
+          "name": "ports",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "ports",
+      "longname": "ports",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          809,
+          845
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 30,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003726",
+          "name": "\"27017/tcp\"",
+          "type": "ArrayExpression",
+          "value": "[\"{\\\"HostPort\\\":\\\"27017\\\"}\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "\"27017/tcp\"",
+      "longname": "ports.\"27017/tcp\"",
+      "kind": "member",
+      "memberof": "ports",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          825,
+          842
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 30,
+        "columnno": 28,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003729",
+          "name": "HostPort",
+          "type": "Literal",
+          "value": "27017"
+        }
+      },
+      "undocumented": true,
+      "name": "HostPort",
+      "longname": "HostPort",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          866,
+          915
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 32,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003731",
+          "name": "exposed",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "exposed",
+      "longname": "exposed",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          889,
+          904
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 33,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003733",
+          "name": "\"27017/tcp\"",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"27017/tcp\"",
+      "longname": "exposed.\"27017/tcp\"",
+      "kind": "member",
+      "memberof": "exposed",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          925,
+          1078
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 35,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003735",
+          "name": "env",
+          "type": "ArrayExpression",
+          "value": "[\"MONGO_INITDB_ROOT_USERNAME=root\",\"MONGO_INITDB_ROOT_PASSWORD=example\",\"SERVICE_NAME=noona-mongo\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1088,
+          1127
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 40,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003740",
+          "name": "volumes",
+          "type": "ArrayExpression",
+          "value": "[\"/noona-mongo-data:/data/db\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "volumes",
+      "longname": "volumes",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1137,
+          1149
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 41,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003743",
+          "name": "health",
+          "type": "Literal",
+          "value": null
+        }
+      },
+      "undocumented": true,
+      "name": "health",
+      "longname": "health",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1200,
+          1243
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 42,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003745",
+          "name": "hostServiceUrl",
+          "type": "TemplateLiteral",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "hostServiceUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1262,
+          1807
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 46,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003749",
+          "name": "addonDockers",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "addonDockers",
+      "longname": "addonDockers",
+      "kind": "constant",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1340,
+          1387
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 48,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003763",
+          "name": "internal",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "internal",
+      "longname": "<anonymous>~internal",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1403,
+          1477
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 49,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003773",
+          "name": "exposed",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "exposed",
+      "longname": "<anonymous>~exposed",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1493,
+          1637
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 50,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003786",
+          "name": "ports",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "ports",
+      "longname": "<anonymous>~ports",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1584,
+          1614
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 51,
+        "columnno": 40,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003802",
+          "name": "HostPort",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "HostPort",
+      "longname": "HostPort",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1741,
+          1748
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 58,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003817",
+          "name": "exposed",
+          "type": "Identifier",
+          "value": "exposed"
+        }
+      },
+      "undocumented": true,
+      "name": "exposed",
+      "longname": "exposed",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1766,
+          1771
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 59,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003819",
+          "name": "ports",
+          "type": "Identifier",
+          "value": "ports"
+        }
+      },
+      "undocumented": true,
+      "name": "ports",
+      "longname": "ports",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1810,
+          1838
+        ],
+        "filename": "addonDockers.mjs",
+        "lineno": 65,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003821",
+          "name": "module.exports",
+          "type": "Identifier"
+        }
+      },
+      "undocumented": true,
+      "name": "exports",
+      "longname": "module.exports",
+      "kind": "member",
+      "memberof": "module",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          189,
+          210
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 6,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003842",
+          "name": "docker",
+          "type": "NewExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "docker",
+      "longname": "docker",
+      "kind": "constant",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "/**\n * Ensures the Docker network exists (idempotent)\n */",
+      "meta": {
+        "range": [
+          271,
+          581
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 11,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003846",
+          "name": "exports.ensureNetwork",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "dockerInstance",
+            "networkName"
+          ]
+        }
+      },
+      "description": "Ensures the Docker network exists (idempotent)",
+      "name": "ensureNetwork",
+      "longname": "ensureNetwork",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          278,
+          581
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 11,
+        "columnno": 7,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003847",
+          "name": "ensureNetwork",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "dockerInstance",
+            "networkName"
+          ]
+        },
+        "vars": {
+          "networks": "ensureNetwork~networks",
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "ensureNetwork",
+      "longname": "ensureNetwork",
+      "kind": "function",
+      "scope": "global",
+      "params": [],
+      "async": true
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          348,
+          394
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 12,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003853",
+          "name": "networks",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "networks",
+      "longname": "ensureNetwork~networks",
+      "kind": "constant",
+      "memberof": "ensureNetwork",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          552,
+          569
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 15,
+        "columnno": 45,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003888",
+          "name": "Name",
+          "type": "Identifier",
+          "value": "networkName"
+        }
+      },
+      "undocumented": true,
+      "name": "Name",
+      "longname": "Name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "/**\n * Attaches the Warden container to the Docker network if not already connected\n */",
+      "meta": {
+        "range": [
+          671,
+          1097
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 22,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003890",
+          "name": "exports.attachSelfToNetwork",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "dockerInstance",
+            "networkName"
+          ]
+        }
+      },
+      "description": "Attaches the Warden container to the Docker network if not already connected",
+      "name": "attachSelfToNetwork",
+      "longname": "attachSelfToNetwork",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          678,
+          1097
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 22,
+        "columnno": 7,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003891",
+          "name": "attachSelfToNetwork",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "dockerInstance",
+            "networkName"
+          ]
+        },
+        "vars": {
+          "id": "attachSelfToNetwork~id",
+          "info": "attachSelfToNetwork~info",
+          "networks": "attachSelfToNetwork~networks"
+        }
+      },
+      "undocumented": true,
+      "name": "attachSelfToNetwork",
+      "longname": "attachSelfToNetwork",
+      "kind": "function",
+      "scope": "global",
+      "params": [],
+      "async": true
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          754,
+          779
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 23,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003897",
+          "name": "id",
+          "type": "MemberExpression",
+          "value": "process.env.HOSTNAME"
+        }
+      },
+      "undocumented": true,
+      "name": "id",
+      "longname": "attachSelfToNetwork~id",
+      "kind": "constant",
+      "memberof": "attachSelfToNetwork",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          791,
+          845
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 24,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003905",
+          "name": "info",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "info",
+      "longname": "attachSelfToNetwork~info",
+      "kind": "constant",
+      "memberof": "attachSelfToNetwork",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          857,
+          905
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 25,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003917",
+          "name": "networks",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "networks",
+      "longname": "attachSelfToNetwork~networks",
+      "kind": "constant",
+      "memberof": "attachSelfToNetwork",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1072,
+          1085
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 29,
+        "columnno": 63,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003946",
+          "name": "Container",
+          "type": "Identifier",
+          "value": "id"
+        }
+      },
+      "undocumented": true,
+      "name": "Container",
+      "longname": "Container",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "/**\n * Checks whether a container by name exists (running or stopped)\n */",
+      "meta": {
+        "range": [
+          1173,
+          1338
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 36,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003948",
+          "name": "exports.containerExists",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "name"
+          ]
+        }
+      },
+      "description": "Checks whether a container by name exists (running or stopped)",
+      "name": "containerExists",
+      "longname": "containerExists",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1180,
+          1338
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 36,
+        "columnno": 7,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003949",
+          "name": "containerExists",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "name"
+          ]
+        },
+        "vars": {
+          "list": "containerExists~list",
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "containerExists",
+      "longname": "containerExists",
+      "kind": "function",
+      "scope": "global",
+      "params": [],
+      "async": true
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1229,
+          1278
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 37,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003954",
+          "name": "list",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "list",
+      "longname": "containerExists~list",
+      "kind": "constant",
+      "memberof": "containerExists",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1266,
+          1275
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 37,
+        "columnno": 47,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003962",
+          "name": "all",
+          "type": "Literal",
+          "value": true
+        }
+      },
+      "undocumented": true,
+      "name": "all",
+      "longname": "all",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "/**\n * Pulls a Docker image if not already present\n */",
+      "meta": {
+        "range": [
+          1395,
+          2214
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 44,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003981",
+          "name": "exports.pullImageIfNeeded",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "image"
+          ]
+        }
+      },
+      "description": "Pulls a Docker image if not already present",
+      "name": "pullImageIfNeeded",
+      "longname": "pullImageIfNeeded",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1402,
+          2214
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 44,
+        "columnno": 7,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003982",
+          "name": "pullImageIfNeeded",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "image"
+          ]
+        },
+        "vars": {
+          "images": "pullImageIfNeeded~images",
+          "exists": "pullImageIfNeeded~exists",
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "pullImageIfNeeded",
+      "longname": "pullImageIfNeeded",
+      "kind": "function",
+      "scope": "global",
+      "params": [],
+      "async": true
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1454,
+          1488
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 45,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003987",
+          "name": "images",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "images",
+      "longname": "pullImageIfNeeded~images",
+      "kind": "constant",
+      "memberof": "pullImageIfNeeded",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1500,
+          1554
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 46,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100003995",
+          "name": "exists",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "exists",
+      "longname": "pullImageIfNeeded~exists",
+      "kind": "constant",
+      "memberof": "pullImageIfNeeded",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "/**\n * Create and start a Docker container for the given service and optionally stream its logs.\n *\n * Ensures the service's environment includes `SERVICE_NAME`, creates the container attached to the specified network,\n * records the service name in `trackedContainers`, starts the container, and conditionally streams its stdout/stderr\n * to stdout when `DEBUG` is set to a truthy debug value (`\"true\"`, `\"1\"`, `\"yes\"`, or `\"super\"`).\n *\n * @param {Object} service - Service descriptor with properties such as `name`, `image`, `env`, `volumes`, `exposed`, and `ports`.\n * @param {string} networkName - Name of the Docker network to attach the container to.\n * @param {Set<string>} trackedContainers - Set used to record the started container's service name.\n * @param {string|boolean|undefined} DEBUG - Debug flag that enables log streaming when set to a recognized truthy value.\n */",
+      "meta": {
+        "range": [
+          3101,
+          4657
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 84,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004089",
+          "name": "exports.runContainerWithLogs",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "service",
+            "networkName",
+            "trackedContainers",
+            "DEBUG"
+          ]
+        }
+      },
+      "description": "Create and start a Docker container for the given service and optionally stream its logs.\n\nEnsures the service's environment includes `SERVICE_NAME`, creates the container attached to the specified network,\nrecords the service name in `trackedContainers`, starts the container, and conditionally streams its stdout/stderr\nto stdout when `DEBUG` is set to a truthy debug value (`\"true\"`, `\"1\"`, `\"yes\"`, or `\"super\"`).",
+      "params": [
+        {
+          "type": {
+            "names": [
+              "Object"
+            ]
+          },
+          "description": "Service descriptor with properties such as `name`, `image`, `env`, `volumes`, `exposed`, and `ports`.",
+          "name": "service"
+        },
+        {
+          "type": {
+            "names": [
+              "string"
+            ]
+          },
+          "description": "Name of the Docker network to attach the container to.",
+          "name": "networkName"
+        },
+        {
+          "type": {
+            "names": [
+              "Set.<string>"
+            ]
+          },
+          "description": "Set used to record the started container's service name.",
+          "name": "trackedContainers"
+        },
+        {
+          "type": {
+            "names": [
+              "string",
+              "boolean",
+              "undefined"
+            ]
+          },
+          "description": "Debug flag that enables log streaming when set to a recognized truthy value.",
+          "name": "DEBUG"
+        }
+      ],
+      "name": "runContainerWithLogs",
+      "longname": "runContainerWithLogs",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3108,
+          4657
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 84,
+        "columnno": 7,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004090",
+          "name": "runContainerWithLogs",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "service",
+            "networkName",
+            "trackedContainers",
+            "DEBUG"
+          ]
+        },
+        "vars": {
+          "binds": "runContainerWithLogs~binds",
+          "envVars": "runContainerWithLogs~envVars",
+          "": null,
+          "exposed": "runContainerWithLogs~exposed",
+          "ports": "runContainerWithLogs~ports",
+          "debugValue": "runContainerWithLogs~debugValue",
+          "shouldStreamLogs": "runContainerWithLogs~shouldStreamLogs",
+          "container": "runContainerWithLogs~container",
+          "logs": "runContainerWithLogs~logs"
+        }
+      },
+      "undocumented": true,
+      "name": "runContainerWithLogs",
+      "longname": "runContainerWithLogs",
+      "kind": "function",
+      "scope": "global",
+      "params": [],
+      "async": true
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3204,
+          3233
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 85,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004098",
+          "name": "binds",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "binds",
+      "longname": "runContainerWithLogs~binds",
+      "kind": "constant",
+      "memberof": "runContainerWithLogs",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3289,
+          3323
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 88,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004106",
+          "name": "envVars",
+          "type": "ArrayExpression",
+          "value": "[\"\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "envVars",
+      "longname": "runContainerWithLogs~envVars",
+      "kind": "constant",
+      "memberof": "runContainerWithLogs",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3457,
+          3488
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 93,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004141",
+          "name": "exposed",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "exposed",
+      "longname": "runContainerWithLogs~exposed",
+      "kind": "constant",
+      "memberof": "runContainerWithLogs",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3500,
+          3527
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 94,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004149",
+          "name": "ports",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "ports",
+      "longname": "runContainerWithLogs~ports",
+      "kind": "constant",
+      "memberof": "runContainerWithLogs",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3540,
+          3591
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 96,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004157",
+          "name": "debugValue",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "debugValue",
+      "longname": "runContainerWithLogs~debugValue",
+      "kind": "constant",
+      "memberof": "runContainerWithLogs",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3603,
+          3672
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 97,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004169",
+          "name": "shouldStreamLogs",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "shouldStreamLogs",
+      "longname": "runContainerWithLogs~shouldStreamLogs",
+      "kind": "constant",
+      "memberof": "runContainerWithLogs",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3685,
+          4084
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 99,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004181",
+          "name": "container",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "container",
+      "longname": "runContainerWithLogs~container",
+      "kind": "constant",
+      "memberof": "runContainerWithLogs",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3736,
+          3754
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 100,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004189",
+          "name": "name",
+          "type": "MemberExpression",
+          "value": "service.name"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3764,
+          3784
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 101,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004193",
+          "name": "Image",
+          "type": "MemberExpression",
+          "value": "service.image"
+        }
+      },
+      "undocumented": true,
+      "name": "Image",
+      "longname": "Image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3794,
+          3806
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 102,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004197",
+          "name": "Env",
+          "type": "Identifier",
+          "value": "envVars"
+        }
+      },
+      "undocumented": true,
+      "name": "Env",
+      "longname": "Env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3816,
+          3837
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 103,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004199",
+          "name": "ExposedPorts",
+          "type": "Identifier",
+          "value": "exposed"
+        }
+      },
+      "undocumented": true,
+      "name": "ExposedPorts",
+      "longname": "ExposedPorts",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3847,
+          3956
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 104,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004201",
+          "name": "HostConfig",
+          "type": "ObjectExpression",
+          "value": "{\"PortBindings\":\"\",\"Binds\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "HostConfig",
+      "longname": "HostConfig",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3873,
+          3892
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 105,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004203",
+          "name": "PortBindings",
+          "type": "Identifier",
+          "value": "ports"
+        }
+      },
+      "undocumented": true,
+      "name": "PortBindings",
+      "longname": "HostConfig.PortBindings",
+      "kind": "member",
+      "memberof": "HostConfig",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3906,
+          3945
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 106,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004205",
+          "name": "Binds",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "Binds",
+      "longname": "HostConfig.Binds",
+      "kind": "member",
+      "memberof": "HostConfig",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3966,
+          4076
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 108,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004212",
+          "name": "NetworkingConfig",
+          "type": "ObjectExpression",
+          "value": "{\"EndpointsConfig\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "NetworkingConfig",
+      "longname": "NetworkingConfig",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3998,
+          4065
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 109,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004214",
+          "name": "EndpointsConfig",
+          "type": "ObjectExpression",
+          "value": "{\"networkName\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "EndpointsConfig",
+      "longname": "NetworkingConfig.EndpointsConfig",
+      "kind": "member",
+      "memberof": "NetworkingConfig",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4033,
+          4050
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 110,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004216",
+          "name": "networkName",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "networkName",
+      "longname": "NetworkingConfig.EndpointsConfig.networkName",
+      "kind": "member",
+      "memberof": "NetworkingConfig.EndpointsConfig",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4200,
+          4340
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 119,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004236",
+          "name": "logs",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "logs",
+      "longname": "runContainerWithLogs~logs",
+      "kind": "constant",
+      "memberof": "runContainerWithLogs",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4242,
+          4254
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 120,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004244",
+          "name": "follow",
+          "type": "Literal",
+          "value": true
+        }
+      },
+      "undocumented": true,
+      "name": "follow",
+      "longname": "follow",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4268,
+          4280
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 121,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004246",
+          "name": "stdout",
+          "type": "Literal",
+          "value": true
+        }
+      },
+      "undocumented": true,
+      "name": "stdout",
+      "longname": "stdout",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4294,
+          4306
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 122,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004248",
+          "name": "stderr",
+          "type": "Literal",
+          "value": true
+        }
+      },
+      "undocumented": true,
+      "name": "stderr",
+      "longname": "stderr",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4320,
+          4328
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 123,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004250",
+          "name": "tail",
+          "type": "Literal",
+          "value": 10
+        }
+      },
+      "undocumented": true,
+      "name": "tail",
+      "longname": "tail",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4396,
+          4426
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 127,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004262",
+          "name": "line",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "line",
+      "longname": "<anonymous>~line",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "/**\n * Waits for a service's HTTP healthcheck to return 200 OK\n */",
+      "meta": {
+        "range": [
+          4726,
+          5338
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 140,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004307",
+          "name": "exports.waitForHealthyStatus",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "name",
+            "url",
+            "tries",
+            "delay"
+          ]
+        }
+      },
+      "description": "Waits for a service's HTTP healthcheck to return 200 OK",
+      "name": "waitForHealthyStatus",
+      "longname": "waitForHealthyStatus",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4733,
+          5338
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 140,
+        "columnno": 7,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004308",
+          "name": "waitForHealthyStatus",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "name",
+            "url",
+            "tries",
+            "delay"
+          ]
+        },
+        "vars": {
+          "i": "waitForHealthyStatus~i",
+          "res": "waitForHealthyStatus~res",
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "waitForHealthyStatus",
+      "longname": "waitForHealthyStatus",
+      "kind": "function",
+      "scope": "global",
+      "params": [],
+      "async": true
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4821,
+          4826
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 141,
+        "columnno": 13,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004321",
+          "name": "i",
+          "type": "Literal",
+          "value": 0
+        }
+      },
+      "undocumented": true,
+      "name": "i",
+      "longname": "waitForHealthyStatus~i",
+      "kind": "member",
+      "memberof": "waitForHealthyStatus",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4878,
+          4900
+        ],
+        "filename": "dockerUtilties.mjs",
+        "lineno": 143,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004333",
+          "name": "res",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "res",
+      "longname": "waitForHealthyStatus~res",
+      "kind": "constant",
+      "memberof": "waitForHealthyStatus",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          131,
+          167
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 5,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004402",
+          "name": "DEBUG",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "DEBUG",
+      "longname": "DEBUG",
+      "kind": "constant",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          175,
+          244
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 6,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004412",
+          "name": "HOST_SERVICE_URL",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "HOST_SERVICE_URL",
+      "longname": "HOST_SERVICE_URL",
+      "kind": "constant",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          252,
+          375
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 7,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004422",
+          "name": "DOCKER_WARDEN_URL",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "DOCKER_WARDEN_URL",
+      "longname": "DOCKER_WARDEN_URL",
+      "kind": "constant",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          384,
+          510
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 10,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004438",
+          "name": "rawList",
+          "type": "ArrayExpression",
+          "value": "[\"noona-sage\",\"noona-moon\",\"noona-oracle\",\"noona-raven\",\"noona-portal\",\"noona-vault\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "rawList",
+      "longname": "rawList",
+      "kind": "constant",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          519,
+          569
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 19,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004448",
+          "name": "tokensByService",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "tokensByService",
+      "longname": "tokensByService",
+      "kind": "constant",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          578,
+          2082
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 21,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004454",
+          "name": "serviceDefs",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "serviceDefs",
+      "longname": "serviceDefs",
+      "kind": "constant",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          624,
+          814
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 22,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004464",
+          "name": "portMap",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":3005}"
+        }
+      },
+      "undocumented": true,
+      "name": "portMap",
+      "longname": "<anonymous>~portMap",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          644,
+          662
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 23,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004467",
+          "name": "\"noona-sage\"",
+          "type": "Literal",
+          "value": 3004
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-sage\"",
+      "longname": "<anonymous>~portMap.\"noona-sage\"",
+      "kind": "member",
+      "memberof": "<anonymous>~portMap",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          672,
+          690
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 24,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004469",
+          "name": "\"noona-moon\"",
+          "type": "Literal",
+          "value": 3000
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-moon\"",
+      "longname": "<anonymous>~portMap.\"noona-moon\"",
+      "kind": "member",
+      "memberof": "<anonymous>~portMap",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          700,
+          720
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 25,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004471",
+          "name": "\"noona-oracle\"",
+          "type": "Literal",
+          "value": 3001
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-oracle\"",
+      "longname": "<anonymous>~portMap.\"noona-oracle\"",
+      "kind": "member",
+      "memberof": "<anonymous>~portMap",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          730,
+          749
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 26,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004473",
+          "name": "\"noona-raven\"",
+          "type": "Literal",
+          "value": 3002
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-raven\"",
+      "longname": "<anonymous>~portMap.\"noona-raven\"",
+      "kind": "member",
+      "memberof": "<anonymous>~portMap",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          759,
+          779
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 27,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004475",
+          "name": "\"noona-portal\"",
+          "type": "Literal",
+          "value": 3003
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-portal\"",
+      "longname": "<anonymous>~portMap.\"noona-portal\"",
+      "kind": "member",
+      "memberof": "<anonymous>~portMap",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          789,
+          808
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 28,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004477",
+          "name": "\"noona-vault\"",
+          "type": "Literal",
+          "value": 3005
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-vault\"",
+      "longname": "<anonymous>~portMap.\"noona-vault\"",
+      "kind": "member",
+      "memberof": "<anonymous>~portMap",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          827,
+          887
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 31,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004480",
+          "name": "internalPort",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "internalPort",
+      "longname": "<anonymous>~internalPort",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          899,
+          928
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 32,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004491",
+          "name": "token",
+          "type": "MemberExpression",
+          "value": "tokensByService[undefined]"
+        }
+      },
+      "undocumented": true,
+      "name": "token",
+      "longname": "<anonymous>~token",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          941,
+          1011
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 34,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004497",
+          "name": "env",
+          "type": "ArrayExpression",
+          "value": "[\"\",\"\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "<anonymous>~env",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1230,
+          1281
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 48,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004540",
+          "name": "tokenMapString",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "tokenMapString",
+      "longname": "<anonymous>~tokenMapString",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1368,
+          1462
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 52,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004557",
+          "name": "hostServiceUrl",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "<anonymous>~hostServiceUrl",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1475,
+          1882
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 56,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004573",
+          "name": "healthChecks",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "healthChecks",
+      "longname": "<anonymous>~healthChecks",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1906,
+          1910
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 73,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004610",
+          "name": "name",
+          "type": "Identifier",
+          "value": "name"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1920,
+          1954
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 74,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004612",
+          "name": "image",
+          "type": "TemplateLiteral",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1964,
+          1983
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 75,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004617",
+          "name": "port",
+          "type": "MemberExpression",
+          "value": "portMap[undefined]"
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1993,
+          2005
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 76,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004621",
+          "name": "internalPort",
+          "type": "Identifier",
+          "value": "internalPort"
+        }
+      },
+      "undocumented": true,
+      "name": "internalPort",
+      "longname": "internalPort",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2015,
+          2018
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 77,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004623",
+          "name": "env",
+          "type": "Identifier",
+          "value": "env"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2028,
+          2042
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 78,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004625",
+          "name": "hostServiceUrl",
+          "type": "Identifier",
+          "value": "hostServiceUrl"
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "hostServiceUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2052,
+          2072
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 79,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004627",
+          "name": "health",
+          "type": "Identifier",
+          "value": "healthChecks"
+        }
+      },
+      "undocumented": true,
+      "name": "health",
+      "longname": "health",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2091,
+          2523
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 83,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004630",
+          "name": "noonaDockers",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "noonaDockers",
+      "longname": "noonaDockers",
+      "kind": "constant",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2173,
+          2220
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 85,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004644",
+          "name": "internal",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "internal",
+      "longname": "<anonymous>~internal",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2236,
+          2289
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 86,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004654",
+          "name": "exposed",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "exposed",
+      "longname": "<anonymous>~exposed",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2305,
+          2450
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 87,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004663",
+          "name": "ports",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "ports",
+      "longname": "<anonymous>~ports",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2394,
+          2424
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 89,
+        "columnno": 44,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004675",
+          "name": "HostPort",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "HostPort",
+      "longname": "HostPort",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2496,
+          2503
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 91,
+        "columnno": 44,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004690",
+          "name": "exposed",
+          "type": "Identifier",
+          "value": "exposed"
+        }
+      },
+      "undocumented": true,
+      "name": "exposed",
+      "longname": "exposed",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2505,
+          2510
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 91,
+        "columnno": 53,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004692",
+          "name": "ports",
+          "type": "Identifier",
+          "value": "ports"
+        }
+      },
+      "undocumented": true,
+      "name": "ports",
+      "longname": "ports",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2526,
+          2554
+        ],
+        "filename": "noonaDockers.mjs",
+        "lineno": 95,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004694",
+          "name": "module.exports",
+          "type": "Identifier"
+        }
+      },
+      "undocumented": true,
+      "name": "exports",
+      "longname": "module.exports",
+      "kind": "member",
+      "memberof": "module",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          83,
+          367
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 4,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004703",
+          "name": "DEFAULT_TOKENS",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"noona-vault-dev-token\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "DEFAULT_TOKENS",
+      "longname": "DEFAULT_TOKENS",
+      "kind": "constant",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          106,
+          142
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 5,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004706",
+          "name": "\"noona-sage\"",
+          "type": "Literal",
+          "value": "noona-sage-dev-token"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-sage\"",
+      "longname": "DEFAULT_TOKENS.\"noona-sage\"",
+      "kind": "member",
+      "memberof": "DEFAULT_TOKENS",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          148,
+          184
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 6,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004708",
+          "name": "\"noona-moon\"",
+          "type": "Literal",
+          "value": "noona-moon-dev-token"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-moon\"",
+      "longname": "DEFAULT_TOKENS.\"noona-moon\"",
+      "kind": "member",
+      "memberof": "DEFAULT_TOKENS",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          190,
+          230
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 7,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004710",
+          "name": "\"noona-oracle\"",
+          "type": "Literal",
+          "value": "noona-oracle-dev-token"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-oracle\"",
+      "longname": "DEFAULT_TOKENS.\"noona-oracle\"",
+      "kind": "member",
+      "memberof": "DEFAULT_TOKENS",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          236,
+          274
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 8,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004712",
+          "name": "\"noona-raven\"",
+          "type": "Literal",
+          "value": "noona-raven-dev-token"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-raven\"",
+      "longname": "DEFAULT_TOKENS.\"noona-raven\"",
+      "kind": "member",
+      "memberof": "DEFAULT_TOKENS",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          280,
+          320
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 9,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004714",
+          "name": "\"noona-portal\"",
+          "type": "Literal",
+          "value": "noona-portal-dev-token"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-portal\"",
+      "longname": "DEFAULT_TOKENS.\"noona-portal\"",
+      "kind": "member",
+      "memberof": "DEFAULT_TOKENS",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          326,
+          364
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 10,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004716",
+          "name": "\"noona-vault\"",
+          "type": "Literal",
+          "value": "noona-vault-dev-token"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-vault\"",
+      "longname": "DEFAULT_TOKENS.\"noona-vault\"",
+      "kind": "member",
+      "memberof": "DEFAULT_TOKENS",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          376,
+          494
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 13,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004719",
+          "name": "sanitizeToken",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "sanitizeToken",
+      "longname": "sanitizeToken",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          503,
+          589
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 21,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004738",
+          "name": "normalizeEnvKey",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "normalizeEnvKey",
+      "longname": "normalizeEnvKey",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          592,
+          665
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 24,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004754",
+          "name": "exports.__testables__",
+          "type": "VariableDeclaration"
+        }
+      },
+      "undocumented": true,
+      "name": "__testables__",
+      "longname": "__testables__",
+      "kind": "constant",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          605,
+          664
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 24,
+        "columnno": 13,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004756",
+          "name": "__testables__",
+          "type": "ObjectExpression",
+          "value": "{\"sanitizeToken\":\"\",\"normalizeEnvKey\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "__testables__",
+      "longname": "__testables__",
+      "kind": "constant",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          627,
+          640
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 25,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004759",
+          "name": "sanitizeToken",
+          "type": "Identifier",
+          "value": "sanitizeToken"
+        }
+      },
+      "undocumented": true,
+      "name": "sanitizeToken",
+      "longname": "__testables__.sanitizeToken",
+      "kind": "member",
+      "memberof": "__testables__",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          646,
+          661
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 26,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004761",
+          "name": "normalizeEnvKey",
+          "type": "Identifier",
+          "value": "normalizeEnvKey"
+        }
+      },
+      "undocumented": true,
+      "name": "normalizeEnvKey",
+      "longname": "__testables__.normalizeEnvKey",
+      "kind": "member",
+      "memberof": "__testables__",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          667,
+          1032
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 29,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004763",
+          "name": "exports.generateVaultToken",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "name",
+            "randomBytes"
+          ]
+        }
+      },
+      "undocumented": true,
+      "name": "generateVaultToken",
+      "longname": "generateVaultToken",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          674,
+          1032
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 29,
+        "columnno": 7,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004764",
+          "name": "generateVaultToken",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "name",
+            "randomBytes"
+          ]
+        },
+        "vars": {
+          "safeName": "generateVaultToken~safeName",
+          "prefix": "generateVaultToken~prefix",
+          "trimmedPrefix": "generateVaultToken~trimmedPrefix",
+          "entropy": "generateVaultToken~entropy"
+        }
+      },
+      "undocumented": true,
+      "name": "generateVaultToken",
+      "longname": "generateVaultToken",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          754,
+          806
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 30,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004774",
+          "name": "safeName",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "safeName",
+      "longname": "generateVaultToken~safeName",
+      "kind": "constant",
+      "memberof": "generateVaultToken",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          818,
+          887
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 31,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004784",
+          "name": "prefix",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "prefix",
+      "longname": "generateVaultToken~prefix",
+      "kind": "constant",
+      "memberof": "generateVaultToken",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          899,
+          934
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 32,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004798",
+          "name": "trimmedPrefix",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "trimmedPrefix",
+      "longname": "generateVaultToken~trimmedPrefix",
+      "kind": "constant",
+      "memberof": "generateVaultToken",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          946,
+          987
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 33,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004807",
+          "name": "entropy",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "entropy",
+      "longname": "generateVaultToken~entropy",
+      "kind": "constant",
+      "memberof": "generateVaultToken",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1034,
+          1974
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 37,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004823",
+          "name": "exports.buildVaultTokenRegistry",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "names",
+            "options"
+          ]
+        }
+      },
+      "undocumented": true,
+      "name": "buildVaultTokenRegistry",
+      "longname": "buildVaultTokenRegistry",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1041,
+          1974
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 37,
+        "columnno": 7,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004824",
+          "name": "buildVaultTokenRegistry",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "names",
+            "options"
+          ]
+        },
+        "vars": {
+          "undefined": null,
+          "": null,
+          "tokensByService": "buildVaultTokenRegistry~tokensByService",
+          "rawName": "buildVaultTokenRegistry~rawName",
+          "name": "buildVaultTokenRegistry~name",
+          "envKey": "buildVaultTokenRegistry~envKey",
+          "envToken": "buildVaultTokenRegistry~envToken",
+          "tokensByService[undefined]": "buildVaultTokenRegistry~tokensByService[undefined]",
+          "defaultToken": "buildVaultTokenRegistry~defaultToken"
+        }
+      },
+      "undocumented": true,
+      "name": "buildVaultTokenRegistry",
+      "longname": "buildVaultTokenRegistry",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1122,
+          1139
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 39,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004836",
+          "name": "env",
+          "type": "AssignmentPattern",
+          "value": "env"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1149,
+          1174
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 40,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004842",
+          "name": "defaults",
+          "type": "AssignmentPattern",
+          "value": "defaults"
+        }
+      },
+      "undocumented": true,
+      "name": "defaults",
+      "longname": "defaults",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1184,
+          1244
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 41,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004846",
+          "name": "generator",
+          "type": "AssignmentPattern",
+          "value": "generator"
+        }
+      },
+      "undocumented": true,
+      "name": "generator",
+      "longname": "generator",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1274,
+          1294
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 44,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004856",
+          "name": "tokensByService",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "tokensByService",
+      "longname": "buildVaultTokenRegistry~tokensByService",
+      "kind": "constant",
+      "memberof": "buildVaultTokenRegistry",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1312,
+          1319
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 46,
+        "columnno": 15,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004861",
+          "name": "rawName"
+        }
+      },
+      "undocumented": true,
+      "name": "rawName",
+      "longname": "buildVaultTokenRegistry~rawName",
+      "kind": "constant",
+      "memberof": "buildVaultTokenRegistry",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1434,
+          1455
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 51,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004876",
+          "name": "name",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "buildVaultTokenRegistry~name",
+      "kind": "constant",
+      "memberof": "buildVaultTokenRegistry",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1525,
+          1555
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 56,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004888",
+          "name": "envKey",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "envKey",
+      "longname": "buildVaultTokenRegistry~envKey",
+      "kind": "constant",
+      "memberof": "buildVaultTokenRegistry",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1571,
+          1610
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 57,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004894",
+          "name": "envToken",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "envToken",
+      "longname": "buildVaultTokenRegistry~envToken",
+      "kind": "constant",
+      "memberof": "buildVaultTokenRegistry",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1649,
+          1681
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 60,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004903",
+          "name": "tokensByService[undefined]",
+          "type": "Identifier",
+          "funcscope": "buildVaultTokenRegistry",
+          "value": "envToken",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "tokensByService[undefined]",
+      "longname": "buildVaultTokenRegistry~tokensByService[undefined]",
+      "kind": "member",
+      "memberof": "buildVaultTokenRegistry",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1730,
+          1776
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 64,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004910",
+          "name": "defaultToken",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "defaultToken",
+      "longname": "buildVaultTokenRegistry~defaultToken",
+      "kind": "constant",
+      "memberof": "buildVaultTokenRegistry",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1818,
+          1854
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 66,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004919",
+          "name": "tokensByService[undefined]",
+          "type": "Identifier",
+          "funcscope": "buildVaultTokenRegistry",
+          "value": "defaultToken",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "tokensByService[undefined]",
+      "longname": "buildVaultTokenRegistry~tokensByService[undefined]",
+      "kind": "member",
+      "memberof": "buildVaultTokenRegistry",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1897,
+          1936
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 70,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004926",
+          "name": "tokensByService[undefined]",
+          "type": "CallExpression",
+          "funcscope": "buildVaultTokenRegistry",
+          "value": "",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "tokensByService[undefined]",
+      "longname": "buildVaultTokenRegistry~tokensByService[undefined]",
+      "kind": "member",
+      "memberof": "buildVaultTokenRegistry",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1976,
+          2299
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 76,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004935",
+          "name": "exports.stringifyTokenMap",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "tokensByService"
+          ]
+        }
+      },
+      "undocumented": true,
+      "name": "stringifyTokenMap",
+      "longname": "stringifyTokenMap",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1983,
+          2299
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 76,
+        "columnno": 7,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004936",
+          "name": "stringifyTokenMap",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "tokensByService"
+          ]
+        },
+        "vars": {
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "stringifyTokenMap",
+      "longname": "stringifyTokenMap",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2301,
+          2396
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 84,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004988",
+          "name": "module.exports",
+          "type": "ObjectExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "exports",
+      "longname": "module.exports",
+      "kind": "member",
+      "memberof": "module",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2322,
+          2345
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 85,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004990",
+          "name": "buildVaultTokenRegistry",
+          "type": "Identifier",
+          "value": "buildVaultTokenRegistry"
+        }
+      },
+      "undocumented": true,
+      "name": "buildVaultTokenRegistry",
+      "longname": "module.exports.buildVaultTokenRegistry",
+      "kind": "member",
+      "memberof": "module.exports",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2351,
+          2369
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 86,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004992",
+          "name": "generateVaultToken",
+          "type": "Identifier",
+          "value": "generateVaultToken"
+        }
+      },
+      "undocumented": true,
+      "name": "generateVaultToken",
+      "longname": "module.exports.generateVaultToken",
+      "kind": "member",
+      "memberof": "module.exports",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2375,
+          2392
+        ],
+        "filename": "vaultTokens.mjs",
+        "lineno": 87,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/docker",
+        "code": {
+          "id": "astnode100004994",
+          "name": "stringifyTokenMap",
+          "type": "Identifier",
+          "value": "stringifyTokenMap"
+        }
+      },
+      "undocumented": true,
+      "name": "stringifyTokenMap",
+      "longname": "module.exports.stringifyTokenMap",
+      "kind": "member",
+      "memberof": "module.exports",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          217,
+          240
+        ],
+        "filename": "initWarden.mjs",
+        "lineno": 6,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden",
+        "code": {
+          "id": "astnode100005011",
+          "name": "warden",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "warden",
+      "kind": "constant",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          248,
+          316
+        ],
+        "filename": "initWarden.mjs",
+        "lineno": 7,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden",
+        "code": {
+          "id": "astnode100005016",
+          "name": "apiPort",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "apiPort",
+      "longname": "apiPort",
+      "kind": "constant",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          326,
+          343
+        ],
+        "filename": "initWarden.mjs",
+        "lineno": 8,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden",
+        "code": {
+          "id": "astnode100005033",
+          "name": "server",
+          "type": "Identifier",
+          "value": "apiServer"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          368,
+          374
+        ],
+        "filename": "initWarden.mjs",
+        "lineno": 8,
+        "columnno": 50,
+        "path": "/workspace/Noona/services/warden",
+        "code": {
+          "id": "astnode100005038",
+          "name": "warden",
+          "type": "Identifier",
+          "value": "warden"
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "warden",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          376,
+          389
+        ],
+        "filename": "initWarden.mjs",
+        "lineno": 8,
+        "columnno": 58,
+        "path": "/workspace/Noona/services/warden",
+        "code": {
+          "id": "astnode100005040",
+          "name": "port",
+          "type": "Identifier",
+          "value": "apiPort"
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          401,
+          491
+        ],
+        "filename": "initWarden.mjs",
+        "lineno": 10,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden",
+        "code": {
+          "id": "astnode100005043",
+          "name": "closeApiServer",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "closeApiServer",
+      "longname": "closeApiServer",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "/**\n * Generates the HTML for the Noona Setup Wizard.\n * This is pushed into Redis and rendered by Moon.\n *\n * @param {string[]} slugs - List of service slugs (e.g. noona-moon)\n * @returns {string} - Full HTML document as string\n */",
+      "meta": {
+        "range": [
+          234,
+          2340
+        ],
+        "filename": "setupWizard.mjs",
+        "lineno": 8,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/setup",
+        "code": {
+          "id": "astnode100005128",
+          "name": "exports.generateSetupWizardHTML",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "slugs"
+          ]
+        }
+      },
+      "description": "Generates the HTML for the Noona Setup Wizard.\nThis is pushed into Redis and rendered by Moon.",
+      "params": [
+        {
+          "type": {
+            "names": [
+              "Array.<string>"
+            ]
+          },
+          "description": "List of service slugs (e.g. noona-moon)",
+          "name": "slugs"
+        }
+      ],
+      "returns": [
+        {
+          "type": {
+            "names": [
+              "string"
+            ]
+          },
+          "description": "- Full HTML document as string"
+        }
+      ],
+      "name": "generateSetupWizardHTML",
+      "longname": "generateSetupWizardHTML",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          241,
+          2340
+        ],
+        "filename": "setupWizard.mjs",
+        "lineno": 8,
+        "columnno": 7,
+        "path": "/workspace/Noona/services/warden/setup",
+        "code": {
+          "id": "astnode100005129",
+          "name": "generateSetupWizardHTML",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "slugs"
+          ]
+        },
+        "vars": {
+          "sorted": "generateSetupWizardHTML~sorted",
+          "buttons": "generateSetupWizardHTML~buttons",
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "generateSetupWizardHTML",
+      "longname": "generateSetupWizardHTML",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          331,
+          357
+        ],
+        "filename": "setupWizard.mjs",
+        "lineno": 10,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/setup",
+        "code": {
+          "id": "astnode100005136",
+          "name": "sorted",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "sorted",
+      "longname": "generateSetupWizardHTML~sorted",
+      "kind": "constant",
+      "memberof": "generateSetupWizardHTML",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          368,
+          558
+        ],
+        "filename": "setupWizard.mjs",
+        "lineno": 11,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/setup",
+        "code": {
+          "id": "astnode100005145",
+          "name": "buttons",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "buttons",
+      "longname": "generateSetupWizardHTML~buttons",
+      "kind": "constant",
+      "memberof": "generateSetupWizardHTML",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          492,
+          645
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 18,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005218",
+          "name": "normalizeServices",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "servicesOption"
+          ]
+        },
+        "vars": {
+          "undefined": null
+        }
+      },
+      "undocumented": true,
+      "name": "normalizeServices",
+      "longname": "normalizeServices",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          554,
+          574
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 19,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005227",
+          "name": "addon",
+          "type": "AssignmentPattern",
+          "value": "addon"
+        }
+      },
+      "undocumented": true,
+      "name": "addon",
+      "longname": "addon",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          576,
+          595
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 19,
+        "columnno": 34,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005231",
+          "name": "core",
+          "type": "AssignmentPattern",
+          "value": "core"
+        }
+      },
+      "undocumented": true,
+      "name": "core",
+      "longname": "core",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          629,
+          634
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 20,
+        "columnno": 13,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005238",
+          "name": "addon",
+          "type": "Identifier",
+          "value": "addon"
+        }
+      },
+      "undocumented": true,
+      "name": "addon",
+      "longname": "addon",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          636,
+          640
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 20,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005240",
+          "name": "core",
+          "type": "Identifier",
+          "value": "core"
+        }
+      },
+      "undocumented": true,
+      "name": "core",
+      "longname": "core",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          647,
+          906
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 23,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005242",
+          "name": "normalizeDockerUtils",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "utilsOption"
+          ]
+        }
+      },
+      "undocumented": true,
+      "name": "normalizeDockerUtils",
+      "longname": "normalizeDockerUtils",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          718,
+          737
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 25,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005250",
+          "name": "attachSelfToNetwork",
+          "type": "Identifier",
+          "value": "attachSelfToNetwork"
+        }
+      },
+      "undocumented": true,
+      "name": "attachSelfToNetwork",
+      "longname": "attachSelfToNetwork",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          747,
+          762
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 26,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005252",
+          "name": "containerExists",
+          "type": "Identifier",
+          "value": "containerExists"
+        }
+      },
+      "undocumented": true,
+      "name": "containerExists",
+      "longname": "containerExists",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          772,
+          785
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 27,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005254",
+          "name": "ensureNetwork",
+          "type": "Identifier",
+          "value": "ensureNetwork"
+        }
+      },
+      "undocumented": true,
+      "name": "ensureNetwork",
+      "longname": "ensureNetwork",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          795,
+          812
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 28,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005256",
+          "name": "pullImageIfNeeded",
+          "type": "Identifier",
+          "value": "pullImageIfNeeded"
+        }
+      },
+      "undocumented": true,
+      "name": "pullImageIfNeeded",
+      "longname": "pullImageIfNeeded",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          822,
+          842
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 29,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005258",
+          "name": "runContainerWithLogs",
+          "type": "Identifier",
+          "value": "runContainerWithLogs"
+        }
+      },
+      "undocumented": true,
+      "name": "runContainerWithLogs",
+      "longname": "runContainerWithLogs",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          852,
+          872
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 30,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005260",
+          "name": "waitForHealthyStatus",
+          "type": "Identifier",
+          "value": "waitForHealthyStatus"
+        }
+      },
+      "undocumented": true,
+      "name": "waitForHealthyStatus",
+      "longname": "waitForHealthyStatus",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          908,
+          1031
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 35,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005264",
+          "name": "createDefaultLogger",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "loggerOption"
+          ]
+        }
+      },
+      "undocumented": true,
+      "name": "createDefaultLogger",
+      "longname": "createDefaultLogger",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          979,
+          982
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 37,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005272",
+          "name": "log",
+          "type": "Identifier",
+          "value": "log"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "log",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          992,
+          996
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 38,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005274",
+          "name": "warn",
+          "type": "Identifier",
+          "value": "warn"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "warn",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1033,
+          1430
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 43,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005278",
+          "name": "normalizeSocketPath",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "candidate"
+          ]
+        },
+        "vars": {
+          "trimmed": "normalizeSocketPath~trimmed"
+        }
+      },
+      "undocumented": true,
+      "name": "normalizeSocketPath",
+      "longname": "normalizeSocketPath",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1168,
+          1194
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 48,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005294",
+          "name": "trimmed",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "trimmed",
+      "longname": "normalizeSocketPath~trimmed",
+      "kind": "constant",
+      "memberof": "normalizeSocketPath",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1432,
+          3893
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 65,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005332",
+          "name": "defaultDockerSocketDetector",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            ""
+          ]
+        },
+        "vars": {
+          "sockets": "defaultDockerSocketDetector~sockets",
+          "envCandidates": "defaultDockerSocketDetector~envCandidates",
+          "": null,
+          "candidate": "defaultDockerSocketDetector~candidate",
+          "dockerHost": "defaultDockerSocketDetector~dockerHost",
+          "defaultCandidates": "defaultDockerSocketDetector~defaultCandidates",
+          "normalized": "defaultDockerSocketDetector~normalized",
+          "directories": "defaultDockerSocketDetector~directories",
+          "directory": "defaultDockerSocketDetector~directory",
+          "entries": "defaultDockerSocketDetector~entries",
+          "entry": "defaultDockerSocketDetector~entry",
+          "isSocket": "defaultDockerSocketDetector~isSocket",
+          "isFile": "defaultDockerSocketDetector~isFile",
+          "name": "defaultDockerSocketDetector~name",
+          "fullPath": "defaultDockerSocketDetector~fullPath"
+        }
+      },
+      "undocumented": true,
+      "name": "defaultDockerSocketDetector",
+      "longname": "defaultDockerSocketDetector",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1471,
+          1488
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 65,
+        "columnno": 39,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005336",
+          "name": "env",
+          "type": "AssignmentPattern",
+          "value": "env"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1490,
+          1507
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 65,
+        "columnno": 58,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005342",
+          "name": "fs",
+          "type": "AssignmentPattern",
+          "value": "fsModule"
+        }
+      },
+      "undocumented": true,
+      "name": "fs",
+      "longname": "fs",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1528,
+          1547
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 66,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005349",
+          "name": "sockets",
+          "type": "NewExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "sockets",
+      "longname": "defaultDockerSocketDetector~sockets",
+      "kind": "constant",
+      "memberof": "defaultDockerSocketDetector",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1560,
+          1798
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 68,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005354",
+          "name": "envCandidates",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "envCandidates",
+      "longname": "defaultDockerSocketDetector~envCandidates",
+      "kind": "constant",
+      "memberof": "defaultDockerSocketDetector",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1816,
+          1825
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 72,
+        "columnno": 15,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005397",
+          "name": "candidate"
+        }
+      },
+      "undocumented": true,
+      "name": "candidate",
+      "longname": "defaultDockerSocketDetector~candidate",
+      "kind": "constant",
+      "memberof": "defaultDockerSocketDetector",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1934,
+          1984
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 78,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005411",
+          "name": "dockerHost",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "dockerHost",
+      "longname": "defaultDockerSocketDetector~dockerHost",
+      "kind": "constant",
+      "memberof": "defaultDockerSocketDetector",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2058,
+          2293
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 83,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005426",
+          "name": "defaultCandidates",
+          "type": "ArrayExpression",
+          "value": "[\"/var/run/docker.sock\",\"/var/run/docker/docker.sock\",\"/run/docker.sock\",\"/run/docker/docker.sock\",\"/var/run/podman/podman.sock\",\"/run/podman/podman.sock\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "defaultCandidates",
+      "longname": "defaultDockerSocketDetector~defaultCandidates",
+      "kind": "constant",
+      "memberof": "defaultDockerSocketDetector",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2311,
+          2320
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 92,
+        "columnno": 15,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005437",
+          "name": "candidate"
+        }
+      },
+      "undocumented": true,
+      "name": "candidate",
+      "longname": "defaultDockerSocketDetector~candidate",
+      "kind": "constant",
+      "memberof": "defaultDockerSocketDetector",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2359,
+          2402
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 93,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005442",
+          "name": "normalized",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "normalized",
+      "longname": "defaultDockerSocketDetector~normalized",
+      "kind": "constant",
+      "memberof": "defaultDockerSocketDetector",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2553,
+          2738
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 100,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005463",
+          "name": "directories",
+          "type": "ArrayExpression",
+          "value": "[\"/var/run\",\"/run\",\"/var/run/docker\",\"/run/docker\",\"/var/run/podman\",\"/run/podman\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "directories",
+      "longname": "defaultDockerSocketDetector~directories",
+      "kind": "constant",
+      "memberof": "defaultDockerSocketDetector",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2760,
+          2769
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 109,
+        "columnno": 19,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005474",
+          "name": "directory"
+        }
+      },
+      "undocumented": true,
+      "name": "directory",
+      "longname": "defaultDockerSocketDetector~directory",
+      "kind": "constant",
+      "memberof": "defaultDockerSocketDetector",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2828,
+          2894
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 111,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005481",
+          "name": "entries",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "entries",
+      "longname": "defaultDockerSocketDetector~entries",
+      "kind": "constant",
+      "memberof": "defaultDockerSocketDetector",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2872,
+          2891
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 111,
+        "columnno": 66,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005489",
+          "name": "withFileTypes",
+          "type": "Literal",
+          "value": true
+        }
+      },
+      "undocumented": true,
+      "name": "withFileTypes",
+      "longname": "withFileTypes",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2924,
+          2929
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 113,
+        "columnno": 27,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005493",
+          "name": "entry"
+        }
+      },
+      "undocumented": true,
+      "name": "entry",
+      "longname": "defaultDockerSocketDetector~entry",
+      "kind": "constant",
+      "memberof": "defaultDockerSocketDetector",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3061,
+          3128
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 118,
+        "columnno": 26,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005503",
+          "name": "isSocket",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "isSocket",
+      "longname": "defaultDockerSocketDetector~isSocket",
+      "kind": "constant",
+      "memberof": "defaultDockerSocketDetector",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3156,
+          3217
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 119,
+        "columnno": 26,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005517",
+          "name": "isFile",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "isFile",
+      "longname": "defaultDockerSocketDetector~isFile",
+      "kind": "constant",
+      "memberof": "defaultDockerSocketDetector",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3351,
+          3368
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 125,
+        "columnno": 26,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005539",
+          "name": "name",
+          "type": "MemberExpression",
+          "value": "entry.name"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "defaultDockerSocketDetector~name",
+      "kind": "constant",
+      "memberof": "defaultDockerSocketDetector",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3641,
+          3684
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 134,
+        "columnno": 26,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005569",
+          "name": "fullPath",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "fullPath",
+      "longname": "defaultDockerSocketDetector~fullPath",
+      "kind": "constant",
+      "memberof": "defaultDockerSocketDetector",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3895,
+          4323
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 146,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005592",
+          "name": "createServiceCatalog",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "services"
+          ]
+        },
+        "vars": {
+          "catalog": "createServiceCatalog~catalog",
+          "undefined": null,
+          "service": "createServiceCatalog~service"
+        }
+      },
+      "undocumented": true,
+      "name": "createServiceCatalog",
+      "longname": "createServiceCatalog",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3947,
+          3966
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 147,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005597",
+          "name": "catalog",
+          "type": "NewExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "catalog",
+      "longname": "createServiceCatalog~catalog",
+      "kind": "constant",
+      "memberof": "createServiceCatalog",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4054,
+          4061
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 150,
+        "columnno": 19,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005613",
+          "name": "service"
+        }
+      },
+      "undocumented": true,
+      "name": "service",
+      "longname": "createServiceCatalog~service",
+      "kind": "constant",
+      "memberof": "createServiceCatalog",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4222,
+          4230
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 156,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005635",
+          "name": "category",
+          "type": "Identifier",
+          "value": "category"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4248,
+          4267
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 157,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005637",
+          "name": "descriptor",
+          "type": "Identifier",
+          "value": "service"
+        }
+      },
+      "undocumented": true,
+      "name": "descriptor",
+      "longname": "descriptor",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4325,
+          18898
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 165,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005641",
+          "name": "exports.createWarden",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "options"
+          ]
+        }
+      },
+      "undocumented": true,
+      "name": "createWarden",
+      "longname": "createWarden",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4332,
+          18898
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 165,
+        "columnno": 7,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005642",
+          "name": "createWarden",
+          "type": "FunctionDeclaration",
+          "paramnames": [
+            "options"
+          ]
+        },
+        "vars": {
+          "undefined": null,
+          "": null,
+          "services": "createWarden~services",
+          "dockerUtils": "createWarden~dockerUtils",
+          "logger": "createWarden~logger",
+          "serviceCatalog": "createWarden~serviceCatalog",
+          "fsModule": "createWarden~fsModule",
+          "trackedContainers": "createWarden~trackedContainers",
+          "networkName": "createWarden~networkName",
+          "DEBUG": "createWarden~DEBUG",
+          "SUPER_MODE": "createWarden~SUPER_MODE",
+          "hostServiceBase": "createWarden~hostServiceBase",
+          "bootOrder": "createWarden~bootOrder",
+          "dockerFactory": "createWarden~dockerFactory",
+          "hostDockerSockets": "createWarden~hostDockerSockets",
+          "detectKavitaDataMount": "createWarden~detectKavitaDataMount",
+          "api": "createWarden~api",
+          "api.resolveHostServiceUrl": "createWarden~api.resolveHostServiceUrl",
+          "api.startService": "createWarden~api.startService",
+          "api.listServices": "createWarden~api.listServices",
+          "api.installService": "createWarden~api.installService",
+          "api.installServices": "createWarden~api.installServices",
+          "api.bootMinimal": "createWarden~api.bootMinimal",
+          "api.bootFull": "createWarden~api.bootFull",
+          "api.shutdownAll": "createWarden~api.shutdownAll",
+          "api.init": "createWarden~api.init"
+        }
+      },
+      "undocumented": true,
+      "name": "createWarden",
+      "longname": "createWarden",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4390,
+          4419
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 167,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005651",
+          "name": "dockerInstance",
+          "type": "AssignmentPattern",
+          "value": "dockerInstance"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerInstance",
+      "longname": "dockerInstance",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4429,
+          4453
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 168,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005656",
+          "name": "services",
+          "type": "Identifier",
+          "value": "servicesOption"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4463,
+          4493
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 169,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005658",
+          "name": "dockerUtils",
+          "type": "Identifier",
+          "value": "dockerUtilsOption"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerUtils",
+      "longname": "dockerUtils",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4503,
+          4523
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 170,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005660",
+          "name": "logger",
+          "type": "Identifier",
+          "value": "loggerOption"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4533,
+          4550
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 171,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005662",
+          "name": "env",
+          "type": "AssignmentPattern",
+          "value": "env"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4560,
+          4602
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 172,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005668",
+          "name": "processExit",
+          "type": "AssignmentPattern",
+          "value": "processExit"
+        }
+      },
+      "undocumented": true,
+      "name": "processExit",
+      "longname": "processExit",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4612,
+          4642
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 173,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005678",
+          "name": "networkName",
+          "type": "Identifier",
+          "value": "networkNameOption"
+        }
+      },
+      "undocumented": true,
+      "name": "networkName",
+      "longname": "networkName",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4652,
+          4694
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 174,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005680",
+          "name": "trackedContainers",
+          "type": "Identifier",
+          "value": "trackedContainersOption"
+        }
+      },
+      "undocumented": true,
+      "name": "trackedContainers",
+      "longname": "trackedContainers",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4704,
+          4740
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 175,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005682",
+          "name": "superBootOrder",
+          "type": "Identifier",
+          "value": "superBootOrderOption"
+        }
+      },
+      "undocumented": true,
+      "name": "superBootOrder",
+      "longname": "superBootOrder",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4750,
+          4792
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 176,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005684",
+          "name": "hostDockerSockets",
+          "type": "Identifier",
+          "value": "hostDockerSocketsOption"
+        }
+      },
+      "undocumented": true,
+      "name": "hostDockerSockets",
+      "longname": "hostDockerSockets",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4802,
+          4852
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 177,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005686",
+          "name": "dockerSocketDetector",
+          "type": "AssignmentPattern",
+          "value": "dockerSocketDetector"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerSocketDetector",
+      "longname": "dockerSocketDetector",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4862,
+          4896
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 178,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005690",
+          "name": "dockerFactory",
+          "type": "Identifier",
+          "value": "dockerFactoryOption"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerFactory",
+      "longname": "dockerFactory",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4906,
+          4918
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 179,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005692",
+          "name": "fs",
+          "type": "Identifier",
+          "value": "fsOption"
+        }
+      },
+      "undocumented": true,
+      "name": "fs",
+      "longname": "fs",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4948,
+          4992
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 182,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005696",
+          "name": "services",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "createWarden~services",
+      "kind": "constant",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5004,
+          5057
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 183,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005702",
+          "name": "dockerUtils",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "dockerUtils",
+      "longname": "createWarden~dockerUtils",
+      "kind": "constant",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5069,
+          5111
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 184,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005708",
+          "name": "logger",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "createWarden~logger",
+      "kind": "constant",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5123,
+          5170
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 185,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005714",
+          "name": "serviceCatalog",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "serviceCatalog",
+      "longname": "createWarden~serviceCatalog",
+      "kind": "constant",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5182,
+          5207
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 186,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005720",
+          "name": "fsModule",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "fsModule",
+      "longname": "createWarden~fsModule",
+      "kind": "constant",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5220,
+          5276
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 188,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005726",
+          "name": "trackedContainers",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "trackedContainers",
+      "longname": "createWarden~trackedContainers",
+      "kind": "constant",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5288,
+          5338
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 189,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005733",
+          "name": "networkName",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "networkName",
+      "longname": "createWarden~networkName",
+      "kind": "constant",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5350,
+          5378
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 190,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005739",
+          "name": "DEBUG",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "DEBUG",
+      "longname": "createWarden~DEBUG",
+      "kind": "constant",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5390,
+          5420
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 191,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005747",
+          "name": "SUPER_MODE",
+          "type": "BinaryExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "SUPER_MODE",
+      "longname": "createWarden~SUPER_MODE",
+      "kind": "constant",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5432,
+          5492
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 192,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005753",
+          "name": "hostServiceBase",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceBase",
+      "longname": "createWarden~hostServiceBase",
+      "kind": "constant",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5504,
+          5683
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 193,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005761",
+          "name": "bootOrder",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "bootOrder",
+      "longname": "createWarden~bootOrder",
+      "kind": "constant",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5696,
+          5779
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 202,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005773",
+          "name": "dockerFactory",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "dockerFactory",
+      "longname": "createWarden~dockerFactory",
+      "kind": "constant",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5765,
+          5775
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 202,
+        "columnno": 79,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005782",
+          "name": "socketPath",
+          "type": "Identifier",
+          "value": "socketPath"
+        }
+      },
+      "undocumented": true,
+      "name": "socketPath",
+      "longname": "socketPath",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5792,
+          6020
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 204,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005785",
+          "name": "hostDockerSockets",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "hostDockerSockets",
+      "longname": "createWarden~hostDockerSockets",
+      "kind": "constant",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5938,
+          5941
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 206,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005807",
+          "name": "env",
+          "type": "Identifier",
+          "value": "env"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5943,
+          5955
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 206,
+        "columnno": 38,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005809",
+          "name": "fs",
+          "type": "Identifier",
+          "value": "fsModule"
+        }
+      },
+      "undocumented": true,
+      "name": "fs",
+      "longname": "fs",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6027,
+          11094
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 210,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005815",
+          "name": "detectKavitaDataMount",
+          "type": "FunctionDeclaration",
+          "paramnames": []
+        },
+        "vars": {
+          "contexts": "createWarden~detectKavitaDataMount~contexts",
+          "visitedSockets": "createWarden~detectKavitaDataMount~visitedSockets",
+          "primarySocketPath": "createWarden~detectKavitaDataMount~primarySocketPath",
+          "candidate": "createWarden~detectKavitaDataMount~candidate",
+          "stats": "createWarden~detectKavitaDataMount~stats",
+          "client": "createWarden~detectKavitaDataMount~client",
+          "foundContainer": "createWarden~detectKavitaDataMount~foundContainer",
+          "context": "createWarden~detectKavitaDataMount~context",
+          "contextLabel": "createWarden~detectKavitaDataMount~contextLabel",
+          "containers": "createWarden~detectKavitaDataMount~containers",
+          "kavitaContainer": "createWarden~detectKavitaDataMount~kavitaContainer",
+          "": null,
+          "inspected": "createWarden~detectKavitaDataMount~inspected",
+          "mounts": "createWarden~detectKavitaDataMount~mounts",
+          "dataMount": "createWarden~detectKavitaDataMount~dataMount",
+          "rawName": "createWarden~detectKavitaDataMount~rawName",
+          "cleanName": "createWarden~detectKavitaDataMount~cleanName",
+          "details": "createWarden~detectKavitaDataMount~details",
+          "suffix": "createWarden~detectKavitaDataMount~suffix"
+        }
+      },
+      "undocumented": true,
+      "name": "detectKavitaDataMount",
+      "longname": "createWarden~detectKavitaDataMount",
+      "kind": "function",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": [],
+      "async": true
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6100,
+          6113
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 212,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005821",
+          "name": "contexts",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "contexts",
+      "longname": "createWarden~detectKavitaDataMount~contexts",
+      "kind": "constant",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6133,
+          6159
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 213,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005825",
+          "name": "visitedSockets",
+          "type": "NewExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "visitedSockets",
+      "longname": "createWarden~detectKavitaDataMount~visitedSockets",
+      "kind": "constant",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6180,
+          6313
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 215,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005830",
+          "name": "primarySocketPath",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "primarySocketPath",
+      "longname": "createWarden~detectKavitaDataMount~primarySocketPath",
+      "kind": "constant",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6360,
+          6382
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 220,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005845",
+          "name": "client",
+          "type": "Identifier",
+          "value": "dockerInstance"
+        }
+      },
+      "undocumented": true,
+      "name": "client",
+      "longname": "client",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6400,
+          6429
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 221,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005847",
+          "name": "socketPath",
+          "type": "Identifier",
+          "value": "primarySocketPath"
+        }
+      },
+      "undocumented": true,
+      "name": "socketPath",
+      "longname": "socketPath",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6447,
+          6479
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 222,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005849",
+          "name": "label",
+          "type": "Literal",
+          "value": "default Docker instance"
+        }
+      },
+      "undocumented": true,
+      "name": "label",
+      "longname": "label",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6628,
+          6637
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 229,
+        "columnno": 23,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005862",
+          "name": "candidate"
+        }
+      },
+      "undocumented": true,
+      "name": "candidate",
+      "longname": "createWarden~detectKavitaDataMount~candidate",
+      "kind": "constant",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7222,
+          7258
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 246,
+        "columnno": 30,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005905",
+          "name": "stats",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "stats",
+      "longname": "createWarden~detectKavitaDataMount~stats",
+      "kind": "constant",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7567,
+          7600
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 256,
+        "columnno": 26,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005930",
+          "name": "client",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "client",
+      "longname": "createWarden~detectKavitaDataMount~client",
+      "kind": "constant",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7676,
+          7682
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 258,
+        "columnno": 40,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005944",
+          "name": "client",
+          "type": "Identifier",
+          "value": "client"
+        }
+      },
+      "undocumented": true,
+      "name": "client",
+      "longname": "client",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7684,
+          7705
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 258,
+        "columnno": 48,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005946",
+          "name": "socketPath",
+          "type": "Identifier",
+          "value": "candidate"
+        }
+      },
+      "undocumented": true,
+      "name": "socketPath",
+      "longname": "socketPath",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7707,
+          7735
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 258,
+        "columnno": 71,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005948",
+          "name": "label",
+          "type": "TemplateLiteral",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "label",
+      "longname": "label",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8022,
+          8044
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 266,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005974",
+          "name": "foundContainer",
+          "type": "Literal",
+          "value": false
+        }
+      },
+      "undocumented": true,
+      "name": "foundContainer",
+      "longname": "createWarden~detectKavitaDataMount~foundContainer",
+      "kind": "member",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8070,
+          8077
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 268,
+        "columnno": 23,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005979",
+          "name": "context"
+        }
+      },
+      "undocumented": true,
+      "name": "context",
+      "longname": "createWarden~detectKavitaDataMount~context",
+      "kind": "constant",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8115,
+          8197
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 269,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005984",
+          "name": "contextLabel",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "contextLabel",
+      "longname": "createWarden~detectKavitaDataMount~contextLabel",
+      "kind": "constant",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8248,
+          8311
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 272,
+        "columnno": 26,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006002",
+          "name": "containers",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "containers",
+      "longname": "createWarden~detectKavitaDataMount~containers",
+      "kind": "constant",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8299,
+          8308
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 272,
+        "columnno": 77,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006012",
+          "name": "all",
+          "type": "Literal",
+          "value": true
+        }
+      },
+      "undocumented": true,
+      "name": "all",
+      "longname": "all",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8339,
+          8859
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 273,
+        "columnno": 26,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006015",
+          "name": "kavitaContainer",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "kavitaContainer",
+      "longname": "createWarden~detectKavitaDataMount~kavitaContainer",
+      "kind": "constant",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8418,
+          8499
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 274,
+        "columnno": 30,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006025",
+          "name": "image",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "<anonymous>~image",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8655,
+          8717
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 279,
+        "columnno": 30,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006049",
+          "name": "names",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "names",
+      "longname": "<anonymous>~names",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8983,
+          9004
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 287,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006087",
+          "name": "foundContainer",
+          "type": "Literal",
+          "funcscope": "createWarden~detectKavitaDataMount",
+          "value": true,
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "foundContainer",
+      "longname": "createWarden~detectKavitaDataMount~foundContainer",
+      "kind": "member",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9033,
+          9158
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 289,
+        "columnno": 26,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006091",
+          "name": "inspected",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "inspected",
+      "longname": "createWarden~detectKavitaDataMount~inspected",
+      "kind": "constant",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9186,
+          9218
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 292,
+        "columnno": 26,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006107",
+          "name": "mounts",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "mounts",
+      "longname": "createWarden~detectKavitaDataMount~mounts",
+      "kind": "constant",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9246,
+          9310
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 293,
+        "columnno": 26,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006113",
+          "name": "dataMount",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "dataMount",
+      "longname": "createWarden~detectKavitaDataMount~dataMount",
+      "kind": "constant",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9388,
+          9547
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 296,
+        "columnno": 30,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006128",
+          "name": "rawName",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "rawName",
+      "longname": "createWarden~detectKavitaDataMount~rawName",
+      "kind": "constant",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9579,
+          9654
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 299,
+        "columnno": 30,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006145",
+          "name": "cleanName",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "cleanName",
+      "longname": "createWarden~detectKavitaDataMount~cleanName",
+      "kind": "constant",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9687,
+          9699
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 301,
+        "columnno": 30,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006160",
+          "name": "details",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "details",
+      "longname": "createWarden~detectKavitaDataMount~details",
+      "kind": "constant",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9995,
+          10052
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 311,
+        "columnno": 30,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006185",
+          "name": "suffix",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "suffix",
+      "longname": "createWarden~detectKavitaDataMount~suffix",
+      "kind": "constant",
+      "memberof": "createWarden~detectKavitaDataMount",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10225,
+          10252
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 316,
+        "columnno": 28,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006215",
+          "name": "mountPath",
+          "type": "MemberExpression",
+          "value": "dataMount.Source"
+        }
+      },
+      "undocumented": true,
+      "name": "mountPath",
+      "longname": "mountPath",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10282,
+          10320
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 317,
+        "columnno": 28,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006219",
+          "name": "socketPath",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "socketPath",
+      "longname": "socketPath",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10350,
+          10389
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 318,
+        "columnno": 28,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006225",
+          "name": "containerId",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "containerId",
+      "longname": "containerId",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10419,
+          10451
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 319,
+        "columnno": 28,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006231",
+          "name": "containerName",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "containerName",
+      "longname": "containerName",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11106,
+          11202
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 339,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006283",
+          "name": "api",
+          "type": "ObjectExpression",
+          "value": "{\"trackedContainers\":\"\",\"networkName\":\"\",\"DEBUG\":\"\",\"SUPER_MODE\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "api",
+      "longname": "createWarden~api",
+      "kind": "constant",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11122,
+          11139
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 340,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006286",
+          "name": "trackedContainers",
+          "type": "Identifier",
+          "value": "trackedContainers"
+        }
+      },
+      "undocumented": true,
+      "name": "trackedContainers",
+      "longname": "createWarden~api.trackedContainers",
+      "kind": "member",
+      "memberof": "createWarden~api",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11149,
+          11160
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 341,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006288",
+          "name": "networkName",
+          "type": "Identifier",
+          "value": "networkName"
+        }
+      },
+      "undocumented": true,
+      "name": "networkName",
+      "longname": "createWarden~api.networkName",
+      "kind": "member",
+      "memberof": "createWarden~api",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11170,
+          11175
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 342,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006290",
+          "name": "DEBUG",
+          "type": "Identifier",
+          "value": "DEBUG"
+        }
+      },
+      "undocumented": true,
+      "name": "DEBUG",
+      "longname": "createWarden~api.DEBUG",
+      "kind": "member",
+      "memberof": "createWarden~api",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11185,
+          11195
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 343,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006292",
+          "name": "SUPER_MODE",
+          "type": "Identifier",
+          "value": "SUPER_MODE"
+        }
+      },
+      "undocumented": true,
+      "name": "SUPER_MODE",
+      "longname": "createWarden~api.SUPER_MODE",
+      "kind": "member",
+      "memberof": "createWarden~api",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11209,
+          11553
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 346,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006295",
+          "name": "api.resolveHostServiceUrl",
+          "type": "FunctionExpression",
+          "funcscope": "createWarden",
+          "value": "resolveHostServiceUrl",
+          "paramnames": [
+            "service"
+          ]
+        }
+      },
+      "undocumented": true,
+      "name": "resolveHostServiceUrl",
+      "longname": "createWarden~api.resolveHostServiceUrl",
+      "kind": "function",
+      "memberof": "createWarden~api",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11560,
+          12486
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 362,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006335",
+          "name": "api.startService",
+          "type": "FunctionExpression",
+          "funcscope": "createWarden",
+          "value": "startService",
+          "paramnames": [
+            "service",
+            "healthUrl"
+          ]
+        },
+        "vars": {
+          "hostServiceUrl": "createWarden~api.startService~hostServiceUrl",
+          "alreadyRunning": "createWarden~api.startService~alreadyRunning"
+        }
+      },
+      "undocumented": true,
+      "name": "startService",
+      "longname": "createWarden~api.startService",
+      "kind": "function",
+      "memberof": "createWarden~api",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11749,
+          11800
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 367,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006355",
+          "name": "hostServiceUrl",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "createWarden~api.startService~hostServiceUrl",
+      "kind": "constant",
+      "memberof": "createWarden~api.startService",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11816,
+          11880
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 368,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006363",
+          "name": "alreadyRunning",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "alreadyRunning",
+      "longname": "createWarden~api.startService~alreadyRunning",
+      "kind": "constant",
+      "memberof": "createWarden~api.startService",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12493,
+          13813
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 388,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006450",
+          "name": "api.listServices",
+          "type": "FunctionExpression",
+          "funcscope": "createWarden",
+          "value": "listServices",
+          "paramnames": [
+            "options"
+          ]
+        },
+        "vars": {
+          "undefined": null,
+          "formatted": "createWarden~api.listServices~formatted",
+          "": null,
+          "entries": "createWarden~api.listServices~entries"
+        }
+      },
+      "undocumented": true,
+      "name": "listServices",
+      "longname": "createWarden~api.listServices",
+      "kind": "function",
+      "memberof": "createWarden~api",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12572,
+          12595
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 389,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006463",
+          "name": "includeInstalled",
+          "type": "AssignmentPattern",
+          "value": "includeInstalled"
+        }
+      },
+      "undocumented": true,
+      "name": "includeInstalled",
+      "longname": "includeInstalled",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12624,
+          13131
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 391,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006469",
+          "name": "formatted",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "formatted",
+      "longname": "createWarden~api.listServices~formatted",
+      "kind": "constant",
+      "memberof": "createWarden~api.listServices",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12692,
+          12700
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 392,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006486",
+          "name": "category",
+          "type": "Identifier",
+          "value": "category"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12702,
+          12712
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 392,
+        "columnno": 30,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006488",
+          "name": "descriptor",
+          "type": "Identifier",
+          "value": "descriptor"
+        }
+      },
+      "undocumented": true,
+      "name": "descriptor",
+      "longname": "descriptor",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12738,
+          12759
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 393,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006491",
+          "name": "name",
+          "type": "MemberExpression",
+          "value": "descriptor.name"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12777,
+          12785
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 394,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006495",
+          "name": "category",
+          "type": "Identifier",
+          "value": "category"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12803,
+          12826
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 395,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006497",
+          "name": "image",
+          "type": "MemberExpression",
+          "value": "descriptor.image"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12844,
+          12873
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 396,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006501",
+          "name": "port",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12891,
+          12944
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 397,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006507",
+          "name": "hostServiceUrl",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "hostServiceUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12962,
+          13005
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 398,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006513",
+          "name": "description",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "description",
+      "longname": "description",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13023,
+          13056
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 399,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006519",
+          "name": "health",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "health",
+      "longname": "health",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13148,
+          13662
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 403,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006539",
+          "name": "entries",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "entries",
+      "longname": "createWarden~api.listServices~entries",
+      "kind": "constant",
+      "memberof": "createWarden~api.listServices",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13244,
+          13261
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 405,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006554",
+          "name": "installed",
+          "type": "Literal",
+          "value": false
+        }
+      },
+      "undocumented": true,
+      "name": "installed",
+      "longname": "<anonymous>~installed",
+      "kind": "member",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13306,
+          13365
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 408,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006560",
+          "name": "installed",
+          "type": "AwaitExpression",
+          "funcscope": "<anonymous>",
+          "value": "",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "installed",
+      "longname": "<anonymous>~installed",
+      "kind": "member",
+      "memberof": "<anonymous>",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13624,
+          13633
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 415,
+        "columnno": 37,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006577",
+          "name": "installed",
+          "type": "Identifier",
+          "value": "installed"
+        }
+      },
+      "undocumented": true,
+      "name": "installed",
+      "longname": "installed",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13820,
+          15714
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 426,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006597",
+          "name": "api.installService",
+          "type": "FunctionExpression",
+          "funcscope": "createWarden",
+          "value": "installService",
+          "paramnames": [
+            "name"
+          ]
+        },
+        "vars": {
+          "trimmedName": "createWarden~api.installService~trimmedName",
+          "entry": "createWarden~api.installService~entry",
+          "undefined": null,
+          "healthUrl": "createWarden~api.installService~healthUrl",
+          "kavitaDetection": "createWarden~api.installService~kavitaDetection",
+          "kavitaDataMount": "createWarden~api.installService~kavitaDataMount",
+          "serviceDescriptor": "createWarden~api.installService~serviceDescriptor",
+          "baseEnv": "createWarden~api.installService~baseEnv",
+          "volumes": "createWarden~api.installService~volumes",
+          "result": "createWarden~api.installService~result",
+          "result.kavitaDataMount": "createWarden~api.installService~result.kavitaDataMount",
+          "result.kavitaDetection": "createWarden~api.installService~result.kavitaDetection"
+        }
+      },
+      "undocumented": true,
+      "name": "installService",
+      "longname": "createWarden~api.installService",
+      "kind": "function",
+      "memberof": "createWarden~api",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14026,
+          14051
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 431,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006619",
+          "name": "trimmedName",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "trimmedName",
+      "longname": "createWarden~api.installService~trimmedName",
+      "kind": "constant",
+      "memberof": "createWarden~api.installService",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14067,
+          14106
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 432,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006626",
+          "name": "entry",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "entry",
+      "longname": "createWarden~api.installService~entry",
+      "kind": "constant",
+      "memberof": "createWarden~api.installService",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14244,
+          14254
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 438,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006647",
+          "name": "descriptor",
+          "type": "Identifier",
+          "value": "descriptor"
+        }
+      },
+      "undocumented": true,
+      "name": "descriptor",
+      "longname": "descriptor",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14256,
+          14264
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 438,
+        "columnno": 28,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006649",
+          "name": "category",
+          "type": "Identifier",
+          "value": "category"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14290,
+          14327
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 439,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006653",
+          "name": "healthUrl",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "healthUrl",
+      "longname": "createWarden~api.installService~healthUrl",
+      "kind": "constant",
+      "memberof": "createWarden~api.installService",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14341,
+          14363
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 440,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006661",
+          "name": "kavitaDetection",
+          "type": "Literal",
+          "value": null
+        }
+      },
+      "undocumented": true,
+      "name": "kavitaDetection",
+      "longname": "createWarden~api.installService~kavitaDetection",
+      "kind": "member",
+      "memberof": "createWarden~api.installService",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14377,
+          14399
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 441,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006665",
+          "name": "kavitaDataMount",
+          "type": "Literal",
+          "value": null
+        }
+      },
+      "undocumented": true,
+      "name": "kavitaDataMount",
+      "longname": "createWarden~api.installService~kavitaDataMount",
+      "kind": "member",
+      "memberof": "createWarden~api.installService",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14413,
+          14443
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 442,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006669",
+          "name": "serviceDescriptor",
+          "type": "Identifier",
+          "value": "descriptor"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceDescriptor",
+      "longname": "createWarden~api.installService~serviceDescriptor",
+      "kind": "member",
+      "memberof": "createWarden~api.installService",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14507,
+          14554
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 445,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006680",
+          "name": "kavitaDetection",
+          "type": "AwaitExpression",
+          "funcscope": "createWarden~api.installService",
+          "value": "",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "kavitaDetection",
+      "longname": "createWarden~api.installService~kavitaDetection",
+      "kind": "member",
+      "memberof": "createWarden~api.installService",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14568,
+          14620
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 446,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006686",
+          "name": "kavitaDataMount",
+          "type": "LogicalExpression",
+          "funcscope": "createWarden~api.installService",
+          "value": "",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "kavitaDataMount",
+      "longname": "createWarden~api.installService~kavitaDataMount",
+      "kind": "member",
+      "memberof": "createWarden~api.installService",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14680,
+          14746
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 449,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006695",
+          "name": "baseEnv",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "baseEnv",
+      "longname": "createWarden~api.installService~baseEnv",
+      "kind": "constant",
+      "memberof": "createWarden~api.installService",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14770,
+          14844
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 450,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006712",
+          "name": "volumes",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "volumes",
+      "longname": "createWarden~api.installService~volumes",
+      "kind": "constant",
+      "memberof": "createWarden~api.installService",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15017,
+          15154
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 455,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006745",
+          "name": "serviceDescriptor",
+          "type": "ObjectExpression",
+          "funcscope": "createWarden~api.installService",
+          "value": "{\"env\":\"\",\"volumes\":\"\"}",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "serviceDescriptor",
+      "longname": "createWarden~api.installService~serviceDescriptor",
+      "kind": "member",
+      "memberof": "createWarden~api.installService",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15094,
+          15106
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 457,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006750",
+          "name": "env",
+          "type": "Identifier",
+          "value": "baseEnv"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "createWarden~api.installService~serviceDescriptor.env",
+      "kind": "member",
+      "memberof": "createWarden~api.installService~serviceDescriptor",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15128,
+          15135
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 458,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006752",
+          "name": "volumes",
+          "type": "Identifier",
+          "value": "volumes"
+        }
+      },
+      "undocumented": true,
+      "name": "volumes",
+      "longname": "createWarden~api.installService~serviceDescriptor.volumes",
+      "kind": "member",
+      "memberof": "createWarden~api.installService~serviceDescriptor",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15258,
+          15515
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 465,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006763",
+          "name": "result",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"\",\"category\":\"\",\"status\":\"installed\",\"hostServiceUrl\":\"\",\"image\":\"\",\"port\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "result",
+      "longname": "createWarden~api.installService~result",
+      "kind": "constant",
+      "memberof": "createWarden~api.installService",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15281,
+          15302
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 466,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006766",
+          "name": "name",
+          "type": "MemberExpression",
+          "value": "descriptor.name"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "createWarden~api.installService~result.name",
+      "kind": "member",
+      "memberof": "createWarden~api.installService~result",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15316,
+          15324
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 467,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006770",
+          "name": "category",
+          "type": "Identifier",
+          "value": "category"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "createWarden~api.installService~result.category",
+      "kind": "member",
+      "memberof": "createWarden~api.installService~result",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15338,
+          15357
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 468,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006772",
+          "name": "status",
+          "type": "Literal",
+          "value": "installed"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "createWarden~api.installService~result.status",
+      "kind": "member",
+      "memberof": "createWarden~api.installService~result",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15371,
+          15424
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 469,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006774",
+          "name": "hostServiceUrl",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "createWarden~api.installService~result.hostServiceUrl",
+      "kind": "member",
+      "memberof": "createWarden~api.installService~result",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15438,
+          15461
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 470,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006780",
+          "name": "image",
+          "type": "MemberExpression",
+          "value": "descriptor.image"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "createWarden~api.installService~result.image",
+      "kind": "member",
+      "memberof": "createWarden~api.installService~result",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15475,
+          15504
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 471,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006784",
+          "name": "port",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "createWarden~api.installService~result.port",
+      "kind": "member",
+      "memberof": "createWarden~api.installService~result",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15579,
+          15619
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 475,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006798",
+          "name": "result.kavitaDataMount",
+          "type": "Identifier",
+          "funcscope": "createWarden~api.installService",
+          "value": "kavitaDataMount",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "kavitaDataMount",
+      "longname": "createWarden~api.installService~result.kavitaDataMount",
+      "kind": "member",
+      "memberof": "createWarden~api.installService~result",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15633,
+          15673
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 476,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006804",
+          "name": "result.kavitaDetection",
+          "type": "Identifier",
+          "funcscope": "createWarden~api.installService",
+          "value": "kavitaDetection",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "kavitaDetection",
+      "longname": "createWarden~api.installService~result.kavitaDetection",
+      "kind": "member",
+      "memberof": "createWarden~api.installService~result",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15721,
+          16558
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 482,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006812",
+          "name": "api.installServices",
+          "type": "FunctionExpression",
+          "funcscope": "createWarden",
+          "value": "installServices",
+          "paramnames": [
+            "names"
+          ]
+        },
+        "vars": {
+          "results": "createWarden~api.installServices~results",
+          "candidate": "createWarden~api.installServices~candidate",
+          "name": "createWarden~api.installServices~name",
+          "result": "createWarden~api.installServices~result"
+        }
+      },
+      "undocumented": true,
+      "name": "installServices",
+      "longname": "createWarden~api.installServices",
+      "kind": "function",
+      "memberof": "createWarden~api",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15802,
+          15814
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 483,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006823",
+          "name": "results",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "results",
+      "longname": "createWarden~api.installServices~results",
+      "kind": "constant",
+      "memberof": "createWarden~api.installServices",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15836,
+          15845
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 485,
+        "columnno": 19,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006828",
+          "name": "candidate"
+        }
+      },
+      "undocumented": true,
+      "name": "candidate",
+      "longname": "createWarden~api.installServices~candidate",
+      "kind": "constant",
+      "memberof": "createWarden~api.installServices",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15876,
+          15936
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 486,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006833",
+          "name": "name",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "createWarden~api.installServices~name",
+      "kind": "constant",
+      "memberof": "createWarden~api.installServices",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16015,
+          16038
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 490,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006855",
+          "name": "name",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16060,
+          16075
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 491,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006859",
+          "name": "status",
+          "type": "Literal",
+          "value": "error"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16097,
+          16136
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 492,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006861",
+          "name": "error",
+          "type": "Literal",
+          "value": "Invalid service name provided."
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16239,
+          16278
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 498,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006867",
+          "name": "result",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "result",
+      "longname": "createWarden~api.installServices~result",
+      "kind": "constant",
+      "memberof": "createWarden~api.installServices",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16399,
+          16403
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 502,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006888",
+          "name": "name",
+          "type": "Identifier",
+          "value": "name"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16425,
+          16440
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 503,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006890",
+          "name": "status",
+          "type": "Literal",
+          "value": "error"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16462,
+          16482
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 504,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006892",
+          "name": "error",
+          "type": "MemberExpression",
+          "value": "error.message"
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16565,
+          16976
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 512,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006899",
+          "name": "api.bootMinimal",
+          "type": "FunctionExpression",
+          "funcscope": "createWarden",
+          "value": "bootMinimal",
+          "paramnames": []
+        },
+        "vars": {
+          "redis": "createWarden~api.bootMinimal~redis",
+          "moon": "createWarden~api.bootMinimal~moon",
+          "sage": "createWarden~api.bootMinimal~sage"
+        }
+      },
+      "undocumented": true,
+      "name": "bootMinimal",
+      "longname": "createWarden~api.bootMinimal",
+      "kind": "function",
+      "memberof": "createWarden~api",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16628,
+          16665
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 513,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006907",
+          "name": "redis",
+          "type": "MemberExpression",
+          "value": "services.addon['noona-redis']"
+        }
+      },
+      "undocumented": true,
+      "name": "redis",
+      "longname": "createWarden~api.bootMinimal~redis",
+      "kind": "constant",
+      "memberof": "createWarden~api.bootMinimal",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16681,
+          16715
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 514,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006915",
+          "name": "moon",
+          "type": "MemberExpression",
+          "value": "services.core['noona-moon']"
+        }
+      },
+      "undocumented": true,
+      "name": "moon",
+      "longname": "createWarden~api.bootMinimal~moon",
+      "kind": "constant",
+      "memberof": "createWarden~api.bootMinimal",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16731,
+          16765
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 515,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006923",
+          "name": "sage",
+          "type": "MemberExpression",
+          "value": "services.core['noona-sage']"
+        }
+      },
+      "undocumented": true,
+      "name": "sage",
+      "longname": "createWarden~api.bootMinimal~sage",
+      "kind": "constant",
+      "memberof": "createWarden~api.bootMinimal",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16983,
+          17702
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 522,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006955",
+          "name": "api.bootFull",
+          "type": "FunctionExpression",
+          "funcscope": "createWarden",
+          "value": "bootFull",
+          "paramnames": []
+        },
+        "vars": {
+          "servicesMap": "createWarden~api.bootFull~servicesMap",
+          "name": "createWarden~api.bootFull~name",
+          "svc": "createWarden~api.bootFull~svc",
+          "healthUrl": "createWarden~api.bootFull~healthUrl"
+        }
+      },
+      "undocumented": true,
+      "name": "bootFull",
+      "longname": "createWarden~api.bootFull",
+      "kind": "function",
+      "memberof": "createWarden~api",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          17040,
+          17126
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 523,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006963",
+          "name": "servicesMap",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "servicesMap",
+      "longname": "createWarden~api.bootFull~servicesMap",
+      "kind": "constant",
+      "memberof": "createWarden~api.bootFull",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          17148,
+          17152
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 528,
+        "columnno": 19,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006976",
+          "name": "name"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "createWarden~api.bootFull~name",
+      "kind": "constant",
+      "memberof": "createWarden~api.bootFull",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          17187,
+          17210
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 529,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006981",
+          "name": "svc",
+          "type": "MemberExpression",
+          "value": "servicesMap[undefined]"
+        }
+      },
+      "undocumented": true,
+      "name": "svc",
+      "longname": "createWarden~api.bootFull~svc",
+      "kind": "constant",
+      "memberof": "createWarden~api.bootFull",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          17386,
+          17632
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 535,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007001",
+          "name": "healthUrl",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "healthUrl",
+      "longname": "createWarden~api.bootFull~healthUrl",
+      "kind": "constant",
+      "memberof": "createWarden~api.bootFull",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          17709,
+          18276
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 546,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007027",
+          "name": "api.shutdownAll",
+          "type": "FunctionExpression",
+          "funcscope": "createWarden",
+          "value": "shutdownAll",
+          "paramnames": []
+        },
+        "vars": {
+          "name": "createWarden~api.shutdownAll~name",
+          "container": "createWarden~api.shutdownAll~container"
+        }
+      },
+      "undocumented": true,
+      "name": "shutdownAll",
+      "longname": "createWarden~api.shutdownAll",
+      "kind": "function",
+      "memberof": "createWarden~api",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          17833,
+          17837
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 548,
+        "columnno": 19,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007043",
+          "name": "name"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "createWarden~api.shutdownAll~name",
+      "kind": "constant",
+      "memberof": "createWarden~api.shutdownAll",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          17902,
+          17947
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 550,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007050",
+          "name": "container",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "container",
+      "longname": "createWarden~api.shutdownAll~container",
+      "kind": "constant",
+      "memberof": "createWarden~api.shutdownAll",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          18283,
+          18878
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 563,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007102",
+          "name": "api.init",
+          "type": "FunctionExpression",
+          "funcscope": "createWarden",
+          "value": "init",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "init",
+      "longname": "createWarden~api.init",
+      "kind": "function",
+      "memberof": "createWarden~api",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          18831,
+          18869
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 576,
+        "columnno": 17,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007162",
+          "name": "mode",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "mode",
+      "longname": "mode",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          18900,
+          18928
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 582,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007169",
+          "name": "module.exports",
+          "type": "Identifier"
+        }
+      },
+      "undocumented": true,
+      "name": "exports",
+      "longname": "module.exports",
+      "kind": "member",
+      "memberof": "module",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          184,
+          262
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 7,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007190",
+          "name": "defaultPort",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "defaultPort",
+      "longname": "defaultPort",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          271,
+          440
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 9,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007206",
+          "name": "DEFAULT_HEADERS",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"GET,POST,OPTIONS\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "DEFAULT_HEADERS",
+      "longname": "DEFAULT_HEADERS",
+      "kind": "constant",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          295,
+          329
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 10,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007209",
+          "name": "\"Access-Control-Allow-Origin\"",
+          "type": "Literal",
+          "value": "*"
+        }
+      },
+      "undocumented": true,
+      "name": "\"Access-Control-Allow-Origin\"",
+      "longname": "DEFAULT_HEADERS.\"Access-Control-Allow-Origin\"",
+      "kind": "member",
+      "memberof": "DEFAULT_HEADERS",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          335,
+          381
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 11,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007211",
+          "name": "\"Access-Control-Allow-Headers\"",
+          "type": "Literal",
+          "value": "Content-Type"
+        }
+      },
+      "undocumented": true,
+      "name": "\"Access-Control-Allow-Headers\"",
+      "longname": "DEFAULT_HEADERS.\"Access-Control-Allow-Headers\"",
+      "kind": "member",
+      "memberof": "DEFAULT_HEADERS",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          387,
+          437
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 12,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007213",
+          "name": "\"Access-Control-Allow-Methods\"",
+          "type": "Literal",
+          "value": "GET,POST,OPTIONS"
+        }
+      },
+      "undocumented": true,
+      "name": "\"Access-Control-Allow-Methods\"",
+      "longname": "DEFAULT_HEADERS.\"Access-Control-Allow-Methods\"",
+      "kind": "member",
+      "memberof": "DEFAULT_HEADERS",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          449,
+          546
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 15,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007216",
+          "name": "resolveLogger",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "resolveLogger",
+      "longname": "resolveLogger",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          492,
+          505
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 16,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007223",
+          "name": "error",
+          "type": "Identifier",
+          "value": "errMSG"
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          511,
+          514
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 17,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007225",
+          "name": "log",
+          "type": "Identifier",
+          "value": "log"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "log",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          520,
+          524
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 18,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007227",
+          "name": "warn",
+          "type": "Identifier",
+          "value": "warn"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "warn",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          555,
+          749
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 22,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007232",
+          "name": "sendJson",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "sendJson",
+      "longname": "sendJson",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          666,
+          700
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 25,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007248",
+          "name": "\"Content-Type\"",
+          "type": "Literal",
+          "value": "application/json"
+        }
+      },
+      "undocumented": true,
+      "name": "\"Content-Type\"",
+      "longname": "\"Content-Type\"",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          758,
+          1273
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 30,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007261",
+          "name": "parseJsonBody",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "parseJsonBody",
+      "longname": "parseJsonBody",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          828,
+          839
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 31,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007272",
+          "name": "chunks",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "chunks",
+      "longname": "<anonymous>~chunks",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1062,
+          1121
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 44,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007313",
+          "name": "parsed",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "parsed",
+      "longname": "<anonymous>~parsed",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1276,
+          4231
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 54,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007348",
+          "name": "exports.startWardenServer",
+          "type": "VariableDeclaration"
+        }
+      },
+      "undocumented": true,
+      "name": "startWardenServer",
+      "longname": "startWardenServer",
+      "kind": "constant",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1289,
+          4230
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 54,
+        "columnno": 13,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007350",
+          "name": "startWardenServer",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "logger": "startWardenServer~logger",
+          "server": "startWardenServer~server",
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "startWardenServer",
+      "longname": "startWardenServer",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1316,
+          1322
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 55,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007355",
+          "name": "warden",
+          "type": "Identifier",
+          "value": "warden"
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "warden",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1328,
+          1348
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 56,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007357",
+          "name": "port",
+          "type": "AssignmentPattern",
+          "value": "port"
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1354,
+          1377
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 57,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007362",
+          "name": "logger",
+          "type": "Identifier",
+          "value": "loggerOverrides"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1509,
+          1548
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 63,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007375",
+          "name": "logger",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "startWardenServer~logger",
+      "kind": "constant",
+      "memberof": "startWardenServer",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1561,
+          4083
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 65,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007381",
+          "name": "server",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "startWardenServer~server",
+      "kind": "constant",
+      "memberof": "startWardenServer",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1667,
+          1696
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 67,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007403",
+          "name": "error",
+          "type": "Literal",
+          "value": "Invalid request URL."
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1889,
+          1956
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 77,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007427",
+          "name": "url",
+          "type": "NewExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "url",
+      "longname": "<anonymous>~url",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2058,
+          2070
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 80,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007463",
+          "name": "status",
+          "type": "Literal",
+          "value": "ok"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2218,
+          2273
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 86,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007482",
+          "name": "includeParam",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "includeParam",
+      "longname": "<anonymous>~includeParam",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2297,
+          2450
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 87,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007492",
+          "name": "includeInstalled",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "includeInstalled",
+      "longname": "<anonymous>~includeInstalled",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2475,
+          2533
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 91,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007513",
+          "name": "services",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "<anonymous>~services",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2514,
+          2530
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 91,
+        "columnno": 61,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007521",
+          "name": "includeInstalled",
+          "type": "Identifier",
+          "value": "includeInstalled"
+        }
+      },
+      "undocumented": true,
+      "name": "includeInstalled",
+      "longname": "includeInstalled",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2572,
+          2580
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 92,
+        "columnno": 37,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007529",
+          "name": "services",
+          "type": "Identifier",
+          "value": "services"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2740,
+          2773
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 95,
+        "columnno": 37,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007549",
+          "name": "error",
+          "type": "Literal",
+          "value": "Unable to list services."
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2920,
+          2924
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 101,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007566",
+          "name": "body"
+        }
+      },
+      "undocumented": true,
+      "name": "body",
+      "longname": "<anonymous>~body",
+      "kind": "member",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2961,
+          2992
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 104,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007571",
+          "name": "body",
+          "type": "AwaitExpression",
+          "funcscope": "<anonymous>",
+          "value": "",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "body",
+      "longname": "<anonymous>~body",
+      "kind": "member",
+      "memberof": "<anonymous>",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3061,
+          3102
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 106,
+        "columnno": 37,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007584",
+          "name": "error",
+          "type": "Literal",
+          "value": "Request body must be valid JSON."
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3164,
+          3189
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 110,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007588",
+          "name": "services",
+          "type": "ChainExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "<anonymous>~services",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3298,
+          3354
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 113,
+        "columnno": 37,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007611",
+          "name": "error",
+          "type": "Literal",
+          "value": "Body must include a non-empty \"services\" array."
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3438,
+          3486
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 118,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007617",
+          "name": "results",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "results",
+      "longname": "<anonymous>~results",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3510,
+          3571
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 119,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007626",
+          "name": "hasErrors",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "hasErrors",
+      "longname": "<anonymous>~hasErrors",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3595,
+          3629
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 120,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007640",
+          "name": "statusCode",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "statusCode",
+      "longname": "<anonymous>~statusCode",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3675,
+          3682
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 121,
+        "columnno": 44,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007652",
+          "name": "results",
+          "type": "Identifier",
+          "value": "results"
+        }
+      },
+      "undocumented": true,
+      "name": "results",
+      "longname": "results",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3845,
+          3891
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 124,
+        "columnno": 37,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007672",
+          "name": "error",
+          "type": "Literal",
+          "value": "Failed to install requested services."
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4054,
+          4072
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 130,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007696",
+          "name": "error",
+          "type": "Literal",
+          "value": "Not Found"
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4219,
+          4225
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 137,
+        "columnno": 13,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007722",
+          "name": "server",
+          "type": "Identifier",
+          "value": "server"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4233,
+          4266
+        ],
+        "filename": "wardenServer.mjs",
+        "lineno": 140,
+        "columnno": 0,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007724",
+          "name": "module.exports",
+          "type": "Identifier"
+        }
+      },
+      "undocumented": true,
+      "name": "exports",
+      "longname": "module.exports",
+      "kind": "member",
+      "memberof": "module",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          347,
+          424
+        ],
+        "filename": "vaultTokens.test.mjs",
+        "lineno": 13,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007753",
+          "name": "stubRandom",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "stubRandom",
+      "longname": "<anonymous>~stubRandom",
+      "kind": "function",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          436,
+          488
+        ],
+        "filename": "vaultTokens.test.mjs",
+        "lineno": 14,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007763",
+          "name": "token",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "token",
+      "longname": "<anonymous>~token",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          720,
+          973
+        ],
+        "filename": "vaultTokens.test.mjs",
+        "lineno": 21,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007796",
+          "name": "registry",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "registry",
+      "longname": "<anonymous>~registry",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          813,
+          857
+        ],
+        "filename": "vaultTokens.test.mjs",
+        "lineno": 22,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007805",
+          "name": "env",
+          "type": "ObjectExpression",
+          "value": "{\"NOONA_SAGE_VAULT_TOKEN\":\"env-token\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          820,
+          855
+        ],
+        "filename": "vaultTokens.test.mjs",
+        "lineno": 22,
+        "columnno": 15,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007807",
+          "name": "NOONA_SAGE_VAULT_TOKEN",
+          "type": "Literal",
+          "value": "env-token"
+        }
+      },
+      "undocumented": true,
+      "name": "NOONA_SAGE_VAULT_TOKEN",
+      "longname": "env.NOONA_SAGE_VAULT_TOKEN",
+      "kind": "member",
+      "memberof": "env",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          867,
+          921
+        ],
+        "filename": "vaultTokens.test.mjs",
+        "lineno": 23,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007809",
+          "name": "defaults",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"custom-default-token\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "defaults",
+      "longname": "defaults",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          879,
+          919
+        ],
+        "filename": "vaultTokens.test.mjs",
+        "lineno": 23,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007811",
+          "name": "\"custom-service\"",
+          "type": "Literal",
+          "value": "custom-default-token"
+        }
+      },
+      "undocumented": true,
+      "name": "\"custom-service\"",
+      "longname": "defaults.\"custom-service\"",
+      "kind": "member",
+      "memberof": "defaults",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          931,
+          965
+        ],
+        "filename": "vaultTokens.test.mjs",
+        "lineno": 24,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007813",
+          "name": "generator",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "generator",
+      "longname": "generator",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1017,
+          1042
+        ],
+        "filename": "vaultTokens.test.mjs",
+        "lineno": 28,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007823",
+          "name": "\"noona-sage\"",
+          "type": "Literal",
+          "value": "env-token"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-sage\"",
+      "longname": "\"noona-sage\"",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1052,
+          1083
+        ],
+        "filename": "vaultTokens.test.mjs",
+        "lineno": 29,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007825",
+          "name": "\"noona-moon\"",
+          "type": "Literal",
+          "value": "generated-token"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-moon\"",
+      "longname": "\"noona-moon\"",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1093,
+          1133
+        ],
+        "filename": "vaultTokens.test.mjs",
+        "lineno": 30,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007827",
+          "name": "\"custom-service\"",
+          "type": "Literal",
+          "value": "custom-default-token"
+        }
+      },
+      "undocumented": true,
+      "name": "\"custom-service\"",
+      "longname": "\"custom-service\"",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1218,
+          1350
+        ],
+        "filename": "vaultTokens.test.mjs",
+        "lineno": 35,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007836",
+          "name": "registry",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "registry",
+      "longname": "<anonymous>~registry",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1308,
+          1342
+        ],
+        "filename": "vaultTokens.test.mjs",
+        "lineno": 36,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007847",
+          "name": "generator",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "generator",
+      "longname": "generator",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1386,
+          1426
+        ],
+        "filename": "vaultTokens.test.mjs",
+        "lineno": 39,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007857",
+          "name": "\"noona-portal\"",
+          "type": "Literal",
+          "value": "noona-portal-dev-token"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-portal\"",
+      "longname": "\"noona-portal\"",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1511,
+          1635
+        ],
+        "filename": "vaultTokens.test.mjs",
+        "lineno": 43,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007866",
+          "name": "map",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "map",
+      "longname": "<anonymous>~map",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1545,
+          1570
+        ],
+        "filename": "vaultTokens.test.mjs",
+        "lineno": 44,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007871",
+          "name": "\"noona-zeta\"",
+          "type": "Literal",
+          "value": " token-z "
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-zeta\"",
+      "longname": "\"noona-zeta\"",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1580,
+          1604
+        ],
+        "filename": "vaultTokens.test.mjs",
+        "lineno": 45,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007873",
+          "name": "\"noona-alpha\"",
+          "type": "Literal",
+          "value": "token-a"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-alpha\"",
+      "longname": "\"noona-alpha\"",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1796,
+          1811
+        ],
+        "filename": "vaultTokens.test.mjs",
+        "lineno": 53,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007893",
+          "name": "normalizeEnvKey",
+          "type": "Identifier",
+          "value": "normalizeEnvKey"
+        }
+      },
+      "undocumented": true,
+      "name": "normalizeEnvKey",
+      "longname": "normalizeEnvKey",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          255,
+          338
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 8,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007935",
+          "name": "warden",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "<anonymous>~warden",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          279,
+          312
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 8,
+        "columnno": 34,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007940",
+          "name": "services",
+          "type": "ObjectExpression",
+          "value": "{\"addon\":\"\",\"core\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          291,
+          300
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 8,
+        "columnno": 46,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007942",
+          "name": "addon",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "addon",
+      "longname": "services.addon",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          302,
+          310
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 8,
+        "columnno": 57,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007944",
+          "name": "core",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "core",
+      "longname": "services.core",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          314,
+          335
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 8,
+        "columnno": 69,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007946",
+          "name": "hostDockerSockets",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "hostDockerSockets",
+      "longname": "hostDockerSockets",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          350,
+          401
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 9,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007949",
+          "name": "service",
+          "type": "ObjectExpression",
+          "value": "{\"hostServiceUrl\":\"http://custom.local\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "service",
+      "longname": "<anonymous>~service",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          362,
+          399
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 9,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007952",
+          "name": "hostServiceUrl",
+          "type": "Literal",
+          "value": "http://custom.local"
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "<anonymous>~service.hostServiceUrl",
+      "kind": "member",
+      "memberof": "<anonymous>~service",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          577,
+          739
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 15,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007972",
+          "name": "warden",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "<anonymous>~warden",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          609,
+          642
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 16,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007977",
+          "name": "services",
+          "type": "ObjectExpression",
+          "value": "{\"addon\":\"\",\"core\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          621,
+          630
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 16,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007979",
+          "name": "addon",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "addon",
+      "longname": "services.addon",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          632,
+          640
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 16,
+        "columnno": 31,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007981",
+          "name": "core",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "core",
+      "longname": "services.core",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          652,
+          700
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 17,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007983",
+          "name": "env",
+          "type": "ObjectExpression",
+          "value": "{\"HOST_SERVICE_URL\":\"http://host.example\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          659,
+          698
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 17,
+        "columnno": 15,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007985",
+          "name": "HOST_SERVICE_URL",
+          "type": "Literal",
+          "value": "http://host.example"
+        }
+      },
+      "undocumented": true,
+      "name": "HOST_SERVICE_URL",
+      "longname": "env.HOST_SERVICE_URL",
+      "kind": "member",
+      "memberof": "env",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          710,
+          731
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 18,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007987",
+          "name": "hostDockerSockets",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "hostDockerSockets",
+      "longname": "hostDockerSockets",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          751,
+          775
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 20,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007990",
+          "name": "service",
+          "type": "ObjectExpression",
+          "value": "{\"port\":8080}"
+        }
+      },
+      "undocumented": true,
+      "name": "service",
+      "longname": "<anonymous>~service",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          763,
+          773
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 20,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100007993",
+          "name": "port",
+          "type": "Literal",
+          "value": 8080
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "<anonymous>~service.port",
+      "kind": "member",
+      "memberof": "<anonymous>~service",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          967,
+          977
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 26,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008013",
+          "name": "calls",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "calls",
+      "longname": "<anonymous>~calls",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          989,
+          1562
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 27,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008017",
+          "name": "dockerUtils",
+          "type": "ObjectExpression",
+          "value": "{\"ensureNetwork\":\"\",\"attachSelfToNetwork\":\"\",\"containerExists\":\"\",\"pullImageIfNeeded\":\"\",\"runContainerWithLogs\":\"\",\"waitForHealthyStatus\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerUtils",
+      "longname": "<anonymous>~dockerUtils",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1013,
+          1042
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 28,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008020",
+          "name": "ensureNetwork",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "ensureNetwork",
+      "longname": "<anonymous>~dockerUtils.ensureNetwork",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1052,
+          1087
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 29,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008023",
+          "name": "attachSelfToNetwork",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "attachSelfToNetwork",
+      "longname": "<anonymous>~dockerUtils.attachSelfToNetwork",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1097,
+          1131
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 30,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008026",
+          "name": "containerExists",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "containerExists",
+      "longname": "<anonymous>~dockerUtils.containerExists",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1141,
+          1229
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 31,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008029",
+          "name": "pullImageIfNeeded",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "pullImageIfNeeded",
+      "longname": "<anonymous>~dockerUtils.pullImageIfNeeded",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1239,
+          1446
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 34,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008041",
+          "name": "runContainerWithLogs",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "runContainerWithLogs",
+      "longname": "<anonymous>~dockerUtils.runContainerWithLogs",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1456,
+          1555
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 38,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008068",
+          "name": "waitForHealthyStatus",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "waitForHealthyStatus",
+      "longname": "<anonymous>~dockerUtils.waitForHealthyStatus",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1574,
+          1583
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 42,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008083",
+          "name": "logs",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "logs",
+      "longname": "<anonymous>~logs",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1595,
+          1859
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 43,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008087",
+          "name": "warden",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "<anonymous>~warden",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1627,
+          1638
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 44,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008092",
+          "name": "dockerUtils",
+          "type": "Identifier",
+          "value": "dockerUtils"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerUtils",
+      "longname": "dockerUtils",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1648,
+          1681
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 45,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008094",
+          "name": "services",
+          "type": "ObjectExpression",
+          "value": "{\"addon\":\"\",\"core\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1660,
+          1669
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 45,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008096",
+          "name": "addon",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "addon",
+      "longname": "services.addon",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1671,
+          1679
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 45,
+        "columnno": 31,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008098",
+          "name": "core",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "core",
+      "longname": "services.core",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1691,
+          1755
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 46,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008100",
+          "name": "logger",
+          "type": "ObjectExpression",
+          "value": "{\"log\":\"\",\"warn\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1701,
+          1737
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 46,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008102",
+          "name": "log",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "logger.log",
+      "kind": "function",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1739,
+          1753
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 46,
+        "columnno": 56,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008110",
+          "name": "warn",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "logger.warn",
+      "kind": "function",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1765,
+          1820
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 47,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008113",
+          "name": "env",
+          "type": "ObjectExpression",
+          "value": "{\"HOST_SERVICE_URL\":\"http://host\",\"DEBUG\":\"true\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1772,
+          1803
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 47,
+        "columnno": 15,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008115",
+          "name": "HOST_SERVICE_URL",
+          "type": "Literal",
+          "value": "http://host"
+        }
+      },
+      "undocumented": true,
+      "name": "HOST_SERVICE_URL",
+      "longname": "env.HOST_SERVICE_URL",
+      "kind": "member",
+      "memberof": "env",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1805,
+          1818
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 47,
+        "columnno": 48,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008117",
+          "name": "DEBUG",
+          "type": "Literal",
+          "value": "true"
+        }
+      },
+      "undocumented": true,
+      "name": "DEBUG",
+      "longname": "env.DEBUG",
+      "kind": "member",
+      "memberof": "env",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1830,
+          1851
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 48,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008119",
+          "name": "hostDockerSockets",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "hostDockerSockets",
+      "longname": "hostDockerSockets",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1872,
+          1944
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 51,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008122",
+          "name": "service",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-test\",\"image\":\"noona/test:latest\",\"port\":1234}"
+        }
+      },
+      "undocumented": true,
+      "name": "service",
+      "longname": "<anonymous>~service",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1884,
+          1902
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 51,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008125",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-test"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "<anonymous>~service.name",
+      "kind": "member",
+      "memberof": "<anonymous>~service",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1904,
+          1930
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 51,
+        "columnno": 42,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008127",
+          "name": "image",
+          "type": "Literal",
+          "value": "noona/test:latest"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "<anonymous>~service.image",
+      "kind": "member",
+      "memberof": "<anonymous>~service",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1932,
+          1942
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 51,
+        "columnno": 70,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008129",
+          "name": "port",
+          "type": "Literal",
+          "value": 1234
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "<anonymous>~service.port",
+      "kind": "member",
+      "memberof": "<anonymous>~service",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2443,
+          2889
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 64,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008193",
+          "name": "dockerUtils",
+          "type": "ObjectExpression",
+          "value": "{\"ensureNetwork\":\"\",\"attachSelfToNetwork\":\"\",\"containerExists\":\"\",\"pullImageIfNeeded\":\"\",\"runContainerWithLogs\":\"\",\"waitForHealthyStatus\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerUtils",
+      "longname": "<anonymous>~dockerUtils",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2467,
+          2496
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 65,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008196",
+          "name": "ensureNetwork",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "ensureNetwork",
+      "longname": "<anonymous>~dockerUtils.ensureNetwork",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2506,
+          2541
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 66,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008199",
+          "name": "attachSelfToNetwork",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "attachSelfToNetwork",
+      "longname": "<anonymous>~dockerUtils.attachSelfToNetwork",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2551,
+          2584
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 67,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008202",
+          "name": "containerExists",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "containerExists",
+      "longname": "<anonymous>~dockerUtils.containerExists",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2594,
+          2707
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 68,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008205",
+          "name": "pullImageIfNeeded",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "pullImageIfNeeded",
+      "longname": "<anonymous>~dockerUtils.pullImageIfNeeded",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2717,
+          2836
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 71,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008212",
+          "name": "runContainerWithLogs",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "runContainerWithLogs",
+      "longname": "<anonymous>~dockerUtils.runContainerWithLogs",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2846,
+          2882
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 74,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008219",
+          "name": "waitForHealthyStatus",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "waitForHealthyStatus",
+      "longname": "<anonymous>~dockerUtils.waitForHealthyStatus",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2901,
+          2910
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 76,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008223",
+          "name": "logs",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "logs",
+      "longname": "<anonymous>~logs",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2922,
+          3121
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 77,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008227",
+          "name": "warden",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "<anonymous>~warden",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2954,
+          2965
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 78,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008232",
+          "name": "dockerUtils",
+          "type": "Identifier",
+          "value": "dockerUtils"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerUtils",
+      "longname": "dockerUtils",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2975,
+          3008
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 79,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008234",
+          "name": "services",
+          "type": "ObjectExpression",
+          "value": "{\"addon\":\"\",\"core\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2987,
+          2996
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 79,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008236",
+          "name": "addon",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "addon",
+      "longname": "services.addon",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2998,
+          3006
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 79,
+        "columnno": 31,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008238",
+          "name": "core",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "core",
+      "longname": "services.core",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3018,
+          3082
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 80,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008240",
+          "name": "logger",
+          "type": "ObjectExpression",
+          "value": "{\"log\":\"\",\"warn\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3028,
+          3064
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 80,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008242",
+          "name": "log",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "logger.log",
+      "kind": "function",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3066,
+          3080
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 80,
+        "columnno": 56,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008250",
+          "name": "warn",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "logger.warn",
+      "kind": "function",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3092,
+          3113
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 81,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008253",
+          "name": "hostDockerSockets",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "hostDockerSockets",
+      "longname": "hostDockerSockets",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3156,
+          3174
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 84,
+        "columnno": 32,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008262",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-test"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3176,
+          3192
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 84,
+        "columnno": 52,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008264",
+          "name": "image",
+          "type": "Literal",
+          "value": "ignored"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3194,
+          3225
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 84,
+        "columnno": 70,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008266",
+          "name": "hostServiceUrl",
+          "type": "Literal",
+          "value": "http://custom"
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "hostServiceUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3490,
+          3510
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 91,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008307",
+          "name": "containerChecks",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "containerChecks",
+      "longname": "<anonymous>~containerChecks",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3522,
+          3680
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 92,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008311",
+          "name": "dockerUtils",
+          "type": "ObjectExpression",
+          "value": "{\"containerExists\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerUtils",
+      "longname": "<anonymous>~dockerUtils",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3546,
+          3673
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 93,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008314",
+          "name": "containerExists",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "containerExists",
+      "longname": "<anonymous>~dockerUtils.containerExists",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3692,
+          3705
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 98,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008329",
+          "name": "warnings",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "warnings",
+      "longname": "<anonymous>~warnings",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3717,
+          4450
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 99,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008333",
+          "name": "warden",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "<anonymous>~warden",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3749,
+          4257
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 100,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008338",
+          "name": "services",
+          "type": "ObjectExpression",
+          "value": "{\"addon\":\"\",\"core\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3773,
+          3901
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 101,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008340",
+          "name": "addon",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "addon",
+      "longname": "services.addon",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3798,
+          3886
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 102,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008342",
+          "name": "\"noona-redis\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-redis\",\"image\":\"redis\",\"port\":8001,\"description\":\"Cache\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-redis\"",
+      "longname": "services.addon.\"noona-redis\"",
+      "kind": "member",
+      "memberof": "services.addon",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3815,
+          3834
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 102,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008344",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-redis"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.addon.\"noona-redis\".name",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3836,
+          3850
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 102,
+        "columnno": 54,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008346",
+          "name": "image",
+          "type": "Literal",
+          "value": "redis"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "services.addon.\"noona-redis\".image",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3852,
+          3862
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 102,
+        "columnno": 70,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008348",
+          "name": "port",
+          "type": "Literal",
+          "value": 8001
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "services.addon.\"noona-redis\".port",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3864,
+          3884
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 102,
+        "columnno": 82,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008350",
+          "name": "description",
+          "type": "Literal",
+          "value": "Cache"
+        }
+      },
+      "undocumented": true,
+      "name": "description",
+      "longname": "services.addon.\"noona-redis\".description",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3915,
+          4246
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 104,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008352",
+          "name": "core",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "core",
+      "longname": "services.core",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3939,
+          4150
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 105,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008354",
+          "name": "\"noona-sage\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-sage\",\"image\":\"sage\",\"hostServiceUrl\":\"http://custom-sage\",\"health\":\"http://health\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-sage\"",
+      "longname": "services.core.\"noona-sage\"",
+      "kind": "member",
+      "memberof": "services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3975,
+          3993
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 106,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008356",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.core.\"noona-sage\".name",
+      "kind": "member",
+      "memberof": "services.core.\"noona-sage\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4015,
+          4028
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 107,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008358",
+          "name": "image",
+          "type": "Literal",
+          "value": "sage"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "services.core.\"noona-sage\".image",
+      "kind": "member",
+      "memberof": "services.core.\"noona-sage\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4050,
+          4086
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 108,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008360",
+          "name": "hostServiceUrl",
+          "type": "Literal",
+          "value": "http://custom-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "services.core.\"noona-sage\".hostServiceUrl",
+      "kind": "member",
+      "memberof": "services.core.\"noona-sage\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4108,
+          4131
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 109,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008362",
+          "name": "health",
+          "type": "Literal",
+          "value": "http://health"
+        }
+      },
+      "undocumented": true,
+      "name": "health",
+      "longname": "services.core.\"noona-sage\".health",
+      "kind": "member",
+      "memberof": "services.core.\"noona-sage\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4168,
+          4231
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 111,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008364",
+          "name": "\"noona-moon\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-moon\",\"image\":\"moon\",\"port\":3000}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-moon\"",
+      "longname": "services.core.\"noona-moon\"",
+      "kind": "member",
+      "memberof": "services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4184,
+          4202
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 111,
+        "columnno": 32,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008366",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-moon"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.core.\"noona-moon\".name",
+      "kind": "member",
+      "memberof": "services.core.\"noona-moon\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4204,
+          4217
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 111,
+        "columnno": 52,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008368",
+          "name": "image",
+          "type": "Literal",
+          "value": "moon"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "services.core.\"noona-moon\".image",
+      "kind": "member",
+      "memberof": "services.core.\"noona-moon\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4219,
+          4229
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 111,
+        "columnno": 67,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008370",
+          "name": "port",
+          "type": "Literal",
+          "value": 3000
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "services.core.\"noona-moon\".port",
+      "kind": "member",
+      "memberof": "services.core.\"noona-moon\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4267,
+          4278
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 114,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008372",
+          "name": "dockerUtils",
+          "type": "Identifier",
+          "value": "dockerUtils"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerUtils",
+      "longname": "dockerUtils",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4288,
+          4333
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 115,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008374",
+          "name": "env",
+          "type": "ObjectExpression",
+          "value": "{\"HOST_SERVICE_URL\":\"http://localhost\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "env",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4295,
+          4331
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 115,
+        "columnno": 15,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008376",
+          "name": "HOST_SERVICE_URL",
+          "type": "Literal",
+          "value": "http://localhost"
+        }
+      },
+      "undocumented": true,
+      "name": "HOST_SERVICE_URL",
+      "longname": "env.HOST_SERVICE_URL",
+      "kind": "member",
+      "memberof": "env",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4343,
+          4364
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 116,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008378",
+          "name": "hostDockerSockets",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "hostDockerSockets",
+      "longname": "hostDockerSockets",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4374,
+          4442
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 117,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008380",
+          "name": "logger",
+          "type": "ObjectExpression",
+          "value": "{\"warn\":\"\",\"log\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4384,
+          4425
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 117,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008382",
+          "name": "warn",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "logger.warn",
+      "kind": "function",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4427,
+          4440
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 117,
+        "columnno": 61,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008390",
+          "name": "log",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "logger.log",
+      "kind": "function",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4463,
+          4501
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 120,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008394",
+          "name": "services",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "<anonymous>~services",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4559,
+          4577
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 124,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008409",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-moon"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4591,
+          4607
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 125,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008411",
+          "name": "category",
+          "type": "Literal",
+          "value": "core"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4621,
+          4634
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 126,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008413",
+          "name": "image",
+          "type": "Literal",
+          "value": "moon"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4648,
+          4658
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 127,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008415",
+          "name": "port",
+          "type": "Literal",
+          "value": 3000
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4672,
+          4711
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 128,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008417",
+          "name": "hostServiceUrl",
+          "type": "Literal",
+          "value": "http://localhost:3000"
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "hostServiceUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4725,
+          4742
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 129,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008419",
+          "name": "description",
+          "type": "Literal",
+          "value": null
+        }
+      },
+      "undocumented": true,
+      "name": "description",
+      "longname": "description",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4756,
+          4768
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 130,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008421",
+          "name": "health",
+          "type": "Literal",
+          "value": null
+        }
+      },
+      "undocumented": true,
+      "name": "health",
+      "longname": "health",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4782,
+          4798
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 131,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008423",
+          "name": "installed",
+          "type": "Literal",
+          "value": false
+        }
+      },
+      "undocumented": true,
+      "name": "installed",
+      "longname": "installed",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4833,
+          4852
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 134,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008426",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-redis"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4866,
+          4883
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 135,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008428",
+          "name": "category",
+          "type": "Literal",
+          "value": "addon"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4897,
+          4911
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 136,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008430",
+          "name": "image",
+          "type": "Literal",
+          "value": "redis"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4925,
+          4935
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 137,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008432",
+          "name": "port",
+          "type": "Literal",
+          "value": 8001
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4949,
+          4988
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 138,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008434",
+          "name": "hostServiceUrl",
+          "type": "Literal",
+          "value": "http://localhost:8001"
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "hostServiceUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5002,
+          5022
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 139,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008436",
+          "name": "description",
+          "type": "Literal",
+          "value": "Cache"
+        }
+      },
+      "undocumented": true,
+      "name": "description",
+      "longname": "description",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5036,
+          5048
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 140,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008438",
+          "name": "health",
+          "type": "Literal",
+          "value": null
+        }
+      },
+      "undocumented": true,
+      "name": "health",
+      "longname": "health",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5062,
+          5077
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 141,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008440",
+          "name": "installed",
+          "type": "Literal",
+          "value": true
+        }
+      },
+      "undocumented": true,
+      "name": "installed",
+      "longname": "installed",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5112,
+          5130
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 144,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008443",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5144,
+          5160
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 145,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008445",
+          "name": "category",
+          "type": "Literal",
+          "value": "core"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5174,
+          5187
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 146,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008447",
+          "name": "image",
+          "type": "Literal",
+          "value": "sage"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5201,
+          5211
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 147,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008449",
+          "name": "port",
+          "type": "Literal",
+          "value": null
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5225,
+          5261
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 148,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008451",
+          "name": "hostServiceUrl",
+          "type": "Literal",
+          "value": "http://custom-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "hostServiceUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5275,
+          5292
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 149,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008453",
+          "name": "description",
+          "type": "Literal",
+          "value": null
+        }
+      },
+      "undocumented": true,
+      "name": "description",
+      "longname": "description",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5306,
+          5329
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 150,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008455",
+          "name": "health",
+          "type": "Literal",
+          "value": "http://health"
+        }
+      },
+      "undocumented": true,
+      "name": "health",
+      "longname": "health",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5343,
+          5359
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 151,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008457",
+          "name": "installed",
+          "type": "Literal",
+          "value": false
+        }
+      },
+      "undocumented": true,
+      "name": "installed",
+      "longname": "installed",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5513,
+          5581
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 157,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008479",
+          "name": "installable",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "installable",
+      "longname": "<anonymous>~installable",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5555,
+          5578
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 157,
+        "columnno": 52,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008487",
+          "name": "includeInstalled",
+          "type": "Literal",
+          "value": false
+        }
+      },
+      "undocumented": true,
+      "name": "includeInstalled",
+      "longname": "includeInstalled",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5795,
+          6123
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 165,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008513",
+          "name": "warden",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "<anonymous>~warden",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5827,
+          6084
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 166,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008518",
+          "name": "services",
+          "type": "ObjectExpression",
+          "value": "{\"addon\":\"\",\"core\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5851,
+          5957
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 167,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008520",
+          "name": "addon",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "addon",
+      "longname": "services.addon",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5876,
+          5942
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 168,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008522",
+          "name": "\"noona-redis\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-redis\",\"image\":\"redis\",\"port\":8001}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-redis\"",
+      "longname": "services.addon.\"noona-redis\"",
+      "kind": "member",
+      "memberof": "services.addon",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5893,
+          5912
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 168,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008524",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-redis"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.addon.\"noona-redis\".name",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5914,
+          5928
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 168,
+        "columnno": 54,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008526",
+          "name": "image",
+          "type": "Literal",
+          "value": "redis"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "services.addon.\"noona-redis\".image",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5930,
+          5940
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 168,
+        "columnno": 70,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008528",
+          "name": "port",
+          "type": "Literal",
+          "value": 8001
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "services.addon.\"noona-redis\".port",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5971,
+          6073
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 170,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008530",
+          "name": "core",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "core",
+      "longname": "services.core",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5995,
+          6058
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 171,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008532",
+          "name": "\"noona-sage\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-sage\",\"image\":\"sage\",\"port\":3004}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-sage\"",
+      "longname": "services.core.\"noona-sage\"",
+      "kind": "member",
+      "memberof": "services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6011,
+          6029
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 171,
+        "columnno": 32,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008534",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.core.\"noona-sage\".name",
+      "kind": "member",
+      "memberof": "services.core.\"noona-sage\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6031,
+          6044
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 171,
+        "columnno": 52,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008536",
+          "name": "image",
+          "type": "Literal",
+          "value": "sage"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "services.core.\"noona-sage\".image",
+      "kind": "member",
+      "memberof": "services.core.\"noona-sage\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6046,
+          6056
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 171,
+        "columnno": 67,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008538",
+          "name": "port",
+          "type": "Literal",
+          "value": 3004
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "services.core.\"noona-sage\".port",
+      "kind": "member",
+      "memberof": "services.core.\"noona-sage\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6094,
+          6115
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 174,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008540",
+          "name": "hostDockerSockets",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "hostDockerSockets",
+      "longname": "hostDockerSockets",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6136,
+          6148
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 177,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008543",
+          "name": "started",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "started",
+      "longname": "<anonymous>~started",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6154,
+          6238
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 178,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008547",
+          "name": "warden.startService",
+          "type": "ArrowFunctionExpression",
+          "funcscope": "<anonymous>",
+          "paramnames": [
+            "service"
+          ]
+        }
+      },
+      "undocumented": true,
+      "name": "startService",
+      "longname": "<anonymous>~warden.startService",
+      "kind": "function",
+      "memberof": "<anonymous>~warden",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6251,
+          6335
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 182,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008563",
+          "name": "results",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "results",
+      "longname": "<anonymous>~results",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6392,
+          6410
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 186,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008583",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6424,
+          6440
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 187,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008585",
+          "name": "category",
+          "type": "Literal",
+          "value": "core"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6454,
+          6473
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 188,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008587",
+          "name": "status",
+          "type": "Literal",
+          "value": "installed"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6487,
+          6526
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 189,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008589",
+          "name": "hostServiceUrl",
+          "type": "Literal",
+          "value": "http://localhost:3004"
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "hostServiceUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6540,
+          6553
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 190,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008591",
+          "name": "image",
+          "type": "Literal",
+          "value": "sage"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6567,
+          6577
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 191,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008593",
+          "name": "port",
+          "type": "Literal",
+          "value": 3004
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6612,
+          6631
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 194,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008596",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-redis"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6645,
+          6662
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 195,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008598",
+          "name": "category",
+          "type": "Literal",
+          "value": "addon"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6676,
+          6695
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 196,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008600",
+          "name": "status",
+          "type": "Literal",
+          "value": "installed"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6709,
+          6748
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 197,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008602",
+          "name": "hostServiceUrl",
+          "type": "Literal",
+          "value": "http://localhost:8001"
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "hostServiceUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6762,
+          6776
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 198,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008604",
+          "name": "image",
+          "type": "Literal",
+          "value": "redis"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6790,
+          6800
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 199,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008606",
+          "name": "port",
+          "type": "Literal",
+          "value": 8001
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6835,
+          6850
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 202,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008609",
+          "name": "name",
+          "type": "Literal",
+          "value": "unknown"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6864,
+          6879
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 203,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008611",
+          "name": "status",
+          "type": "Literal",
+          "value": "error"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6893,
+          6948
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 204,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008613",
+          "name": "error",
+          "type": "Literal",
+          "value": "Service unknown is not registered with Warden."
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6983,
+          6991
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 207,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008616",
+          "name": "name",
+          "type": "Literal",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7005,
+          7020
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 208,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008618",
+          "name": "status",
+          "type": "Literal",
+          "value": "error"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7034,
+          7073
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 209,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008620",
+          "name": "error",
+          "type": "Literal",
+          "value": "Invalid service name provided."
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7254,
+          7695
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 217,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008638",
+          "name": "dockerInstance",
+          "type": "ObjectExpression",
+          "value": "{\"listContainers\":\"\",\"getContainer\":\"\",\"modem\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerInstance",
+      "longname": "<anonymous>~dockerInstance",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7281,
+          7416
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 218,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008641",
+          "name": "listContainers",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "listContainers",
+      "longname": "<anonymous>~dockerInstance.listContainers",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerInstance",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7325,
+          7334
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 219,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008645",
+          "name": "Id",
+          "type": "Literal",
+          "value": "abc"
+        }
+      },
+      "undocumented": true,
+      "name": "Id",
+      "longname": "Id",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7336,
+          7374
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 219,
+        "columnno": 25,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008647",
+          "name": "Image",
+          "type": "Literal",
+          "value": "ghcr.io/example/kavita:latest"
+        }
+      },
+      "undocumented": true,
+      "name": "Image",
+      "longname": "Image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7376,
+          7403
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 219,
+        "columnno": 65,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008649",
+          "name": "Names",
+          "type": "ArrayExpression",
+          "value": "[\"/kavita-instance\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "Names",
+      "longname": "Names",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7426,
+          7633
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 221,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008652",
+          "name": "getContainer",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "getContainer",
+      "longname": "<anonymous>~dockerInstance.getContainer",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerInstance",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7463,
+          7621
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 222,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008656",
+          "name": "inspect",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "inspect",
+      "longname": "inspect",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7503,
+          7605
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 223,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008659",
+          "name": "Mounts",
+          "type": "ArrayExpression",
+          "value": "[\"{\\\"Destination\\\":\\\"/data\\\",\\\"Source\\\":\\\"/host/kavita-data\\\"}\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "Mounts",
+      "longname": "Mounts",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7535,
+          7555
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 224,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008662",
+          "name": "Destination",
+          "type": "Literal",
+          "value": "/data"
+        }
+      },
+      "undocumented": true,
+      "name": "Destination",
+      "longname": "Destination",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7557,
+          7584
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 224,
+        "columnno": 44,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008664",
+          "name": "Source",
+          "type": "Literal",
+          "value": "/host/kavita-data"
+        }
+      },
+      "undocumented": true,
+      "name": "Source",
+      "longname": "Source",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7643,
+          7688
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 228,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008666",
+          "name": "modem",
+          "type": "ObjectExpression",
+          "value": "{\"socketPath\":\"/var/run/docker.sock\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "modem",
+      "longname": "<anonymous>~dockerInstance.modem",
+      "kind": "member",
+      "memberof": "<anonymous>~dockerInstance",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7652,
+          7686
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 228,
+        "columnno": 17,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008668",
+          "name": "socketPath",
+          "type": "Literal",
+          "value": "/var/run/docker.sock"
+        }
+      },
+      "undocumented": true,
+      "name": "socketPath",
+      "longname": "<anonymous>~dockerInstance.modem.socketPath",
+      "kind": "member",
+      "memberof": "<anonymous>~dockerInstance.modem",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7707,
+          7949
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 230,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008671",
+          "name": "services",
+          "type": "ObjectExpression",
+          "value": "{\"addon\":\"\",\"core\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "<anonymous>~services",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7728,
+          7737
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 231,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008674",
+          "name": "addon",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "addon",
+      "longname": "<anonymous>~services.addon",
+      "kind": "member",
+      "memberof": "<anonymous>~services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7747,
+          7942
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 232,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008676",
+          "name": "core",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "core",
+      "longname": "<anonymous>~services.core",
+      "kind": "member",
+      "memberof": "<anonymous>~services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7767,
+          7931
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 233,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008678",
+          "name": "\"noona-raven\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-raven\",\"image\":\"captainpax/noona-raven:latest\",\"env\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-raven\"",
+      "longname": "<anonymous>~services.core.\"noona-raven\"",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7800,
+          7819
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 234,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008680",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-raven"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "<anonymous>~services.core.\"noona-raven\".name",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core.\"noona-raven\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7837,
+          7875
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 235,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008682",
+          "name": "image",
+          "type": "Literal",
+          "value": "captainpax/noona-raven:latest"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "<anonymous>~services.core.\"noona-raven\".image",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core.\"noona-raven\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7893,
+          7916
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 236,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008684",
+          "name": "env",
+          "type": "ArrayExpression",
+          "value": "[\"EXISTING_ENV=1\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "<anonymous>~services.core.\"noona-raven\".env",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core.\"noona-raven\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7962,
+          8116
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 241,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008688",
+          "name": "warden",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "<anonymous>~warden",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7994,
+          8008
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 242,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008693",
+          "name": "dockerInstance",
+          "type": "Identifier",
+          "value": "dockerInstance"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerInstance",
+      "longname": "dockerInstance",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8018,
+          8026
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 243,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008695",
+          "name": "services",
+          "type": "Identifier",
+          "value": "services"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8036,
+          8077
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 244,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008697",
+          "name": "logger",
+          "type": "ObjectExpression",
+          "value": "{\"log\":\"\",\"warn\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8046,
+          8059
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 244,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008699",
+          "name": "log",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "logger.log",
+      "kind": "function",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8061,
+          8075
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 244,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008702",
+          "name": "warn",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "logger.warn",
+      "kind": "function",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8087,
+          8108
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 245,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008705",
+          "name": "hostDockerSockets",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "hostDockerSockets",
+      "longname": "hostDockerSockets",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8127,
+          8149
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 248,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008708",
+          "name": "receivedService",
+          "type": "Literal",
+          "value": null
+        }
+      },
+      "undocumented": true,
+      "name": "receivedService",
+      "longname": "<anonymous>~receivedService",
+      "kind": "member",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8155,
+          8238
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 249,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008712",
+          "name": "warden.startService",
+          "type": "ArrowFunctionExpression",
+          "funcscope": "<anonymous>",
+          "paramnames": [
+            "service"
+          ]
+        },
+        "vars": {
+          "receivedService": "<anonymous>~warden.startService~receivedService"
+        }
+      },
+      "undocumented": true,
+      "name": "startService",
+      "longname": "<anonymous>~warden.startService",
+      "kind": "function",
+      "memberof": "<anonymous>~warden",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8206,
+          8231
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 250,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008720",
+          "name": "receivedService",
+          "type": "Identifier",
+          "funcscope": "<anonymous>~warden.startService",
+          "value": "service",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "receivedService",
+      "longname": "<anonymous>~warden.startService~receivedService",
+      "kind": "member",
+      "memberof": "<anonymous>~warden.startService",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8251,
+          8302
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 253,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008724",
+          "name": "result",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "result",
+      "longname": "<anonymous>~result",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8783,
+          8813
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 262,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008805",
+          "name": "mountPath",
+          "type": "Literal",
+          "value": "/host/kavita-data"
+        }
+      },
+      "undocumented": true,
+      "name": "mountPath",
+      "longname": "mountPath",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8823,
+          8857
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 263,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008807",
+          "name": "socketPath",
+          "type": "Literal",
+          "value": "/var/run/docker.sock"
+        }
+      },
+      "undocumented": true,
+      "name": "socketPath",
+      "longname": "socketPath",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8867,
+          8885
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 264,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008809",
+          "name": "containerId",
+          "type": "Literal",
+          "value": "abc"
+        }
+      },
+      "undocumented": true,
+      "name": "containerId",
+      "longname": "containerId",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8895,
+          8927
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 265,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008811",
+          "name": "containerName",
+          "type": "Literal",
+          "value": "kavita-instance"
+        }
+      },
+      "undocumented": true,
+      "name": "containerName",
+      "longname": "containerName",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9037,
+          9050
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 270,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008820",
+          "name": "listCalls",
+          "type": "Literal",
+          "value": 0
+        }
+      },
+      "undocumented": true,
+      "name": "listCalls",
+      "longname": "<anonymous>~listCalls",
+      "kind": "member",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9062,
+          9186
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 271,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008824",
+          "name": "dockerInstance",
+          "type": "ObjectExpression",
+          "value": "{\"listContainers\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerInstance",
+      "longname": "<anonymous>~dockerInstance",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9089,
+          9179
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 272,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008827",
+          "name": "listContainers",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "listCalls": "<anonymous>~dockerInstance.listContainers~listCalls"
+        }
+      },
+      "undocumented": true,
+      "name": "listContainers",
+      "longname": "<anonymous>~dockerInstance.listContainers",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerInstance",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9131,
+          9145
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 273,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008831",
+          "name": "listCalls",
+          "type": "Literal",
+          "funcscope": "<anonymous>~dockerInstance.listContainers",
+          "value": 1,
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "listCalls",
+      "longname": "<anonymous>~dockerInstance.listContainers~listCalls",
+      "kind": "member",
+      "memberof": "<anonymous>~dockerInstance.listContainers",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9198,
+          9436
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 277,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008837",
+          "name": "services",
+          "type": "ObjectExpression",
+          "value": "{\"addon\":\"\",\"core\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "<anonymous>~services",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9219,
+          9228
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 278,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008840",
+          "name": "addon",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "addon",
+      "longname": "<anonymous>~services.addon",
+      "kind": "member",
+      "memberof": "<anonymous>~services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9238,
+          9429
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 279,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008842",
+          "name": "core",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "core",
+      "longname": "<anonymous>~services.core",
+      "kind": "member",
+      "memberof": "<anonymous>~services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9258,
+          9418
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 280,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008844",
+          "name": "\"noona-raven\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-raven\",\"image\":\"captainpax/noona-raven:latest\",\"env\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-raven\"",
+      "longname": "<anonymous>~services.core.\"noona-raven\"",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9291,
+          9310
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 281,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008846",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-raven"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "<anonymous>~services.core.\"noona-raven\".name",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core.\"noona-raven\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9328,
+          9366
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 282,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008848",
+          "name": "image",
+          "type": "Literal",
+          "value": "captainpax/noona-raven:latest"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "<anonymous>~services.core.\"noona-raven\".image",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core.\"noona-raven\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9384,
+          9403
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 283,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008850",
+          "name": "env",
+          "type": "ArrayExpression",
+          "value": "[\"BASE_ENV=1\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "<anonymous>~services.core.\"noona-raven\".env",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core.\"noona-raven\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9449,
+          9603
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 288,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008854",
+          "name": "warden",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "<anonymous>~warden",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9481,
+          9495
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 289,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008859",
+          "name": "dockerInstance",
+          "type": "Identifier",
+          "value": "dockerInstance"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerInstance",
+      "longname": "dockerInstance",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9505,
+          9513
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 290,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008861",
+          "name": "services",
+          "type": "Identifier",
+          "value": "services"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9523,
+          9564
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 291,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008863",
+          "name": "logger",
+          "type": "ObjectExpression",
+          "value": "{\"log\":\"\",\"warn\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9533,
+          9546
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 291,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008865",
+          "name": "log",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "logger.log",
+      "kind": "function",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9548,
+          9562
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 291,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008868",
+          "name": "warn",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "logger.warn",
+      "kind": "function",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9574,
+          9595
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 292,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008871",
+          "name": "hostDockerSockets",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "hostDockerSockets",
+      "longname": "hostDockerSockets",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9614,
+          9636
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 295,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008874",
+          "name": "receivedService",
+          "type": "Literal",
+          "value": null
+        }
+      },
+      "undocumented": true,
+      "name": "receivedService",
+      "longname": "<anonymous>~receivedService",
+      "kind": "member",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9642,
+          9725
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 296,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008878",
+          "name": "warden.startService",
+          "type": "ArrowFunctionExpression",
+          "funcscope": "<anonymous>",
+          "paramnames": [
+            "service"
+          ]
+        },
+        "vars": {
+          "receivedService": "<anonymous>~warden.startService~receivedService"
+        }
+      },
+      "undocumented": true,
+      "name": "startService",
+      "longname": "<anonymous>~warden.startService",
+      "kind": "function",
+      "memberof": "<anonymous>~warden",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9693,
+          9718
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 297,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008886",
+          "name": "receivedService",
+          "type": "Identifier",
+          "funcscope": "<anonymous>~warden.startService",
+          "value": "service",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "receivedService",
+      "longname": "<anonymous>~warden.startService~receivedService",
+      "kind": "member",
+      "memberof": "<anonymous>~warden.startService",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9738,
+          9789
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 300,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008890",
+          "name": "result",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "result",
+      "longname": "<anonymous>~result",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10215,
+          10373
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 311,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008956",
+          "name": "dockerInstance",
+          "type": "ObjectExpression",
+          "value": "{\"listContainers\":\"\",\"getContainer\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerInstance",
+      "longname": "<anonymous>~dockerInstance",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10242,
+          10272
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 312,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008959",
+          "name": "listContainers",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "listContainers",
+      "longname": "<anonymous>~dockerInstance.listContainers",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerInstance",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10282,
+          10366
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 313,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008962",
+          "name": "getContainer",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "getContainer",
+      "longname": "<anonymous>~dockerInstance.getContainer",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerInstance",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10317,
+          10354
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 314,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008965",
+          "name": "inspect",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "inspect",
+      "longname": "inspect",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10341,
+          10351
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 314,
+        "columnno": 36,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008968",
+          "name": "Mounts",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "Mounts",
+      "longname": "Mounts",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10386,
+          10778
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 318,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008971",
+          "name": "alternateClient",
+          "type": "ObjectExpression",
+          "value": "{\"listContainers\":\"\",\"getContainer\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "alternateClient",
+      "longname": "<anonymous>~alternateClient",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10414,
+          10557
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 319,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008974",
+          "name": "listContainers",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "listContainers",
+      "longname": "<anonymous>~alternateClient.listContainers",
+      "kind": "function",
+      "memberof": "<anonymous>~alternateClient",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10458,
+          10473
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 320,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008978",
+          "name": "Id",
+          "type": "Literal",
+          "value": "secondary"
+        }
+      },
+      "undocumented": true,
+      "name": "Id",
+      "longname": "Id",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10475,
+          10514
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 320,
+        "columnno": 31,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008980",
+          "name": "Image",
+          "type": "Literal",
+          "value": "ghcr.io/example/kavita:nightly"
+        }
+      },
+      "undocumented": true,
+      "name": "Image",
+      "longname": "Image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10516,
+          10544
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 320,
+        "columnno": 72,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008982",
+          "name": "Names",
+          "type": "ArrayExpression",
+          "value": "[\"/secondary-kavita\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "Names",
+      "longname": "Names",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10567,
+          10771
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 322,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008985",
+          "name": "getContainer",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "getContainer",
+      "longname": "<anonymous>~alternateClient.getContainer",
+      "kind": "function",
+      "memberof": "<anonymous>~alternateClient",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10602,
+          10759
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 323,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008988",
+          "name": "inspect",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "inspect",
+      "longname": "inspect",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10642,
+          10743
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 324,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008991",
+          "name": "Mounts",
+          "type": "ArrayExpression",
+          "value": "[\"{\\\"Destination\\\":\\\"/data\\\",\\\"Source\\\":\\\"/alt/kavita-data\\\"}\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "Mounts",
+      "longname": "Mounts",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10674,
+          10694
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 325,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008994",
+          "name": "Destination",
+          "type": "Literal",
+          "value": "/data"
+        }
+      },
+      "undocumented": true,
+      "name": "Destination",
+      "longname": "Destination",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10696,
+          10722
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 325,
+        "columnno": 44,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008996",
+          "name": "Source",
+          "type": "Literal",
+          "value": "/alt/kavita-data"
+        }
+      },
+      "undocumented": true,
+      "name": "Source",
+      "longname": "Source",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10791,
+          10992
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 331,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008999",
+          "name": "services",
+          "type": "ObjectExpression",
+          "value": "{\"addon\":\"\",\"core\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "<anonymous>~services",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10812,
+          10821
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 332,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009002",
+          "name": "addon",
+          "type": "ObjectExpression",
+          "value": "{}"
+        }
+      },
+      "undocumented": true,
+      "name": "addon",
+      "longname": "<anonymous>~services.addon",
+      "kind": "member",
+      "memberof": "<anonymous>~services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10831,
+          10985
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 333,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009004",
+          "name": "core",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "core",
+      "longname": "<anonymous>~services.core",
+      "kind": "member",
+      "memberof": "<anonymous>~services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10851,
+          10974
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 334,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009006",
+          "name": "\"noona-raven\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-raven\",\"image\":\"captainpax/noona-raven:latest\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-raven\"",
+      "longname": "<anonymous>~services.core.\"noona-raven\"",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10884,
+          10903
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 335,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009008",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-raven"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "<anonymous>~services.core.\"noona-raven\".name",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core.\"noona-raven\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10921,
+          10959
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 336,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009010",
+          "name": "image",
+          "type": "Literal",
+          "value": "captainpax/noona-raven:latest"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "<anonymous>~services.core.\"noona-raven\".image",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core.\"noona-raven\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11005,
+          11145
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 341,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009013",
+          "name": "fsStub",
+          "type": "ObjectExpression",
+          "value": "{\"existsSync\":\"\",\"statSync\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "fsStub",
+      "longname": "<anonymous>~fsStub",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11024,
+          11086
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 342,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009016",
+          "name": "existsSync",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "existsSync",
+      "longname": "<anonymous>~fsStub.existsSync",
+      "kind": "function",
+      "memberof": "<anonymous>~fsStub",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11096,
+          11138
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 343,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009022",
+          "name": "statSync",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "statSync",
+      "longname": "<anonymous>~fsStub.statSync",
+      "kind": "function",
+      "memberof": "<anonymous>~fsStub",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11115,
+          11135
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 343,
+        "columnno": 27,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009025",
+          "name": "isSocket",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "isSocket",
+      "longname": "isSocket",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11158,
+          11589
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 346,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009029",
+          "name": "warden",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "<anonymous>~warden",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11190,
+          11204
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 347,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009034",
+          "name": "dockerInstance",
+          "type": "Identifier",
+          "value": "dockerInstance"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerInstance",
+      "longname": "dockerInstance",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11214,
+          11222
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 348,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009036",
+          "name": "services",
+          "type": "Identifier",
+          "value": "services"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11232,
+          11273
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 349,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009038",
+          "name": "logger",
+          "type": "ObjectExpression",
+          "value": "{\"log\":\"\",\"warn\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11242,
+          11255
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 349,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009040",
+          "name": "log",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "logger.log",
+      "kind": "function",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11257,
+          11271
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 349,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009043",
+          "name": "warn",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "logger.warn",
+      "kind": "function",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11283,
+          11325
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 350,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009046",
+          "name": "hostDockerSockets",
+          "type": "ArrayExpression",
+          "value": "[\"/remote/docker.sock\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "hostDockerSockets",
+      "longname": "hostDockerSockets",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11335,
+          11561
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 351,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009049",
+          "name": "dockerFactory",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerFactory",
+      "longname": "dockerFactory",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11571,
+          11581
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 358,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009067",
+          "name": "fs",
+          "type": "Identifier",
+          "value": "fsStub"
+        }
+      },
+      "undocumented": true,
+      "name": "fs",
+      "longname": "fs",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11600,
+          11622
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 361,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009070",
+          "name": "receivedService",
+          "type": "Literal",
+          "value": null
+        }
+      },
+      "undocumented": true,
+      "name": "receivedService",
+      "longname": "<anonymous>~receivedService",
+      "kind": "member",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11628,
+          11711
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 362,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009074",
+          "name": "warden.startService",
+          "type": "ArrowFunctionExpression",
+          "funcscope": "<anonymous>",
+          "paramnames": [
+            "service"
+          ]
+        },
+        "vars": {
+          "receivedService": "<anonymous>~warden.startService~receivedService"
+        }
+      },
+      "undocumented": true,
+      "name": "startService",
+      "longname": "<anonymous>~warden.startService",
+      "kind": "function",
+      "memberof": "<anonymous>~warden",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11679,
+          11704
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 363,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009082",
+          "name": "receivedService",
+          "type": "Identifier",
+          "funcscope": "<anonymous>~warden.startService",
+          "value": "service",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "receivedService",
+      "longname": "<anonymous>~warden.startService~receivedService",
+      "kind": "member",
+      "memberof": "<anonymous>~warden.startService",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11724,
+          11775
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 366,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009086",
+          "name": "result",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "result",
+      "longname": "<anonymous>~result",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12043,
+          12072
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 372,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009131",
+          "name": "mountPath",
+          "type": "Literal",
+          "value": "/alt/kavita-data"
+        }
+      },
+      "undocumented": true,
+      "name": "mountPath",
+      "longname": "mountPath",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12082,
+          12115
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 373,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009133",
+          "name": "socketPath",
+          "type": "Literal",
+          "value": "/remote/docker.sock"
+        }
+      },
+      "undocumented": true,
+      "name": "socketPath",
+      "longname": "socketPath",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12125,
+          12149
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 374,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009135",
+          "name": "containerId",
+          "type": "Literal",
+          "value": "secondary"
+        }
+      },
+      "undocumented": true,
+      "name": "containerId",
+      "longname": "containerId",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12159,
+          12192
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 375,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009137",
+          "name": "containerName",
+          "type": "Literal",
+          "value": "secondary-kavita"
+        }
+      },
+      "undocumented": true,
+      "name": "containerName",
+      "longname": "containerName",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12311,
+          12594
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 380,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009146",
+          "name": "dockerUtils",
+          "type": "ObjectExpression",
+          "value": "{\"ensureNetwork\":\"\",\"attachSelfToNetwork\":\"\",\"containerExists\":\"\",\"pullImageIfNeeded\":\"\",\"runContainerWithLogs\":\"\",\"waitForHealthyStatus\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerUtils",
+      "longname": "<anonymous>~dockerUtils",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12335,
+          12364
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 381,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009149",
+          "name": "ensureNetwork",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "ensureNetwork",
+      "longname": "<anonymous>~dockerUtils.ensureNetwork",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12374,
+          12409
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 382,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009152",
+          "name": "attachSelfToNetwork",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "attachSelfToNetwork",
+      "longname": "<anonymous>~dockerUtils.attachSelfToNetwork",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12419,
+          12452
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 383,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009155",
+          "name": "containerExists",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "containerExists",
+      "longname": "<anonymous>~dockerUtils.containerExists",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12462,
+          12495
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 384,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009158",
+          "name": "pullImageIfNeeded",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "pullImageIfNeeded",
+      "longname": "<anonymous>~dockerUtils.pullImageIfNeeded",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12505,
+          12541
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 385,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009161",
+          "name": "runContainerWithLogs",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "runContainerWithLogs",
+      "longname": "<anonymous>~dockerUtils.runContainerWithLogs",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12551,
+          12587
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 386,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009164",
+          "name": "waitForHealthyStatus",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "waitForHealthyStatus",
+      "longname": "<anonymous>~dockerUtils.waitForHealthyStatus",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12606,
+          12619
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 388,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009168",
+          "name": "warnings",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "warnings",
+      "longname": "<anonymous>~warnings",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12631,
+          13286
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 389,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009172",
+          "name": "warden",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "<anonymous>~warden",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12663,
+          12674
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 390,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009177",
+          "name": "dockerUtils",
+          "type": "Identifier",
+          "value": "dockerUtils"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerUtils",
+      "longname": "dockerUtils",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12684,
+          13200
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 391,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009179",
+          "name": "services",
+          "type": "ObjectExpression",
+          "value": "{\"addon\":\"\",\"core\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12708,
+          12786
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 392,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009181",
+          "name": "addon",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "addon",
+      "longname": "services.addon",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12733,
+          12771
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 393,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009183",
+          "name": "\"noona-redis\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-redis\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-redis\"",
+      "longname": "services.addon.\"noona-redis\"",
+      "kind": "member",
+      "memberof": "services.addon",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12750,
+          12769
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 393,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009185",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-redis"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.addon.\"noona-redis\".name",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12800,
+          13189
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 395,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009187",
+          "name": "core",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "core",
+      "longname": "services.core",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12824,
+          12893
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 396,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009189",
+          "name": "\"noona-mongo\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-mongo\",\"health\":\"http://mongo/health\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-mongo\"",
+      "longname": "services.core.\"noona-mongo\"",
+      "kind": "member",
+      "memberof": "services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12841,
+          12860
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 396,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009191",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-mongo"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.core.\"noona-mongo\".name",
+      "kind": "member",
+      "memberof": "services.core.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12862,
+          12891
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 396,
+        "columnno": 54,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009193",
+          "name": "health",
+          "type": "Literal",
+          "value": "http://mongo/health"
+        }
+      },
+      "undocumented": true,
+      "name": "health",
+      "longname": "services.core.\"noona-mongo\".health",
+      "kind": "member",
+      "memberof": "services.core.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12911,
+          12947
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 397,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009195",
+          "name": "\"noona-sage\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-sage\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-sage\"",
+      "longname": "services.core.\"noona-sage\"",
+      "kind": "member",
+      "memberof": "services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12927,
+          12945
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 397,
+        "columnno": 32,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009197",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.core.\"noona-sage\".name",
+      "kind": "member",
+      "memberof": "services.core.\"noona-sage\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12965,
+          13031
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 398,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009199",
+          "name": "\"noona-moon\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-moon\",\"health\":\"http://moon/health\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-moon\"",
+      "longname": "services.core.\"noona-moon\"",
+      "kind": "member",
+      "memberof": "services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12981,
+          12999
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 398,
+        "columnno": 32,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009201",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-moon"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.core.\"noona-moon\".name",
+      "kind": "member",
+      "memberof": "services.core.\"noona-moon\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13001,
+          13029
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 398,
+        "columnno": 52,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009203",
+          "name": "health",
+          "type": "Literal",
+          "value": "http://moon/health"
+        }
+      },
+      "undocumented": true,
+      "name": "health",
+      "longname": "services.core.\"noona-moon\".health",
+      "kind": "member",
+      "memberof": "services.core.\"noona-moon\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13049,
+          13118
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 399,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009205",
+          "name": "\"noona-vault\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-vault\",\"health\":\"http://vault/health\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-vault\"",
+      "longname": "services.core.\"noona-vault\"",
+      "kind": "member",
+      "memberof": "services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13066,
+          13085
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 399,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009207",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-vault"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.core.\"noona-vault\".name",
+      "kind": "member",
+      "memberof": "services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13087,
+          13116
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 399,
+        "columnno": 54,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009209",
+          "name": "health",
+          "type": "Literal",
+          "value": "http://vault/health"
+        }
+      },
+      "undocumented": true,
+      "name": "health",
+      "longname": "services.core.\"noona-vault\".health",
+      "kind": "member",
+      "memberof": "services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13136,
+          13174
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 400,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009211",
+          "name": "\"noona-raven\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-raven\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-raven\"",
+      "longname": "services.core.\"noona-raven\"",
+      "kind": "member",
+      "memberof": "services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13153,
+          13172
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 400,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009213",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-raven"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.core.\"noona-raven\".name",
+      "kind": "member",
+      "memberof": "services.core.\"noona-raven\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13210,
+          13278
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 403,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009215",
+          "name": "logger",
+          "type": "ObjectExpression",
+          "value": "{\"log\":\"\",\"warn\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13220,
+          13233
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 403,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009217",
+          "name": "log",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "logger.log",
+      "kind": "function",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13235,
+          13276
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 403,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009220",
+          "name": "warn",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "logger.warn",
+      "kind": "function",
+      "memberof": "logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13299,
+          13309
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 406,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009229",
+          "name": "order",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "order",
+      "longname": "<anonymous>~order",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13315,
+          13421
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 407,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009233",
+          "name": "warden.startService",
+          "type": "ArrowFunctionExpression",
+          "funcscope": "<anonymous>",
+          "paramnames": [
+            "service",
+            "healthUrl"
+          ]
+        }
+      },
+      "undocumented": true,
+      "name": "startService",
+      "longname": "<anonymous>~warden.startService",
+      "kind": "function",
+      "memberof": "<anonymous>~warden",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13924,
+          13935
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 425,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009298",
+          "name": "events",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "events",
+      "longname": "<anonymous>~events",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13947,
+          14374
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 426,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009302",
+          "name": "dockerUtils",
+          "type": "ObjectExpression",
+          "value": "{\"ensureNetwork\":\"\",\"attachSelfToNetwork\":\"\",\"containerExists\":\"\",\"pullImageIfNeeded\":\"\",\"runContainerWithLogs\":\"\",\"waitForHealthyStatus\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerUtils",
+      "longname": "<anonymous>~dockerUtils",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13971,
+          14019
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 427,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009305",
+          "name": "ensureNetwork",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "ensureNetwork",
+      "longname": "<anonymous>~dockerUtils.ensureNetwork",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14029,
+          14083
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 428,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009312",
+          "name": "attachSelfToNetwork",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "attachSelfToNetwork",
+      "longname": "<anonymous>~dockerUtils.attachSelfToNetwork",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14093,
+          14232
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 429,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009319",
+          "name": "containerExists",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "containerExists",
+      "longname": "<anonymous>~dockerUtils.containerExists",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14242,
+          14275
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 432,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009326",
+          "name": "pullImageIfNeeded",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "pullImageIfNeeded",
+      "longname": "<anonymous>~dockerUtils.pullImageIfNeeded",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14285,
+          14321
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 433,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009329",
+          "name": "runContainerWithLogs",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "runContainerWithLogs",
+      "longname": "<anonymous>~dockerUtils.runContainerWithLogs",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14331,
+          14367
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 434,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009332",
+          "name": "waitForHealthyStatus",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "waitForHealthyStatus",
+      "longname": "<anonymous>~dockerUtils.waitForHealthyStatus",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14386,
+          14509
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 436,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009336",
+          "name": "logger",
+          "type": "ObjectExpression",
+          "value": "{\"log\":\"\",\"warn\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "<anonymous>~logger",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14405,
+          14443
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 437,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009339",
+          "name": "log",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "<anonymous>~logger.log",
+      "kind": "function",
+      "memberof": "<anonymous>~logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14453,
+          14502
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 438,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009347",
+          "name": "warn",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "<anonymous>~logger.warn",
+      "kind": "function",
+      "memberof": "<anonymous>~logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14521,
+          14854
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 440,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009359",
+          "name": "warden",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "<anonymous>~warden",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14553,
+          14564
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 441,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009364",
+          "name": "dockerUtils",
+          "type": "Identifier",
+          "value": "dockerUtils"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerUtils",
+      "longname": "dockerUtils",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14574,
+          14830
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 442,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009366",
+          "name": "services",
+          "type": "ObjectExpression",
+          "value": "{\"addon\":\"\",\"core\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14598,
+          14676
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 443,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009368",
+          "name": "addon",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "addon",
+      "longname": "services.addon",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14623,
+          14661
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 444,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009370",
+          "name": "\"noona-redis\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-redis\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-redis\"",
+      "longname": "services.addon.\"noona-redis\"",
+      "kind": "member",
+      "memberof": "services.addon",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14640,
+          14659
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 444,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009372",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-redis"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.addon.\"noona-redis\".name",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14690,
+          14819
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 446,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009374",
+          "name": "core",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "core",
+      "longname": "services.core",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14714,
+          14750
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 447,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009376",
+          "name": "\"noona-moon\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-moon\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-moon\"",
+      "longname": "services.core.\"noona-moon\"",
+      "kind": "member",
+      "memberof": "services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14730,
+          14748
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 447,
+        "columnno": 32,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009378",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-moon"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.core.\"noona-moon\".name",
+      "kind": "member",
+      "memberof": "services.core.\"noona-moon\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14768,
+          14804
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 448,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009380",
+          "name": "\"noona-sage\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-sage\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-sage\"",
+      "longname": "services.core.\"noona-sage\"",
+      "kind": "member",
+      "memberof": "services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14784,
+          14802
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 448,
+        "columnno": 32,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009382",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.core.\"noona-sage\".name",
+      "kind": "member",
+      "memberof": "services.core.\"noona-sage\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14840,
+          14846
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 451,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009384",
+          "name": "logger",
+          "type": "Identifier",
+          "value": "logger"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14861,
+          14979
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 454,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009387",
+          "name": "warden.startService",
+          "type": "ArrowFunctionExpression",
+          "funcscope": "<anonymous>",
+          "paramnames": [
+            "service",
+            "healthUrl"
+          ]
+        }
+      },
+      "undocumented": true,
+      "name": "startService",
+      "longname": "<anonymous>~warden.startService",
+      "kind": "function",
+      "memberof": "<anonymous>~warden",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14992,
+          15020
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 458,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009409",
+          "name": "result",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "result",
+      "longname": "<anonymous>~result",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15621,
+          15636
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 471,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009508",
+          "name": "operations",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "operations",
+      "longname": "<anonymous>~operations",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15648,
+          15980
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 472,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009512",
+          "name": "containers",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "containers",
+      "longname": "<anonymous>~containers",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15671,
+          15817
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 473,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009515",
+          "name": "\"svc-1\"",
+          "type": "ObjectExpression",
+          "value": "{\"stop\":\"\",\"remove\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"svc-1\"",
+      "longname": "<anonymous>~containers.\"svc-1\"",
+      "kind": "member",
+      "memberof": "<anonymous>~containers",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15694,
+          15741
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 474,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009517",
+          "name": "stop",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "stop",
+      "longname": "<anonymous>~containers.\"svc-1\".stop",
+      "kind": "function",
+      "memberof": "<anonymous>~containers.\"svc-1\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15755,
+          15806
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 475,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009524",
+          "name": "remove",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "remove",
+      "longname": "<anonymous>~containers.\"svc-1\".remove",
+      "kind": "function",
+      "memberof": "<anonymous>~containers.\"svc-1\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15827,
+          15973
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 477,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009531",
+          "name": "\"svc-2\"",
+          "type": "ObjectExpression",
+          "value": "{\"stop\":\"\",\"remove\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"svc-2\"",
+      "longname": "<anonymous>~containers.\"svc-2\"",
+      "kind": "member",
+      "memberof": "<anonymous>~containers",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15850,
+          15897
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 478,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009533",
+          "name": "stop",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "stop",
+      "longname": "<anonymous>~containers.\"svc-2\".stop",
+      "kind": "function",
+      "memberof": "<anonymous>~containers.\"svc-2\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15911,
+          15962
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 479,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009540",
+          "name": "remove",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "remove",
+      "longname": "<anonymous>~containers.\"svc-2\".remove",
+      "kind": "function",
+      "memberof": "<anonymous>~containers.\"svc-2\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15992,
+          16066
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 482,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009548",
+          "name": "dockerInstance",
+          "type": "ObjectExpression",
+          "value": "{\"getContainer\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerInstance",
+      "longname": "<anonymous>~dockerInstance",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16019,
+          16059
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 483,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009551",
+          "name": "getContainer",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "getContainer",
+      "longname": "<anonymous>~dockerInstance.getContainer",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerInstance",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16078,
+          16125
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 485,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009558",
+          "name": "trackedContainers",
+          "type": "NewExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "trackedContainers",
+      "longname": "<anonymous>~trackedContainers",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16135,
+          16150
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 486,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009566",
+          "name": "exitCode",
+          "type": "Literal",
+          "value": null
+        }
+      },
+      "undocumented": true,
+      "name": "exitCode",
+      "longname": "<anonymous>~exitCode",
+      "kind": "member",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16162,
+          16445
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 487,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009570",
+          "name": "dockerUtils",
+          "type": "ObjectExpression",
+          "value": "{\"ensureNetwork\":\"\",\"attachSelfToNetwork\":\"\",\"containerExists\":\"\",\"pullImageIfNeeded\":\"\",\"runContainerWithLogs\":\"\",\"waitForHealthyStatus\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerUtils",
+      "longname": "<anonymous>~dockerUtils",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16186,
+          16215
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 488,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009573",
+          "name": "ensureNetwork",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "ensureNetwork",
+      "longname": "<anonymous>~dockerUtils.ensureNetwork",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16225,
+          16260
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 489,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009576",
+          "name": "attachSelfToNetwork",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "attachSelfToNetwork",
+      "longname": "<anonymous>~dockerUtils.attachSelfToNetwork",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16270,
+          16303
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 490,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009579",
+          "name": "containerExists",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "containerExists",
+      "longname": "<anonymous>~dockerUtils.containerExists",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16313,
+          16346
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 491,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009582",
+          "name": "pullImageIfNeeded",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "pullImageIfNeeded",
+      "longname": "<anonymous>~dockerUtils.pullImageIfNeeded",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16356,
+          16392
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 492,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009585",
+          "name": "runContainerWithLogs",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "runContainerWithLogs",
+      "longname": "<anonymous>~dockerUtils.runContainerWithLogs",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16402,
+          16438
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 493,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009588",
+          "name": "waitForHealthyStatus",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "waitForHealthyStatus",
+      "longname": "<anonymous>~dockerUtils.waitForHealthyStatus",
+      "kind": "function",
+      "memberof": "<anonymous>~dockerUtils",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16457,
+          16588
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 495,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009592",
+          "name": "logger",
+          "type": "ObjectExpression",
+          "value": "{\"log\":\"\",\"warn\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "<anonymous>~logger",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16476,
+          16518
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 496,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009595",
+          "name": "log",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "log",
+      "longname": "<anonymous>~logger.log",
+      "kind": "function",
+      "memberof": "<anonymous>~logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16528,
+          16581
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 497,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009603",
+          "name": "warn",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "warn",
+      "longname": "<anonymous>~logger.warn",
+      "kind": "function",
+      "memberof": "<anonymous>~logger",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16601,
+          16792
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 500,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009615",
+          "name": "warden",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "<anonymous>~warden",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16633,
+          16647
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 501,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009620",
+          "name": "dockerInstance",
+          "type": "Identifier",
+          "value": "dockerInstance"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerInstance",
+      "longname": "dockerInstance",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16657,
+          16674
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 502,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009622",
+          "name": "trackedContainers",
+          "type": "Identifier",
+          "value": "trackedContainers"
+        }
+      },
+      "undocumented": true,
+      "name": "trackedContainers",
+      "longname": "trackedContainers",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16684,
+          16695
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 503,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009624",
+          "name": "dockerUtils",
+          "type": "Identifier",
+          "value": "dockerUtils"
+        }
+      },
+      "undocumented": true,
+      "name": "dockerUtils",
+      "longname": "dockerUtils",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16705,
+          16711
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 504,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009626",
+          "name": "logger",
+          "type": "Identifier",
+          "value": "logger"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16721,
+          16784
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 505,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009628",
+          "name": "processExit",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "exitCode": "processExit~exitCode"
+        }
+      },
+      "undocumented": true,
+      "name": "processExit",
+      "longname": "processExit",
+      "kind": "function",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16758,
+          16773
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 506,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009633",
+          "name": "exitCode",
+          "type": "Identifier",
+          "funcscope": "processExit",
+          "value": "code",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "exitCode",
+      "longname": "processExit~exitCode",
+      "kind": "member",
+      "memberof": "processExit",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          226,
+          676
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 8,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009691",
+          "name": "listen",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "undefined": null,
+          "address": "listen~address"
+        }
+      },
+      "undocumented": true,
+      "name": "listen",
+      "longname": "listen",
+      "kind": "function",
+      "scope": "global",
+      "params": [],
+      "async": true
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          273,
+          279
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 9,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009701",
+          "name": "server",
+          "type": "Identifier",
+          "value": "server"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          312,
+          334
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 10,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009706",
+          "name": "warden",
+          "type": "MemberExpression",
+          "value": "options.warden"
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "warden",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          344,
+          351
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 11,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009710",
+          "name": "port",
+          "type": "Literal",
+          "value": 0
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          361,
+          383
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 12,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009712",
+          "name": "logger",
+          "type": "MemberExpression",
+          "value": "options.logger"
+        }
+      },
+      "undocumented": true,
+      "name": "logger",
+      "longname": "logger",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          441,
+          467
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 16,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009723",
+          "name": "address",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "address",
+      "longname": "listen~address",
+      "kind": "constant",
+      "memberof": "listen",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          607,
+          613
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 23,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009744",
+          "name": "server",
+          "type": "Identifier",
+          "value": "server"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          623,
+          666
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 24,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009746",
+          "name": "baseUrl",
+          "type": "TemplateLiteral",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrl",
+      "longname": "baseUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          685,
+          884
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 28,
+        "columnno": 6,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009754",
+          "name": "closeServer",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "": null
+        }
+      },
+      "undocumented": true,
+      "name": "closeServer",
+      "longname": "closeServer",
+      "kind": "function",
+      "scope": "global",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          978,
+          988
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 39,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009791",
+          "name": "calls",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "calls",
+      "longname": "<anonymous>~calls",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1000,
+          1371
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 40,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009795",
+          "name": "warden",
+          "type": "ObjectExpression",
+          "value": "{\"listServices\":\"\",\"installServices\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "<anonymous>~warden",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1019,
+          1245
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 41,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009798",
+          "name": "listServices",
+          "type": "FunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "listServices",
+      "longname": "<anonymous>~warden.listServices",
+      "kind": "function",
+      "memberof": "<anonymous>~warden",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1121,
+          1139
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 44,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009811",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1141,
+          1157
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 44,
+        "columnno": 38,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009813",
+          "name": "category",
+          "type": "Literal",
+          "value": "core"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1179,
+          1198
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 45,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009816",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-redis"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1200,
+          1217
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 45,
+        "columnno": 39,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009818",
+          "name": "category",
+          "type": "Literal",
+          "value": "addon"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1255,
+          1364
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 48,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009820",
+          "name": "installServices",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "installServices",
+      "longname": "<anonymous>~warden.installServices",
+      "kind": "function",
+      "memberof": "<anonymous>~warden",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1386,
+          1392
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 53,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009830",
+          "name": "server",
+          "type": "Identifier",
+          "value": "server"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1394,
+          1401
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 53,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009832",
+          "name": "baseUrl",
+          "type": "Identifier",
+          "value": "baseUrl"
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrl",
+      "longname": "baseUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1421,
+          1427
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 53,
+        "columnno": 47,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009838",
+          "name": "warden",
+          "type": "Identifier",
+          "value": "warden"
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "warden",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1483,
+          1532
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 56,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009850",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "<anonymous>~response",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1628,
+          1759
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 59,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009879",
+          "name": "services",
+          "type": "ArrayExpression",
+          "value": "[\"{\\\"name\\\":\\\"noona-sage\\\",\\\"category\\\":\\\"core\\\"}\",\"{\\\"name\\\":\\\"noona-redis\\\",\\\"category\\\":\\\"addon\\\"}\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1654,
+          1672
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 60,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009882",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1674,
+          1690
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 60,
+        "columnno": 34,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009884",
+          "name": "category",
+          "type": "Literal",
+          "value": "core"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1708,
+          1727
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 61,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009887",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-redis"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1729,
+          1746
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 61,
+        "columnno": 35,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009889",
+          "name": "category",
+          "type": "Literal",
+          "value": "addon"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1800,
+          1823
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 64,
+        "columnno": 31,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009899",
+          "name": "includeInstalled",
+          "type": "Literal",
+          "value": false
+        }
+      },
+      "undocumented": true,
+      "name": "includeInstalled",
+      "longname": "includeInstalled",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1931,
+          1941
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 68,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009909",
+          "name": "calls",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "calls",
+      "longname": "<anonymous>~calls",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1953,
+          2359
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 69,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009913",
+          "name": "warden",
+          "type": "ObjectExpression",
+          "value": "{\"listServices\":\"\",\"installServices\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "<anonymous>~warden",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          1972,
+          2233
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 70,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009916",
+          "name": "listServices",
+          "type": "FunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "listServices",
+      "longname": "<anonymous>~warden.listServices",
+      "kind": "function",
+      "memberof": "<anonymous>~warden",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2074,
+          2092
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 73,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009929",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2094,
+          2110
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 73,
+        "columnno": 38,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009931",
+          "name": "category",
+          "type": "Literal",
+          "value": "core"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2112,
+          2127
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 73,
+        "columnno": 56,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009933",
+          "name": "installed",
+          "type": "Literal",
+          "value": true
+        }
+      },
+      "undocumented": true,
+      "name": "installed",
+      "longname": "installed",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2149,
+          2168
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 74,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009936",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-redis"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2170,
+          2187
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 74,
+        "columnno": 39,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009938",
+          "name": "category",
+          "type": "Literal",
+          "value": "addon"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2189,
+          2205
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 74,
+        "columnno": 58,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009940",
+          "name": "installed",
+          "type": "Literal",
+          "value": false
+        }
+      },
+      "undocumented": true,
+      "name": "installed",
+      "longname": "installed",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2243,
+          2352
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 77,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009942",
+          "name": "installServices",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "installServices",
+      "longname": "<anonymous>~warden.installServices",
+      "kind": "function",
+      "memberof": "<anonymous>~warden",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2374,
+          2380
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 82,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009952",
+          "name": "server",
+          "type": "Identifier",
+          "value": "server"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2382,
+          2389
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 82,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009954",
+          "name": "baseUrl",
+          "type": "Identifier",
+          "value": "baseUrl"
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrl",
+      "longname": "baseUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2409,
+          2415
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 82,
+        "columnno": 47,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009960",
+          "name": "warden",
+          "type": "Identifier",
+          "value": "warden"
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "warden",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2471,
+          2542
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 85,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009972",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "<anonymous>~response",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2638,
+          2804
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 88,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010001",
+          "name": "services",
+          "type": "ArrayExpression",
+          "value": "[\"{\\\"name\\\":\\\"noona-sage\\\",\\\"category\\\":\\\"core\\\",\\\"installed\\\":true}\",\"{\\\"name\\\":\\\"noona-redis\\\",\\\"category\\\":\\\"addon\\\",\\\"installed\\\":false}\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2664,
+          2682
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 89,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010004",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2684,
+          2700
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 89,
+        "columnno": 34,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010006",
+          "name": "category",
+          "type": "Literal",
+          "value": "core"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2702,
+          2717
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 89,
+        "columnno": 52,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010008",
+          "name": "installed",
+          "type": "Literal",
+          "value": true
+        }
+      },
+      "undocumented": true,
+      "name": "installed",
+      "longname": "installed",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2735,
+          2754
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 90,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010011",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-redis"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2756,
+          2773
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 90,
+        "columnno": 35,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010013",
+          "name": "category",
+          "type": "Literal",
+          "value": "addon"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2775,
+          2791
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 90,
+        "columnno": 54,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010015",
+          "name": "installed",
+          "type": "Literal",
+          "value": false
+        }
+      },
+      "undocumented": true,
+      "name": "installed",
+      "longname": "installed",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2845,
+          2867
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 93,
+        "columnno": 31,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010025",
+          "name": "includeInstalled",
+          "type": "Literal",
+          "value": true
+        }
+      },
+      "undocumented": true,
+      "name": "includeInstalled",
+      "longname": "includeInstalled",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          2981,
+          2998
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 97,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010035",
+          "name": "installCalls",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "installCalls",
+      "longname": "<anonymous>~installCalls",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3010,
+          3349
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 98,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010039",
+          "name": "warden",
+          "type": "ObjectExpression",
+          "value": "{\"listServices\":\"\",\"installServices\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "<anonymous>~warden",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3029,
+          3057
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 99,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010042",
+          "name": "listServices",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "listServices",
+      "longname": "<anonymous>~warden.listServices",
+      "kind": "function",
+      "memberof": "<anonymous>~warden",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3067,
+          3342
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 100,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010045",
+          "name": "installServices",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "installServices",
+      "longname": "<anonymous>~warden.installServices",
+      "kind": "function",
+      "memberof": "<anonymous>~warden",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3186,
+          3204
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 103,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010058",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3206,
+          3225
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 103,
+        "columnno": 38,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010060",
+          "name": "status",
+          "type": "Literal",
+          "value": "installed"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3227,
+          3243
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 103,
+        "columnno": 59,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010062",
+          "name": "category",
+          "type": "Literal",
+          "value": "core"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3265,
+          3282
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 104,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010065",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-bad"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3284,
+          3299
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 104,
+        "columnno": 37,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010067",
+          "name": "status",
+          "type": "Literal",
+          "value": "error"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3301,
+          3314
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 104,
+        "columnno": 54,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010069",
+          "name": "error",
+          "type": "Literal",
+          "value": "boom"
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3364,
+          3370
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 109,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010074",
+          "name": "server",
+          "type": "Identifier",
+          "value": "server"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3372,
+          3379
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 109,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010076",
+          "name": "baseUrl",
+          "type": "Identifier",
+          "value": "baseUrl"
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrl",
+      "longname": "baseUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3399,
+          3405
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 109,
+        "columnno": 47,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010082",
+          "name": "warden",
+          "type": "Identifier",
+          "value": "warden"
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "warden",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3461,
+          3681
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 112,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010094",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "<anonymous>~response",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3529,
+          3543
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 113,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010104",
+          "name": "method",
+          "type": "Literal",
+          "value": "POST"
+        }
+      },
+      "undocumented": true,
+      "name": "method",
+      "longname": "method",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3553,
+          3600
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 114,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010106",
+          "name": "headers",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"application/json\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "headers",
+      "longname": "headers",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3564,
+          3598
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 114,
+        "columnno": 19,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010108",
+          "name": "\"Content-Type\"",
+          "type": "Literal",
+          "value": "application/json"
+        }
+      },
+      "undocumented": true,
+      "name": "\"Content-Type\"",
+      "longname": "headers.\"Content-Type\"",
+      "kind": "member",
+      "memberof": "headers",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3610,
+          3673
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 115,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010110",
+          "name": "body",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "body",
+      "longname": "body",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3633,
+          3670
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 115,
+        "columnno": 31,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010116",
+          "name": "services",
+          "type": "ArrayExpression",
+          "value": "[\"noona-sage\",\"noona-bad\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3778,
+          3940
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 120,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010140",
+          "name": "results",
+          "type": "ArrayExpression",
+          "value": "[\"{\\\"name\\\":\\\"noona-sage\\\",\\\"status\\\":\\\"installed\\\",\\\"category\\\":\\\"core\\\"}\",\"{\\\"name\\\":\\\"noona-bad\\\",\\\"status\\\":\\\"error\\\",\\\"error\\\":\\\"boom\\\"}\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "results",
+      "longname": "results",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3803,
+          3821
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 121,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010143",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3823,
+          3842
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 121,
+        "columnno": 34,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010145",
+          "name": "status",
+          "type": "Literal",
+          "value": "installed"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3844,
+          3860
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 121,
+        "columnno": 55,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010147",
+          "name": "category",
+          "type": "Literal",
+          "value": "core"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3878,
+          3895
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 122,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010150",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-bad"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3897,
+          3912
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 122,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010152",
+          "name": "status",
+          "type": "Literal",
+          "value": "error"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          3914,
+          3927
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 122,
+        "columnno": 50,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010154",
+          "name": "error",
+          "type": "Literal",
+          "value": "boom"
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4100,
+          4273
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 129,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010174",
+          "name": "warden",
+          "type": "ObjectExpression",
+          "value": "{\"listServices\":\"\",\"installServices\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "<anonymous>~warden",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4119,
+          4147
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 130,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010177",
+          "name": "listServices",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "listServices",
+      "longname": "<anonymous>~warden.listServices",
+      "kind": "function",
+      "memberof": "<anonymous>~warden",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4157,
+          4266
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 131,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010180",
+          "name": "installServices",
+          "type": "ArrowFunctionExpression"
+        }
+      },
+      "undocumented": true,
+      "name": "installServices",
+      "longname": "<anonymous>~warden.installServices",
+      "kind": "function",
+      "memberof": "<anonymous>~warden",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4288,
+          4294
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 136,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010190",
+          "name": "server",
+          "type": "Identifier",
+          "value": "server"
+        }
+      },
+      "undocumented": true,
+      "name": "server",
+      "longname": "server",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4296,
+          4303
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 136,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010192",
+          "name": "baseUrl",
+          "type": "Identifier",
+          "value": "baseUrl"
+        }
+      },
+      "undocumented": true,
+      "name": "baseUrl",
+      "longname": "baseUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4323,
+          4329
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 136,
+        "columnno": 47,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010198",
+          "name": "warden",
+          "type": "Identifier",
+          "value": "warden"
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "warden",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4385,
+          4580
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 139,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010210",
+          "name": "response",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "response",
+      "longname": "<anonymous>~response",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4453,
+          4467
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 140,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010220",
+          "name": "method",
+          "type": "Literal",
+          "value": "POST"
+        }
+      },
+      "undocumented": true,
+      "name": "method",
+      "longname": "method",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4477,
+          4524
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 141,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010222",
+          "name": "headers",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"application/json\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "headers",
+      "longname": "headers",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4488,
+          4522
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 141,
+        "columnno": 19,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010224",
+          "name": "\"Content-Type\"",
+          "type": "Literal",
+          "value": "application/json"
+        }
+      },
+      "undocumented": true,
+      "name": "\"Content-Type\"",
+      "longname": "headers.\"Content-Type\"",
+      "kind": "member",
+      "memberof": "headers",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4534,
+          4572
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 142,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010226",
+          "name": "body",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "body",
+      "longname": "body",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4557,
+          4569
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 142,
+        "columnno": 31,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010232",
+          "name": "services",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          4633,
+          4664
+        ],
+        "filename": "wardenServer.test.mjs",
+        "lineno": 146,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100010244",
+          "name": "payload",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "payload",
+      "longname": "<anonymous>~payload",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "kind": "package",
+      "longname": "package:undefined",
+      "files": [
+        "/workspace/Noona/services/sage/initSage.mjs",
+        "/workspace/Noona/services/sage/routes/pages.mjs",
+        "/workspace/Noona/services/sage/routes/setup.mjs",
+        "/workspace/Noona/services/sage/routes/state.mjs",
+        "/workspace/Noona/services/sage/shared/sageApp.mjs",
+        "/workspace/Noona/services/sage/tests/sageApp.test.mjs",
+        "/workspace/Noona/services/vault/initVault.mjs",
+        "/workspace/Noona/services/vault/shared/vaultApp.mjs",
+        "/workspace/Noona/services/vault/tests/vaultApp.test.mjs",
+        "/workspace/Noona/services/warden/docker/addonDockers.mjs",
+        "/workspace/Noona/services/warden/docker/dockerUtilties.mjs",
+        "/workspace/Noona/services/warden/docker/noonaDockers.mjs",
+        "/workspace/Noona/services/warden/docker/vaultTokens.mjs",
+        "/workspace/Noona/services/warden/initWarden.mjs",
+        "/workspace/Noona/services/warden/setup/setupWizard.mjs",
+        "/workspace/Noona/services/warden/shared/wardenCore.mjs",
+        "/workspace/Noona/services/warden/shared/wardenServer.mjs",
+        "/workspace/Noona/services/warden/tests/vaultTokens.test.mjs",
+        "/workspace/Noona/services/warden/tests/wardenCore.test.mjs",
+        "/workspace/Noona/services/warden/tests/wardenServer.test.mjs"
+      ]
+    }
+  ],
+  "javadoc": [
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/RavenApplication.java",
+      "name": "RavenApplication",
+      "kind": "class",
+      "signature": "public class RavenApplication",
+      "description": "🦅 Raven Application Entry Point\n\nThe main Spring Boot application class for Raven Downloader and Library Manager."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/controller/DownloadController.java",
+      "name": "DownloadController",
+      "kind": "class",
+      "signature": "public class DownloadController",
+      "description": "DownloadController handles endpoints for searching and downloading manga titles and chapters.\n\nAuthor: Pax"
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/controller/DownloadController.java",
+      "name": "healthCheck",
+      "kind": "method",
+      "signature": "public ResponseEntity<String> healthCheck()",
+      "description": "Health check endpoint for Raven's download module.\n\n@return Status message"
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/controller/DownloadController.java",
+      "name": "searchTitle",
+      "kind": "method",
+      "signature": "public ResponseEntity<SearchTitle> searchTitle(@PathVariable String titleName)",
+      "description": "Searches for a manga title.\n\n@param titleName The title to search.\n@return SearchTitle object containing possible matches and a generated searchId."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/controller/DownloadController.java",
+      "name": "queueDownload",
+      "kind": "method",
+      "signature": "public ResponseEntity<String> queueDownload(@PathVariable String searchId, @PathVariable int optionIndex)",
+      "description": "Queues downloading of chapters for a selected manga title asynchronously.\nIf optionIndex is 0, queues downloads for all available titles in the search result.\n\n@param searchId    The search session ID returned by /search.\n@param optionIndex The selected option index from the search results (1-based). Use 0 for ALL.\n@return Status message indicating the queue result."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/controller/LibraryController.java",
+      "name": "LibraryController",
+      "kind": "class",
+      "signature": "public class LibraryController",
+      "description": "REST controller for Raven library endpoints.\nHandles retrieving titles and chapters from the library.\n\nAuthor: Pax"
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/controller/LibraryController.java",
+      "name": "checkForNewChapters",
+      "kind": "method",
+      "signature": "public ResponseEntity<String> checkForNewChapters()",
+      "description": "Endpoint to check all titles for new chapters.\nCalls Vault to get the library data, scrapes sources,\nand queues downloads for missing chapters."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/LibraryService.java",
+      "name": "LibraryService",
+      "kind": "class",
+      "signature": "public class LibraryService",
+      "description": "LibraryService manages Raven's manga library via VaultService.\nTracks downloaded chapters and triggers downloads for new ones.\n\nAuthor: Pax"
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/VaultService.java",
+      "name": "VaultService",
+      "kind": "class",
+      "signature": "public class VaultService",
+      "description": "VaultService handles authenticated communication with Noona Vault using static API tokens.\nProvides helper methods for MongoDB-style insert, find, update operations.\n\nAuthor: Pax"
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/VaultService.java",
+      "name": "sendPacket",
+      "kind": "method",
+      "signature": "private Map<String, Object> sendPacket(Map<String, Object> packet)",
+      "description": "Send a packet to the Vault service's /v1/vault/handle endpoint and return the parsed JSON response.\n\n@param packet the request payload to send to Vault; must be serializable to JSON\n@return       the response body deserialized to a Map<String, Object>\n@throws IllegalStateException if the VAULT_API_TOKEN configuration is missing or blank\n@throws RuntimeException      if the HTTP request to Vault fails"
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/VaultService.java",
+      "name": "parseJson",
+      "kind": "method",
+      "signature": "public <T> T parseJson(Object raw, Type typeOfT)",
+      "description": "Deserialize an object to a target type using Gson."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/VaultService.java",
+      "name": "parseDocuments",
+      "kind": "method",
+      "signature": "public <T> List<T> parseDocuments(List<Map<String, Object>> docs, Type typeOfT)",
+      "description": "Converts a list of Vault documents into typed objects."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/VaultService.java",
+      "name": "fetchLatestChapterFromSource",
+      "kind": "method",
+      "signature": "public String fetchLatestChapterFromSource(String sourceUrl)",
+      "description": "Fetches the latest chapter number from a given manga source URL."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/download/DownloadChapter.java",
+      "name": "DownloadChapter",
+      "kind": "class",
+      "signature": "public class DownloadChapter",
+      "description": "Represents the result of downloading chapters.\nContains title name, status, and optionally a list of chapter statuses.\n<p>\nAuthor: Pax"
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/download/DownloadChapter.java",
+      "name": "chapterStatuses",
+      "kind": "field",
+      "signature": "private List<String> chapterStatuses",
+      "description": "List of individual chapter download statuses (for full downloads).\nEach entry can be \"Chapter X: ✅ Success\" or \"Chapter X: ❌ Failed\"."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/download/SearchTitle.java",
+      "name": "SearchTitle",
+      "kind": "class",
+      "signature": "public class SearchTitle",
+      "description": "SearchTitle represents the result of a manga title search operation.\nContains a generated searchId to track the session and a list of options,\neach option being a map with keys such as:\n- \"index\": option number\n- \"title\": manga title\n- \"href\": URL to the manga page.\n\nAuthor: Pax"
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/download/SearchTitle.java",
+      "name": "searchId",
+      "kind": "field",
+      "signature": "private String searchId",
+      "description": "Unique search session ID for this search request."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/download/SearchTitle.java",
+      "name": "options",
+      "kind": "field",
+      "signature": "private List<Map<String, String>> options",
+      "description": "List of search result options, each as a map with \"index\", \"title\", \"href\"."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/download/SourceFinder.java",
+      "name": "SourceFinder",
+      "kind": "class",
+      "signature": "public class SourceFinder",
+      "description": "SourceFinder scrapes actual page image URLs for a given manga chapter.\nSupports multiple known host patterns via an easy-to-extend scraper map.\n\nAuthor: Pax"
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/download/SourceFinder.java",
+      "name": "HashMap",
+      "kind": "method",
+      "signature": "private final Map<String, ScraperFunction> scrapers = new HashMap<>()",
+      "description": "Map of domain -> ScraperFunction"
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/download/SourceFinder.java",
+      "name": "findSource",
+      "kind": "method",
+      "signature": "public List<String> findSource(String chapterUrl)",
+      "description": "Finds the source images for a given chapter URL."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/download/SourceFinder.java",
+      "name": "defaultScrape",
+      "kind": "method",
+      "signature": "private List<String> defaultScrape(String chapterUrl)",
+      "description": "Default scraper strategy using general image selection."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/download/SourceFinder.java",
+      "name": "scrapePlaneptune",
+      "kind": "method",
+      "signature": "private List<String> scrapePlaneptune(String chapterUrl)",
+      "description": "Scraper for hot.planeptune.us"
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/download/SourceFinder.java",
+      "name": "scrapeLastation",
+      "kind": "method",
+      "signature": "private List<String> scrapeLastation(String chapterUrl)",
+      "description": "Scraper for scans.lastation.us"
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/download/SourceFinder.java",
+      "name": "scrapeLowee",
+      "kind": "method",
+      "signature": "private List<String> scrapeLowee(String chapterUrl)",
+      "description": "Scraper for official.lowee.us"
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/download/SourceFinder.java",
+      "name": "genericImageScrape",
+      "kind": "method",
+      "signature": "private List<String> genericImageScrape(String chapterUrl, String cssSelector)",
+      "description": "Generic scraper for a given CSS selector."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/download/SourceFinder.java",
+      "name": "extractDomain",
+      "kind": "method",
+      "signature": "private String extractDomain(String url)",
+      "description": "Extracts the domain from a URL."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/download/SourceFinder.java",
+      "name": "ScraperFunction",
+      "kind": "interface",
+      "signature": "interface ScraperFunction",
+      "description": "Functional interface for scrapers."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/download/TitleScraper.java",
+      "name": "TitleScraper",
+      "kind": "class",
+      "signature": "public class TitleScraper",
+      "description": "TitleScraper handles searching for manga titles and scraping chapter lists\nfrom weebcentral.com using Selenium and Jsoup.\n\nAuthor: Pax"
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/library/NewChapter.java",
+      "name": "NewChapter",
+      "kind": "class",
+      "signature": "public class NewChapter",
+      "description": "Represents a newly discovered or downloaded chapter.\nTypically used during library updates and Vault sync.\n\nAuthor: Pax"
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/library/NewChapter.java",
+      "name": "chapter",
+      "kind": "field",
+      "signature": "private String chapter",
+      "description": "Chapter identifier (e.g. \"101\", \"12.5\", etc)."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/library/NewChapter.java",
+      "name": "titleName",
+      "kind": "field",
+      "signature": "private String titleName",
+      "description": "Title this chapter belongs to (optional for logging)."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/library/NewChapter.java",
+      "name": "path",
+      "kind": "field",
+      "signature": "private String path",
+      "description": "Downloaded file path (can be empty for updates)."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/library/NewTitle.java",
+      "name": "NewTitle",
+      "kind": "class",
+      "signature": "public class NewTitle",
+      "description": "Represents a manga title stored in the Raven library.\nIncludes title metadata and progress tracking for downloads.\n\nAuthor: Pax"
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/library/NewTitle.java",
+      "name": "titleName",
+      "kind": "field",
+      "signature": "private String titleName",
+      "description": "The human-readable name of the manga title."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/library/NewTitle.java",
+      "name": "uuid",
+      "kind": "field",
+      "signature": "private String uuid",
+      "description": "Unique UUID assigned when the title is first added."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/library/NewTitle.java",
+      "name": "sourceUrl",
+      "kind": "field",
+      "signature": "private String sourceUrl",
+      "description": "Source URL used for scraping chapter list."
+    },
+    {
+      "file": "services/raven/src/main/java/com/paxkun/raven/service/library/NewTitle.java",
+      "name": "lastDownloaded",
+      "kind": "field",
+      "signature": "private String lastDownloaded",
+      "description": "Last downloaded chapter number (used for update checking)."
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,352 @@
+{
+  "name": "noona-monorepo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "noona-monorepo",
+      "devDependencies": {
+        "docdash": "^2.0.1",
+        "jsdoc": "^4.0.3"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@jsdoc/salty": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.9.tgz",
+      "integrity": "sha512-yYxMVH7Dqw6nO0d5NIV8OQWnitU8k6vXH8NtgqAfIa/IUqRMxRv/NUJJ08VEKbAakwxlgBl5PJdrU0dMPStsnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v12.0.0"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/catharsis": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/docdash": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/docdash/-/docdash-2.0.2.tgz",
+      "integrity": "sha512-3SDDheh9ddrwjzf6dPFe1a16M6ftstqTNjik2+1fx46l24H9dD2osT2q9y+nBEC1wWz4GIqA48JmicOLQ0R8xA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsdoc/salty": "^0.2.1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js2xmlparser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xmlcreate": "^2.0.4"
+      }
+    },
+    "node_modules/jsdoc": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.4.tgz",
+      "integrity": "sha512-zeFezwyXeG4syyYHbvh1A967IAqq/67yXtXvuL5wnqCkFZe8I0vKfm+EO+YEvLguo6w9CDUbrAXVtJSHh2E8rw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/parser": "^7.20.15",
+        "@jsdoc/salty": "^0.2.1",
+        "@types/markdown-it": "^14.1.1",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.9.0",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.2",
+        "klaw": "^3.0.0",
+        "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^8.6.7",
+        "marked": "^4.0.10",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "underscore": "~1.13.2"
+      },
+      "bin": {
+        "jsdoc": "jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/klaw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-anchor": {
+      "version": "8.6.7",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+      "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
+      "dev": true,
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/requizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/xmlcreate": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "noona-monorepo",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "docs": "node scripts/generate-docs.mjs"
+  },
+  "devDependencies": {
+    "docdash": "^2.0.1",
+    "jsdoc": "^4.0.3"
+  }
+}

--- a/scripts/generate-docs.mjs
+++ b/scripts/generate-docs.mjs
@@ -1,0 +1,259 @@
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+async function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      ...options,
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    child.on('error', reject);
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+      } else {
+        const error = new Error(`Command ${command} ${args.join(' ')} failed with exit code ${code}`);
+        error.stdout = stdout;
+        error.stderr = stderr;
+        reject(error);
+      }
+    });
+  });
+}
+
+function cleanJavadoc(comment) {
+  return comment
+    .split('\n')
+    .map((line) => line.replace(/^\s*\* ?/, '').trimEnd())
+    .join('\n')
+    .trim();
+}
+
+function determineJavaKind(signature) {
+  if (/\bclass\b/.test(signature)) {
+    return 'class';
+  }
+  if (/\binterface\b/.test(signature)) {
+    return 'interface';
+  }
+  if (/\benum\b/.test(signature)) {
+    return 'enum';
+  }
+  if (/\b@interface\b/.test(signature)) {
+    return 'annotation';
+  }
+  if (signature.includes('(')) {
+    return 'method';
+  }
+  return 'field';
+}
+
+function extractJavaName(signature, kind) {
+  if (kind === 'class') {
+    const match = signature.match(/class\s+([A-Za-z_$][\w$]*)/);
+    return match ? match[1] : null;
+  }
+  if (kind === 'interface') {
+    const match = signature.match(/interface\s+([A-Za-z_$][\w$]*)/);
+    return match ? match[1] : null;
+  }
+  if (kind === 'enum') {
+    const match = signature.match(/enum\s+([A-Za-z_$][\w$]*)/);
+    return match ? match[1] : null;
+  }
+  if (kind === 'annotation') {
+    const match = signature.match(/@interface\s+([A-Za-z_$][\w$]*)/);
+    return match ? match[1] : null;
+  }
+  if (kind === 'method') {
+    const parenIndex = signature.indexOf('(');
+    if (parenIndex === -1) return null;
+    const beforeParen = signature.slice(0, parenIndex).trim();
+    const tokens = beforeParen.split(/\s+/);
+    return tokens.length ? tokens[tokens.length - 1].replace(/<.*>/, '') : null;
+  }
+  if (kind === 'field') {
+    const tokens = signature.split(/\s+/);
+    return tokens.length ? tokens[tokens.length - 1].replace(/;$/, '') : null;
+  }
+  return null;
+}
+
+async function collectFiles(dir, extension) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(entries.map(async (entry) => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return collectFiles(fullPath, extension);
+    }
+    if (entry.isFile() && fullPath.endsWith(extension)) {
+      return [fullPath];
+    }
+    return [];
+  }));
+
+  return files.flat();
+}
+
+function stripLeadingAnnotations(text) {
+  let index = 0;
+
+  const isIdentifierChar = (char) => /[A-Za-z0-9_$.]/.test(char);
+
+  while (index < text.length) {
+    // Skip whitespace before the next token.
+    while (index < text.length && /\s/.test(text[index])) {
+      index += 1;
+    }
+
+    if (text[index] !== '@') {
+      break;
+    }
+
+    index += 1; // Skip '@'
+
+    while (index < text.length && isIdentifierChar(text[index])) {
+      index += 1;
+    }
+
+    if (text[index] === '(') {
+      let depth = 1;
+      index += 1;
+      while (index < text.length && depth > 0) {
+        const char = text[index];
+        if (char === '(') {
+          depth += 1;
+        } else if (char === ')') {
+          depth -= 1;
+        }
+        index += 1;
+      }
+    }
+
+    while (index < text.length && /\s/.test(text[index])) {
+      index += 1;
+    }
+  }
+
+  return text.slice(index);
+}
+
+async function buildJsDocs() {
+  const { stdout } = await runCommand('npx', ['jsdoc', '-X', '-c', path.join('docs', 'jsdoc.json')], {
+    cwd: repoRoot,
+    env: { ...process.env, NODE_ENV: 'production' },
+  });
+
+  try {
+    return JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(`Unable to parse JSDoc output: ${error.message}`);
+  }
+}
+
+async function buildJavaDocs() {
+  const javaSourceDir = path.join(repoRoot, 'services', 'raven', 'src', 'main', 'java');
+  let stats;
+  try {
+    stats = await fs.stat(javaSourceDir);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+
+  if (!stats.isDirectory()) {
+    return [];
+  }
+
+  const files = await collectFiles(javaSourceDir, '.java');
+  const docs = [];
+
+  for (const filePath of files) {
+    const content = await fs.readFile(filePath, 'utf8');
+    let index = 0;
+    while (true) {
+      const start = content.indexOf('/**', index);
+      if (start === -1) {
+        break;
+      }
+      const end = content.indexOf('*/', start + 3);
+      if (end === -1) {
+        break;
+      }
+
+      const commentBody = content.slice(start + 3, end);
+      const afterComment = content.slice(end + 2);
+      const signatureSource = stripLeadingAnnotations(afterComment);
+      const signatureMatch = signatureSource.match(/^\s*[^{;]+/);
+      if (!signatureMatch) {
+        index = end + 2;
+        continue;
+      }
+
+      const signature = signatureMatch[0]
+        .replace(/\s+/g, ' ')
+        .replace(/\(\s+/g, '(')
+        .replace(/\s+\)/g, ')')
+        .trim();
+      const kind = determineJavaKind(signature);
+      const name = extractJavaName(signature, kind);
+      if (!name) {
+        index = end + 2;
+        continue;
+      }
+
+      docs.push({
+        file: path.relative(repoRoot, filePath),
+        name,
+        kind,
+        signature,
+        description: cleanJavadoc(commentBody),
+      });
+
+      index = end + 2;
+    }
+  }
+
+  return docs;
+}
+
+async function main() {
+  const [jsdoc, javadoc] = await Promise.all([buildJsDocs(), buildJavaDocs()]);
+
+  const output = {
+    generatedAt: new Date().toISOString(),
+    jsdoc,
+    javadoc,
+  };
+
+  const docsDir = path.join(repoRoot, 'docs');
+  await fs.mkdir(docsDir, { recursive: true });
+  const destination = path.join(docsDir, 'docs.json');
+  await fs.writeFile(destination, `${JSON.stringify(output, null, 2)}\n`, 'utf8');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a root-level Node tooling package that runs a combined documentation generator
- aggregate JSDoc output and parsed Raven Javadoc comments into docs/docs.json
- document the new workflow in the repository README

## Testing
- npm run docs

------
https://chatgpt.com/codex/tasks/task_e_68dfc539a9008331a67c85aeb14c6fa0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified documentation generation that aggregates JavaScript and Java sources into a single output.
* **Documentation**
  * Updated README with steps to install root dependencies and run a command to regenerate documentation.
* **Chores**
  * Introduced root project configuration and development dependencies to support documentation tooling and scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->