### PR TITLE
Fix health checks for moon and vault containers

### DIFF
--- a/deployment/moon.Dockerfile
+++ b/deployment/moon.Dockerfile
@@ -18,9 +18,11 @@ RUN npx vite build
 ### Stage 2: Serve with nginx
 FROM nginx:alpine
 
+RUN apk add --no-cache curl
+
 # Add healthcheck
 HEALTHCHECK --interval=5s --timeout=2s --start-period=3s --retries=5 \
-  CMD wget -q -O /dev/null http://localhost:3000 || exit 1
+  CMD curl -fsS http://localhost:3000/ || exit 1
 
 COPY services/moon/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/services/moon/dist /usr/share/nginx/html

--- a/deployment/vault.Dockerfile
+++ b/deployment/vault.Dockerfile
@@ -21,7 +21,7 @@ EXPOSE 3005
 
 # Add healthcheck for Vault
 HEALTHCHECK --interval=5s --timeout=3s --start-period=5s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:4000/v1/vault/health', res => res.statusCode === 200 ? process.exit(0) : process.exit(1)).on('error', () => process.exit(1))"
+  CMD node -e "require('http').get('http://localhost:3005/v1/vault/health', res => res.statusCode === 200 ? process.exit(0) : process.exit(1)).on('error', () => process.exit(1))"
 
 # Set default command
 CMD ["node", "initVault.mjs"]


### PR DESCRIPTION
## Summary
- install curl in the moon image and use curl for the container health check
- correct the vault service health check to probe the running port

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfda7beedc83318b7883a7ce171e8c