### PR TITLE
Add healthcheck and expose port for portal Dockerfile

### DIFF
--- a/deployment/portal.Dockerfile
+++ b/deployment/portal.Dockerfile
@@ -21,5 +21,8 @@ WORKDIR /noona/services/portal
 USER root
 COPY services/portal ./
 RUN npm install
+EXPOSE 3003
+HEALTHCHECK --interval=5s --timeout=3s --start-period=5s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:3003/', res => res.statusCode === 200 ? process.exit(0) : process.exit(1)).on('error', () => process.exit(1))"
 USER noona
 CMD ["node", "initmain.mjs"]


### PR DESCRIPTION
## Summary
- expose the portal service port in its Dockerfile so the container advertises the listener
- add a Docker healthcheck that probes the portal root endpoint for an HTTP 200 response

## Testing
- docker build -f deployment/portal.Dockerfile -t noona-portal-test . *(fails: `docker` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd2660c4c83319ce29cd8e4b7563e