### PR TITLE
Align Raven health check with Warden polling endpoint

### DIFF
--- a/deployment/raven.Dockerfile
+++ b/deployment/raven.Dockerfile
@@ -45,7 +45,7 @@ EXPOSE 8080
 
 # Healthcheck to confirm readiness (optional, if you have a health endpoint)
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD curl -f http://localhost:8080/api/health || exit 1
+  CMD curl -f http://localhost:8080/v1/library/health || exit 1
 
 # Entry point to run your Raven Spring Boot API
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## Summary
- update the Raven Docker health check to call the v1/library/health endpoint so it matches Warden's probe

## Testing
- docker build -f deployment/raven.Dockerfile -t raven-test . *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd269c0d08331a95e7ace0a15c24b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated container healthcheck endpoint to /v1/library/health across build stages, improving health probe accuracy and service readiness reporting in deployment environments.
  - Enhances reliability of rollouts and monitoring with fewer false negatives.
  - No changes to features or APIs; end-user experience remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->