### PR TITLE
Use busybox-compatible wget in Moon Dockerfile healthcheck

### DIFF
--- a/deployment/moon.Dockerfile
+++ b/deployment/moon.Dockerfile
@@ -20,7 +20,7 @@ FROM nginx:alpine
 
 # Add healthcheck
 HEALTHCHECK --interval=5s --timeout=2s --start-period=3s --retries=5 \
-  CMD wget --spider -q http://localhost:3000 || exit 1
+  CMD wget -q -O /dev/null http://localhost:3000 || exit 1
 
 COPY services/moon/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/services/moon/dist /usr/share/nginx/html


### PR DESCRIPTION
## Summary
- replace the Moon Dockerfile health check probe with a BusyBox-compatible wget command

## Testing
- ⚠️ `docker build -f deployment/moon.Dockerfile -t noona-moon .` *(docker is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd83057888331bb9b8bba8b437c9f