### PR TITLE
chore: bump warden mongo addon to v8

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-03T12:50:35.791Z",
+  "generatedAt": "2025-10-03T14:25:44.795Z",
   "jsdoc": [
     {
       "comment": "",
@@ -10506,7 +10506,7 @@
           "id": "astnode100003672",
           "name": "rawList",
           "type": "ArrayExpression",
-          "value": "[\"{\\\"name\\\":\\\"noona-redis\\\",\\\"image\\\":\\\"redis/redis-stack:latest\\\",\\\"port\\\":8001,\\\"internalPort\\\":8001,\\\"ports\\\":\\\"\\\",\\\"exposed\\\":\\\"\\\",\\\"env\\\":\\\"\\\",\\\"volumes\\\":\\\"\\\",\\\"health\\\":\\\"http://noona-redis:8001/\\\",\\\"hostServiceUrl\\\":\\\"\\\"}\",\"{\\\"name\\\":\\\"noona-mongo\\\",\\\"image\\\":\\\"mongo:7\\\",\\\"port\\\":27017,\\\"internalPort\\\":27017,\\\"ports\\\":\\\"\\\",\\\"exposed\\\":\\\"\\\",\\\"env\\\":\\\"\\\",\\\"volumes\\\":\\\"\\\",\\\"health\\\":null,\\\"hostServiceUrl\\\":\\\"\\\"}\"]"
+          "value": "[\"{\\\"name\\\":\\\"noona-redis\\\",\\\"image\\\":\\\"redis/redis-stack:latest\\\",\\\"port\\\":8001,\\\"internalPort\\\":8001,\\\"ports\\\":\\\"\\\",\\\"exposed\\\":\\\"\\\",\\\"env\\\":\\\"\\\",\\\"volumes\\\":\\\"\\\",\\\"health\\\":\\\"http://noona-redis:8001/\\\",\\\"hostServiceUrl\\\":\\\"\\\"}\",\"{\\\"name\\\":\\\"noona-mongo\\\",\\\"image\\\":\\\"mongo:8\\\",\\\"port\\\":27017,\\\"internalPort\\\":27017,\\\"ports\\\":\\\"\\\",\\\"exposed\\\":\\\"\\\",\\\"env\\\":\\\"\\\",\\\"volumes\\\":\\\"\\\",\\\"health\\\":null,\\\"hostServiceUrl\\\":\\\"\\\"}\"]"
         }
       },
       "undocumented": true,
@@ -10943,7 +10943,7 @@
           "id": "astnode100003718",
           "name": "image",
           "type": "Literal",
-          "value": "mongo:7"
+          "value": "mongo:8"
         }
       },
       "undocumented": true,
@@ -15937,7 +15937,7 @@
       "meta": {
         "range": [
           4325,
-          18898
+          22119
         ],
         "filename": "wardenCore.mjs",
         "lineno": 165,
@@ -15963,7 +15963,7 @@
       "meta": {
         "range": [
           4332,
-          18898
+          22119
         ],
         "filename": "wardenCore.mjs",
         "lineno": 165,
@@ -15991,6 +15991,8 @@
           "SUPER_MODE": "createWarden~SUPER_MODE",
           "hostServiceBase": "createWarden~hostServiceBase",
           "bootOrder": "createWarden~bootOrder",
+          "dependencyGraph": "createWarden~dependencyGraph",
+          "requiredServices": "createWarden~requiredServices",
           "dockerFactory": "createWarden~dockerFactory",
           "hostDockerSockets": "createWarden~hostDockerSockets",
           "detectKavitaDataMount": "createWarden~detectKavitaDataMount",
@@ -15998,6 +16000,9 @@
           "api.resolveHostServiceUrl": "createWarden~api.resolveHostServiceUrl",
           "api.startService": "createWarden~api.startService",
           "api.listServices": "createWarden~api.listServices",
+          "buildInstallationList": "createWarden~buildInstallationList",
+          "resolveInstallOrder": "createWarden~resolveInstallOrder",
+          "installSingleServiceByName": "createWarden~installSingleServiceByName",
           "api.installService": "createWarden~api.installService",
           "api.installServices": "createWarden~api.installServices",
           "api.bootMinimal": "createWarden~api.bootMinimal",
@@ -16615,15 +16620,67 @@
       "comment": "",
       "meta": {
         "range": [
-          5696,
-          5779
+          5695,
+          5786
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 202,
+        "lineno": 201,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
           "id": "astnode100005773",
+          "name": "dependencyGraph",
+          "type": "NewExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "dependencyGraph",
+      "longname": "createWarden~dependencyGraph",
+      "kind": "constant",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5798,
+          5832
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 204,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005784",
+          "name": "requiredServices",
+          "type": "ArrayExpression",
+          "value": "[\"noona-vault\"]"
+        }
+      },
+      "undocumented": true,
+      "name": "requiredServices",
+      "longname": "createWarden~requiredServices",
+      "kind": "constant",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5845,
+          5928
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 206,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100005789",
           "name": "dockerFactory",
           "type": "LogicalExpression",
           "value": ""
@@ -16641,15 +16698,15 @@
       "comment": "",
       "meta": {
         "range": [
-          5765,
-          5775
+          5914,
+          5924
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 202,
+        "lineno": 206,
         "columnno": 79,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005782",
+          "id": "astnode100005798",
           "name": "socketPath",
           "type": "Identifier",
           "value": "socketPath"
@@ -16665,15 +16722,15 @@
       "comment": "",
       "meta": {
         "range": [
-          5792,
-          6020
+          5941,
+          6169
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 204,
+        "lineno": 208,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005785",
+          "id": "astnode100005801",
           "name": "hostDockerSockets",
           "type": "CallExpression",
           "value": ""
@@ -16691,15 +16748,15 @@
       "comment": "",
       "meta": {
         "range": [
-          5938,
-          5941
+          6087,
+          6090
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 206,
+        "lineno": 210,
         "columnno": 33,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005807",
+          "id": "astnode100005823",
           "name": "env",
           "type": "Identifier",
           "value": "env"
@@ -16715,15 +16772,15 @@
       "comment": "",
       "meta": {
         "range": [
-          5943,
-          5955
+          6092,
+          6104
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 206,
+        "lineno": 210,
         "columnno": 38,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005809",
+          "id": "astnode100005825",
           "name": "fs",
           "type": "Identifier",
           "value": "fsModule"
@@ -16739,15 +16796,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6027,
-          11094
+          6176,
+          11243
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 210,
+        "lineno": 214,
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005815",
+          "id": "astnode100005831",
           "name": "detectKavitaDataMount",
           "type": "FunctionDeclaration",
           "paramnames": []
@@ -16787,15 +16844,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6100,
-          6113
+          6249,
+          6262
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 212,
+        "lineno": 216,
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005821",
+          "id": "astnode100005837",
           "name": "contexts",
           "type": "ArrayExpression",
           "value": "[]"
@@ -16813,15 +16870,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6133,
-          6159
+          6282,
+          6308
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 213,
+        "lineno": 217,
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005825",
+          "id": "astnode100005841",
           "name": "visitedSockets",
           "type": "NewExpression",
           "value": ""
@@ -16839,15 +16896,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6180,
-          6313
+          6329,
+          6462
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 215,
+        "lineno": 219,
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005830",
+          "id": "astnode100005846",
           "name": "primarySocketPath",
           "type": "CallExpression",
           "value": ""
@@ -16865,15 +16922,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6360,
-          6382
+          6509,
+          6531
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 220,
+        "lineno": 224,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005845",
+          "id": "astnode100005861",
           "name": "client",
           "type": "Identifier",
           "value": "dockerInstance"
@@ -16889,15 +16946,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6400,
-          6429
+          6549,
+          6578
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 221,
+        "lineno": 225,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005847",
+          "id": "astnode100005863",
           "name": "socketPath",
           "type": "Identifier",
           "value": "primarySocketPath"
@@ -16913,15 +16970,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6447,
-          6479
+          6596,
+          6628
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 222,
+        "lineno": 226,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005849",
+          "id": "astnode100005865",
           "name": "label",
           "type": "Literal",
           "value": "default Docker instance"
@@ -16937,15 +16994,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6628,
-          6637
+          6777,
+          6786
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 229,
+        "lineno": 233,
         "columnno": 23,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005862",
+          "id": "astnode100005878",
           "name": "candidate"
         }
       },
@@ -16961,15 +17018,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7222,
-          7258
+          7371,
+          7407
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 246,
+        "lineno": 250,
         "columnno": 30,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005905",
+          "id": "astnode100005921",
           "name": "stats",
           "type": "CallExpression",
           "value": ""
@@ -16987,15 +17044,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7567,
-          7600
+          7716,
+          7749
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 256,
+        "lineno": 260,
         "columnno": 26,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005930",
+          "id": "astnode100005946",
           "name": "client",
           "type": "CallExpression",
           "value": ""
@@ -17013,15 +17070,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7676,
-          7682
+          7825,
+          7831
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 258,
+        "lineno": 262,
         "columnno": 40,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005944",
+          "id": "astnode100005960",
           "name": "client",
           "type": "Identifier",
           "value": "client"
@@ -17037,15 +17094,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7684,
-          7705
+          7833,
+          7854
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 258,
+        "lineno": 262,
         "columnno": 48,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005946",
+          "id": "astnode100005962",
           "name": "socketPath",
           "type": "Identifier",
           "value": "candidate"
@@ -17061,15 +17118,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7707,
-          7735
+          7856,
+          7884
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 258,
+        "lineno": 262,
         "columnno": 71,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005948",
+          "id": "astnode100005964",
           "name": "label",
           "type": "TemplateLiteral",
           "value": ""
@@ -17085,15 +17142,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8022,
-          8044
+          8171,
+          8193
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 266,
+        "lineno": 270,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005974",
+          "id": "astnode100005990",
           "name": "foundContainer",
           "type": "Literal",
           "value": false
@@ -17111,15 +17168,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8070,
-          8077
+          8219,
+          8226
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 268,
+        "lineno": 272,
         "columnno": 23,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005979",
+          "id": "astnode100005995",
           "name": "context"
         }
       },
@@ -17135,15 +17192,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8115,
-          8197
+          8264,
+          8346
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 269,
+        "lineno": 273,
         "columnno": 22,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100005984",
+          "id": "astnode100006000",
           "name": "contextLabel",
           "type": "ConditionalExpression",
           "value": ""
@@ -17161,15 +17218,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8248,
-          8311
+          8397,
+          8460
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 272,
+        "lineno": 276,
         "columnno": 26,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006002",
+          "id": "astnode100006018",
           "name": "containers",
           "type": "AwaitExpression",
           "value": ""
@@ -17187,15 +17244,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8299,
-          8308
+          8448,
+          8457
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 272,
+        "lineno": 276,
         "columnno": 77,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006012",
+          "id": "astnode100006028",
           "name": "all",
           "type": "Literal",
           "value": true
@@ -17211,15 +17268,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8339,
-          8859
+          8488,
+          9008
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 273,
+        "lineno": 277,
         "columnno": 26,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006015",
+          "id": "astnode100006031",
           "name": "kavitaContainer",
           "type": "CallExpression",
           "value": ""
@@ -17237,15 +17294,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8418,
-          8499
+          8567,
+          8648
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 274,
+        "lineno": 278,
         "columnno": 30,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006025",
+          "id": "astnode100006041",
           "name": "image",
           "type": "ConditionalExpression",
           "value": ""
@@ -17263,15 +17320,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8655,
-          8717
+          8804,
+          8866
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 279,
+        "lineno": 283,
         "columnno": 30,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006049",
+          "id": "astnode100006065",
           "name": "names",
           "type": "ConditionalExpression",
           "value": ""
@@ -17289,15 +17346,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8983,
-          9004
+          9132,
+          9153
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 287,
+        "lineno": 291,
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006087",
+          "id": "astnode100006103",
           "name": "foundContainer",
           "type": "Literal",
           "funcscope": "createWarden~detectKavitaDataMount",
@@ -17316,15 +17373,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9033,
-          9158
+          9182,
+          9307
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 289,
+        "lineno": 293,
         "columnno": 26,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006091",
+          "id": "astnode100006107",
           "name": "inspected",
           "type": "AwaitExpression",
           "value": ""
@@ -17342,15 +17399,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9186,
-          9218
+          9335,
+          9367
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 292,
+        "lineno": 296,
         "columnno": 26,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006107",
+          "id": "astnode100006123",
           "name": "mounts",
           "type": "LogicalExpression",
           "value": ""
@@ -17368,15 +17425,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9246,
-          9310
+          9395,
+          9459
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 293,
+        "lineno": 297,
         "columnno": 26,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006113",
+          "id": "astnode100006129",
           "name": "dataMount",
           "type": "CallExpression",
           "value": ""
@@ -17394,15 +17451,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9388,
-          9547
+          9537,
+          9696
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 296,
+        "lineno": 300,
         "columnno": 30,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006128",
+          "id": "astnode100006144",
           "name": "rawName",
           "type": "ConditionalExpression",
           "value": ""
@@ -17420,15 +17477,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9579,
-          9654
+          9728,
+          9803
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 299,
+        "lineno": 303,
         "columnno": 30,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006145",
+          "id": "astnode100006161",
           "name": "cleanName",
           "type": "ConditionalExpression",
           "value": ""
@@ -17446,15 +17503,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9687,
-          9699
+          9836,
+          9848
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 301,
+        "lineno": 305,
         "columnno": 30,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006160",
+          "id": "astnode100006176",
           "name": "details",
           "type": "ArrayExpression",
           "value": "[]"
@@ -17472,15 +17529,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9995,
-          10052
+          10144,
+          10201
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 311,
+        "lineno": 315,
         "columnno": 30,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006185",
+          "id": "astnode100006201",
           "name": "suffix",
           "type": "ConditionalExpression",
           "value": ""
@@ -17498,15 +17555,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10225,
-          10252
+          10374,
+          10401
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 316,
+        "lineno": 320,
         "columnno": 28,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006215",
+          "id": "astnode100006231",
           "name": "mountPath",
           "type": "MemberExpression",
           "value": "dataMount.Source"
@@ -17522,15 +17579,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10282,
-          10320
+          10431,
+          10469
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 317,
+        "lineno": 321,
         "columnno": 28,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006219",
+          "id": "astnode100006235",
           "name": "socketPath",
           "type": "LogicalExpression",
           "value": ""
@@ -17546,15 +17603,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10350,
-          10389
+          10499,
+          10538
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 318,
+        "lineno": 322,
         "columnno": 28,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006225",
+          "id": "astnode100006241",
           "name": "containerId",
           "type": "LogicalExpression",
           "value": ""
@@ -17570,15 +17627,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10419,
-          10451
+          10568,
+          10600
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 319,
+        "lineno": 323,
         "columnno": 28,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006231",
+          "id": "astnode100006247",
           "name": "containerName",
           "type": "LogicalExpression",
           "value": ""
@@ -17594,15 +17651,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11106,
-          11202
+          11255,
+          11351
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 339,
+        "lineno": 343,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006283",
+          "id": "astnode100006299",
           "name": "api",
           "type": "ObjectExpression",
           "value": "{\"trackedContainers\":\"\",\"networkName\":\"\",\"DEBUG\":\"\",\"SUPER_MODE\":\"\"}"
@@ -17620,15 +17677,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11122,
-          11139
+          11271,
+          11288
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 340,
+        "lineno": 344,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006286",
+          "id": "astnode100006302",
           "name": "trackedContainers",
           "type": "Identifier",
           "value": "trackedContainers"
@@ -17645,15 +17702,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11149,
-          11160
+          11298,
+          11309
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 341,
+        "lineno": 345,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006288",
+          "id": "astnode100006304",
           "name": "networkName",
           "type": "Identifier",
           "value": "networkName"
@@ -17670,15 +17727,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11170,
-          11175
+          11319,
+          11324
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 342,
+        "lineno": 346,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006290",
+          "id": "astnode100006306",
           "name": "DEBUG",
           "type": "Identifier",
           "value": "DEBUG"
@@ -17695,15 +17752,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11185,
-          11195
+          11334,
+          11344
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 343,
+        "lineno": 347,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006292",
+          "id": "astnode100006308",
           "name": "SUPER_MODE",
           "type": "Identifier",
           "value": "SUPER_MODE"
@@ -17720,15 +17777,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11209,
-          11553
+          11358,
+          11702
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 346,
+        "lineno": 350,
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006295",
+          "id": "astnode100006311",
           "name": "api.resolveHostServiceUrl",
           "type": "FunctionExpression",
           "funcscope": "createWarden",
@@ -17749,15 +17806,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11560,
-          12486
+          11709,
+          12635
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 362,
+        "lineno": 366,
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006335",
+          "id": "astnode100006351",
           "name": "api.startService",
           "type": "FunctionExpression",
           "funcscope": "createWarden",
@@ -17783,15 +17840,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11749,
-          11800
+          11898,
+          11949
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 367,
+        "lineno": 371,
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006355",
+          "id": "astnode100006371",
           "name": "hostServiceUrl",
           "type": "CallExpression",
           "value": ""
@@ -17809,15 +17866,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11816,
-          11880
+          11965,
+          12029
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 368,
+        "lineno": 372,
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006363",
+          "id": "astnode100006379",
           "name": "alreadyRunning",
           "type": "AwaitExpression",
           "value": ""
@@ -17835,15 +17892,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12493,
-          13813
+          12642,
+          13962
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 388,
+        "lineno": 392,
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006450",
+          "id": "astnode100006466",
           "name": "api.listServices",
           "type": "FunctionExpression",
           "funcscope": "createWarden",
@@ -17870,15 +17927,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12572,
-          12595
+          12721,
+          12744
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 389,
+        "lineno": 393,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006463",
+          "id": "astnode100006479",
           "name": "includeInstalled",
           "type": "AssignmentPattern",
           "value": "includeInstalled"
@@ -17894,15 +17951,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12624,
-          13131
+          12773,
+          13280
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 391,
+        "lineno": 395,
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006469",
+          "id": "astnode100006485",
           "name": "formatted",
           "type": "CallExpression",
           "value": ""
@@ -17920,15 +17977,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12692,
-          12700
+          12841,
+          12849
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 392,
+        "lineno": 396,
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006486",
+          "id": "astnode100006502",
           "name": "category",
           "type": "Identifier",
           "value": "category"
@@ -17944,15 +18001,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12702,
-          12712
+          12851,
+          12861
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 392,
+        "lineno": 396,
         "columnno": 30,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006488",
+          "id": "astnode100006504",
           "name": "descriptor",
           "type": "Identifier",
           "value": "descriptor"
@@ -17968,15 +18025,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12738,
-          12759
+          12887,
+          12908
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 393,
+        "lineno": 397,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006491",
+          "id": "astnode100006507",
           "name": "name",
           "type": "MemberExpression",
           "value": "descriptor.name"
@@ -17992,15 +18049,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12777,
-          12785
+          12926,
+          12934
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 394,
+        "lineno": 398,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006495",
+          "id": "astnode100006511",
           "name": "category",
           "type": "Identifier",
           "value": "category"
@@ -18016,15 +18073,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12803,
-          12826
+          12952,
+          12975
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 395,
+        "lineno": 399,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006497",
+          "id": "astnode100006513",
           "name": "image",
           "type": "MemberExpression",
           "value": "descriptor.image"
@@ -18040,15 +18097,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12844,
-          12873
+          12993,
+          13022
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 396,
+        "lineno": 400,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006501",
+          "id": "astnode100006517",
           "name": "port",
           "type": "LogicalExpression",
           "value": ""
@@ -18064,15 +18121,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12891,
-          12944
+          13040,
+          13093
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 397,
+        "lineno": 401,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006507",
+          "id": "astnode100006523",
           "name": "hostServiceUrl",
           "type": "CallExpression",
           "value": ""
@@ -18088,15 +18145,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12962,
-          13005
+          13111,
+          13154
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 398,
+        "lineno": 402,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006513",
+          "id": "astnode100006529",
           "name": "description",
           "type": "LogicalExpression",
           "value": ""
@@ -18112,15 +18169,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13023,
-          13056
+          13172,
+          13205
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 399,
+        "lineno": 403,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006519",
+          "id": "astnode100006535",
           "name": "health",
           "type": "LogicalExpression",
           "value": ""
@@ -18136,15 +18193,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13148,
-          13662
+          13297,
+          13811
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 403,
+        "lineno": 407,
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006539",
+          "id": "astnode100006555",
           "name": "entries",
           "type": "AwaitExpression",
           "value": ""
@@ -18162,15 +18219,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13244,
-          13261
+          13393,
+          13410
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 405,
+        "lineno": 409,
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006554",
+          "id": "astnode100006570",
           "name": "installed",
           "type": "Literal",
           "value": false
@@ -18188,15 +18245,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13306,
-          13365
+          13455,
+          13514
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 408,
+        "lineno": 412,
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006560",
+          "id": "astnode100006576",
           "name": "installed",
           "type": "AwaitExpression",
           "funcscope": "<anonymous>",
@@ -18215,15 +18272,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13624,
-          13633
+          13773,
+          13782
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 415,
+        "lineno": 419,
         "columnno": 37,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006577",
+          "id": "astnode100006593",
           "name": "installed",
           "type": "Identifier",
           "value": "installed"
@@ -18239,15 +18296,1191 @@
       "comment": "",
       "meta": {
         "range": [
-          13820,
-          15714
+          13975,
+          14962
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 426,
+        "lineno": 430,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006613",
+          "name": "buildInstallationList",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "invalidEntries": "createWarden~buildInstallationList~invalidEntries",
+          "seen": "createWarden~buildInstallationList~seen",
+          "prioritized": "createWarden~buildInstallationList~prioritized",
+          "required": "createWarden~buildInstallationList~required",
+          "candidate": "createWarden~buildInstallationList~candidate",
+          "trimmed": "createWarden~buildInstallationList~trimmed"
+        }
+      },
+      "undocumented": true,
+      "name": "buildInstallationList",
+      "longname": "createWarden~buildInstallationList",
+      "kind": "function",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14036,
+          14055
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 431,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006621",
+          "name": "invalidEntries",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "invalidEntries",
+      "longname": "createWarden~buildInstallationList~invalidEntries",
+      "kind": "constant",
+      "memberof": "createWarden~buildInstallationList",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14071,
+          14087
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 432,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006625",
+          "name": "seen",
+          "type": "NewExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "seen",
+      "longname": "createWarden~buildInstallationList~seen",
+      "kind": "constant",
+      "memberof": "createWarden~buildInstallationList",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14103,
+          14119
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 433,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006630",
+          "name": "prioritized",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "prioritized",
+      "longname": "createWarden~buildInstallationList~prioritized",
+      "kind": "constant",
+      "memberof": "createWarden~buildInstallationList",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14141,
+          14149
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 435,
+        "columnno": 19,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006635",
+          "name": "required"
+        }
+      },
+      "undocumented": true,
+      "name": "required",
+      "longname": "createWarden~buildInstallationList~required",
+      "kind": "constant",
+      "memberof": "createWarden~buildInstallationList",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14336,
+          14345
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 442,
+        "columnno": 19,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006661",
+          "name": "candidate"
+        }
+      },
+      "undocumented": true,
+      "name": "candidate",
+      "longname": "createWarden~buildInstallationList~candidate",
+      "kind": "constant",
+      "memberof": "createWarden~buildInstallationList",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14381,
+          14444
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 443,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006666",
+          "name": "trimmed",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "trimmed",
+      "longname": "createWarden~buildInstallationList~trimmed",
+      "kind": "constant",
+      "memberof": "createWarden~buildInstallationList",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14533,
+          14607
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 447,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006688",
+          "name": "name",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14629,
+          14644
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 448,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006701",
+          "name": "status",
+          "type": "Literal",
+          "value": "error"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14666,
+          14705
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 449,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006703",
+          "name": "error",
+          "type": "Literal",
+          "value": "Invalid service name provided."
+        }
+      },
+      "undocumented": true,
+      "name": "error",
+      "longname": "error",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14926,
+          14937
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 460,
+        "columnno": 17,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006728",
+          "name": "prioritized",
+          "type": "Identifier",
+          "value": "prioritized"
+        }
+      },
+      "undocumented": true,
+      "name": "prioritized",
+      "longname": "prioritized",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14939,
+          14953
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 460,
+        "columnno": 30,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006730",
+          "name": "invalidEntries",
+          "type": "Identifier",
+          "value": "invalidEntries"
+        }
+      },
+      "undocumented": true,
+      "name": "invalidEntries",
+      "longname": "invalidEntries",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14975,
+          15824
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 463,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006733",
+          "name": "resolveInstallOrder",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "order": "createWarden~resolveInstallOrder~order",
+          "visited": "createWarden~resolveInstallOrder~visited",
+          "visiting": "createWarden~resolveInstallOrder~visiting",
+          "visit": "createWarden~resolveInstallOrder~visit",
+          "": null,
+          "name": "createWarden~resolveInstallOrder~name"
+        }
+      },
+      "undocumented": true,
+      "name": "resolveInstallOrder",
+      "longname": "createWarden~resolveInstallOrder",
+      "kind": "function",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15029,
+          15039
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 464,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006741",
+          "name": "order",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "order",
+      "longname": "createWarden~resolveInstallOrder~order",
+      "kind": "constant",
+      "memberof": "createWarden~resolveInstallOrder",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15055,
+          15074
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 465,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006745",
+          "name": "visited",
+          "type": "NewExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "visited",
+      "longname": "createWarden~resolveInstallOrder~visited",
+      "kind": "constant",
+      "memberof": "createWarden~resolveInstallOrder",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15090,
+          15110
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 466,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006750",
+          "name": "visiting",
+          "type": "NewExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "visiting",
+      "longname": "createWarden~resolveInstallOrder~visiting",
+      "kind": "constant",
+      "memberof": "createWarden~resolveInstallOrder",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15127,
+          15722
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 468,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006755",
+          "name": "visit",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "chain": "createWarden~resolveInstallOrder~visit~chain",
+          "dependencies": "createWarden~resolveInstallOrder~visit~dependencies",
+          "dependency": "createWarden~resolveInstallOrder~visit~dependency"
+        }
+      },
+      "undocumented": true,
+      "name": "visit",
+      "longname": "createWarden~resolveInstallOrder~visit",
+      "kind": "function",
+      "memberof": "createWarden~resolveInstallOrder",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15283,
+          15323
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 474,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006776",
+          "name": "chain",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "chain",
+      "longname": "createWarden~resolveInstallOrder~visit~chain",
+      "kind": "constant",
+      "memberof": "createWarden~resolveInstallOrder~visit",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15466,
+          15512
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 480,
+        "columnno": 18,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006800",
+          "name": "dependencies",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "dependencies",
+      "longname": "createWarden~resolveInstallOrder~visit~dependencies",
+      "kind": "constant",
+      "memberof": "createWarden~resolveInstallOrder~visit",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15537,
+          15547
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 481,
+        "columnno": 23,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006811",
+          "name": "dependency"
+        }
+      },
+      "undocumented": true,
+      "name": "dependency",
+      "longname": "createWarden~resolveInstallOrder~visit~dependency",
+      "kind": "constant",
+      "memberof": "createWarden~resolveInstallOrder~visit",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15744,
+          15748
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 490,
+        "columnno": 19,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006839",
+          "name": "name"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "createWarden~resolveInstallOrder~name",
+      "kind": "constant",
+      "memberof": "createWarden~resolveInstallOrder",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15837,
+          17531
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 497,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006850",
+          "name": "installSingleServiceByName",
+          "type": "ArrowFunctionExpression"
+        },
+        "vars": {
+          "entry": "createWarden~installSingleServiceByName~entry",
+          "undefined": null,
+          "healthUrl": "createWarden~installSingleServiceByName~healthUrl",
+          "kavitaDetection": "createWarden~installSingleServiceByName~kavitaDetection",
+          "kavitaDataMount": "createWarden~installSingleServiceByName~kavitaDataMount",
+          "serviceDescriptor": "createWarden~installSingleServiceByName~serviceDescriptor",
+          "baseEnv": "createWarden~installSingleServiceByName~baseEnv",
+          "volumes": "createWarden~installSingleServiceByName~volumes",
+          "result": "createWarden~installSingleServiceByName~result",
+          "result.kavitaDataMount": "createWarden~installSingleServiceByName~result.kavitaDataMount",
+          "result.kavitaDetection": "createWarden~installSingleServiceByName~result.kavitaDetection"
+        }
+      },
+      "undocumented": true,
+      "name": "installSingleServiceByName",
+      "longname": "createWarden~installSingleServiceByName",
+      "kind": "function",
+      "memberof": "createWarden",
+      "scope": "inner",
+      "params": [],
+      "async": true
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          15898,
+          15930
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 498,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006856",
+          "name": "entry",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "entry",
+      "longname": "createWarden~installSingleServiceByName~entry",
+      "kind": "constant",
+      "memberof": "createWarden~installSingleServiceByName",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16061,
+          16071
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 504,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006877",
+          "name": "descriptor",
+          "type": "Identifier",
+          "value": "descriptor"
+        }
+      },
+      "undocumented": true,
+      "name": "descriptor",
+      "longname": "descriptor",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16073,
+          16081
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 504,
+        "columnno": 28,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006879",
+          "name": "category",
+          "type": "Identifier",
+          "value": "category"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16107,
+          16144
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 505,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006883",
+          "name": "healthUrl",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "healthUrl",
+      "longname": "createWarden~installSingleServiceByName~healthUrl",
+      "kind": "constant",
+      "memberof": "createWarden~installSingleServiceByName",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16158,
+          16180
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 506,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006891",
+          "name": "kavitaDetection",
+          "type": "Literal",
+          "value": null
+        }
+      },
+      "undocumented": true,
+      "name": "kavitaDetection",
+      "longname": "createWarden~installSingleServiceByName~kavitaDetection",
+      "kind": "member",
+      "memberof": "createWarden~installSingleServiceByName",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16194,
+          16216
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 507,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006895",
+          "name": "kavitaDataMount",
+          "type": "Literal",
+          "value": null
+        }
+      },
+      "undocumented": true,
+      "name": "kavitaDataMount",
+      "longname": "createWarden~installSingleServiceByName~kavitaDataMount",
+      "kind": "member",
+      "memberof": "createWarden~installSingleServiceByName",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16230,
+          16260
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 508,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006899",
+          "name": "serviceDescriptor",
+          "type": "Identifier",
+          "value": "descriptor"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceDescriptor",
+      "longname": "createWarden~installSingleServiceByName~serviceDescriptor",
+      "kind": "member",
+      "memberof": "createWarden~installSingleServiceByName",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16324,
+          16371
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 511,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006910",
+          "name": "kavitaDetection",
+          "type": "AwaitExpression",
+          "funcscope": "createWarden~installSingleServiceByName",
+          "value": "",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "kavitaDetection",
+      "longname": "createWarden~installSingleServiceByName~kavitaDetection",
+      "kind": "member",
+      "memberof": "createWarden~installSingleServiceByName",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16385,
+          16437
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 512,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006916",
+          "name": "kavitaDataMount",
+          "type": "LogicalExpression",
+          "funcscope": "createWarden~installSingleServiceByName",
+          "value": "",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "kavitaDataMount",
+      "longname": "createWarden~installSingleServiceByName~kavitaDataMount",
+      "kind": "member",
+      "memberof": "createWarden~installSingleServiceByName",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16497,
+          16563
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 515,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006925",
+          "name": "baseEnv",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "baseEnv",
+      "longname": "createWarden~installSingleServiceByName~baseEnv",
+      "kind": "constant",
+      "memberof": "createWarden~installSingleServiceByName",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16587,
+          16661
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 516,
+        "columnno": 22,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006942",
+          "name": "volumes",
+          "type": "ConditionalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "volumes",
+      "longname": "createWarden~installSingleServiceByName~volumes",
+      "kind": "constant",
+      "memberof": "createWarden~installSingleServiceByName",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16834,
+          16971
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 521,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006975",
+          "name": "serviceDescriptor",
+          "type": "ObjectExpression",
+          "funcscope": "createWarden~installSingleServiceByName",
+          "value": "{\"env\":\"\",\"volumes\":\"\"}",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "serviceDescriptor",
+      "longname": "createWarden~installSingleServiceByName~serviceDescriptor",
+      "kind": "member",
+      "memberof": "createWarden~installSingleServiceByName",
+      "scope": "inner"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16911,
+          16923
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 523,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006980",
+          "name": "env",
+          "type": "Identifier",
+          "value": "baseEnv"
+        }
+      },
+      "undocumented": true,
+      "name": "env",
+      "longname": "createWarden~installSingleServiceByName~serviceDescriptor.env",
+      "kind": "member",
+      "memberof": "createWarden~installSingleServiceByName~serviceDescriptor",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          16945,
+          16952
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 524,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006982",
+          "name": "volumes",
+          "type": "Identifier",
+          "value": "volumes"
+        }
+      },
+      "undocumented": true,
+      "name": "volumes",
+      "longname": "createWarden~installSingleServiceByName~serviceDescriptor.volumes",
+      "kind": "member",
+      "memberof": "createWarden~installSingleServiceByName~serviceDescriptor",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          17075,
+          17332
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 531,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006993",
+          "name": "result",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"\",\"category\":\"\",\"status\":\"installed\",\"hostServiceUrl\":\"\",\"image\":\"\",\"port\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "result",
+      "longname": "createWarden~installSingleServiceByName~result",
+      "kind": "constant",
+      "memberof": "createWarden~installSingleServiceByName",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          17098,
+          17119
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 532,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100006996",
+          "name": "name",
+          "type": "MemberExpression",
+          "value": "descriptor.name"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "createWarden~installSingleServiceByName~result.name",
+      "kind": "member",
+      "memberof": "createWarden~installSingleServiceByName~result",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          17133,
+          17141
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 533,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007000",
+          "name": "category",
+          "type": "Identifier",
+          "value": "category"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "createWarden~installSingleServiceByName~result.category",
+      "kind": "member",
+      "memberof": "createWarden~installSingleServiceByName~result",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          17155,
+          17174
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 534,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007002",
+          "name": "status",
+          "type": "Literal",
+          "value": "installed"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "createWarden~installSingleServiceByName~result.status",
+      "kind": "member",
+      "memberof": "createWarden~installSingleServiceByName~result",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          17188,
+          17241
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 535,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007004",
+          "name": "hostServiceUrl",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "createWarden~installSingleServiceByName~result.hostServiceUrl",
+      "kind": "member",
+      "memberof": "createWarden~installSingleServiceByName~result",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          17255,
+          17278
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 536,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007010",
+          "name": "image",
+          "type": "MemberExpression",
+          "value": "descriptor.image"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "createWarden~installSingleServiceByName~result.image",
+      "kind": "member",
+      "memberof": "createWarden~installSingleServiceByName~result",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          17292,
+          17321
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 537,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007014",
+          "name": "port",
+          "type": "LogicalExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "createWarden~installSingleServiceByName~result.port",
+      "kind": "member",
+      "memberof": "createWarden~installSingleServiceByName~result",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          17396,
+          17436
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 541,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007028",
+          "name": "result.kavitaDataMount",
+          "type": "Identifier",
+          "funcscope": "createWarden~installSingleServiceByName",
+          "value": "kavitaDataMount",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "kavitaDataMount",
+      "longname": "createWarden~installSingleServiceByName~result.kavitaDataMount",
+      "kind": "member",
+      "memberof": "createWarden~installSingleServiceByName~result",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          17450,
+          17490
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 542,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007034",
+          "name": "result.kavitaDetection",
+          "type": "Identifier",
+          "funcscope": "createWarden~installSingleServiceByName",
+          "value": "kavitaDetection",
+          "paramnames": []
+        }
+      },
+      "undocumented": true,
+      "name": "kavitaDetection",
+      "longname": "createWarden~installSingleServiceByName~result.kavitaDetection",
+      "kind": "member",
+      "memberof": "createWarden~installSingleServiceByName~result",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          17538,
+          18597
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 548,
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006597",
+          "id": "astnode100007042",
           "name": "api.installService",
           "type": "FunctionExpression",
           "funcscope": "createWarden",
@@ -18258,17 +19491,12 @@
         },
         "vars": {
           "trimmedName": "createWarden~api.installService~trimmedName",
-          "entry": "createWarden~api.installService~entry",
           "undefined": null,
-          "healthUrl": "createWarden~api.installService~healthUrl",
-          "kavitaDetection": "createWarden~api.installService~kavitaDetection",
-          "kavitaDataMount": "createWarden~api.installService~kavitaDataMount",
-          "serviceDescriptor": "createWarden~api.installService~serviceDescriptor",
-          "baseEnv": "createWarden~api.installService~baseEnv",
-          "volumes": "createWarden~api.installService~volumes",
-          "result": "createWarden~api.installService~result",
-          "result.kavitaDataMount": "createWarden~api.installService~result.kavitaDataMount",
-          "result.kavitaDetection": "createWarden~api.installService~result.kavitaDetection"
+          "order": "createWarden~api.installService~order",
+          "attempted": "createWarden~api.installService~attempted",
+          "targetResult": "createWarden~api.installService~targetResult",
+          "serviceName": "createWarden~api.installService~serviceName",
+          "result": "createWarden~api.installService~result"
         }
       },
       "undocumented": true,
@@ -18282,15 +19510,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14026,
-          14051
+          17744,
+          17769
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 431,
+        "lineno": 553,
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006619",
+          "id": "astnode100007064",
           "name": "trimmedName",
           "type": "CallExpression",
           "value": ""
@@ -18308,23 +19536,47 @@
       "comment": "",
       "meta": {
         "range": [
-          14067,
-          14106
+          17900,
+          17911
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 432,
+        "lineno": 559,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007081",
+          "name": "prioritized",
+          "type": "Identifier",
+          "value": "prioritized"
+        }
+      },
+      "undocumented": true,
+      "name": "prioritized",
+      "longname": "prioritized",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          17968,
+          18008
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 560,
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006626",
-          "name": "entry",
+          "id": "astnode100007088",
+          "name": "order",
           "type": "CallExpression",
           "value": ""
         }
       },
       "undocumented": true,
-      "name": "entry",
-      "longname": "createWarden~api.installService~entry",
+      "name": "order",
+      "longname": "createWarden~api.installService~order",
       "kind": "constant",
       "memberof": "createWarden~api.installService",
       "scope": "inner",
@@ -18334,71 +19586,23 @@
       "comment": "",
       "meta": {
         "range": [
-          14244,
-          14254
+          18024,
+          18045
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 438,
-        "columnno": 16,
-        "path": "/workspace/Noona/services/warden/shared",
-        "code": {
-          "id": "astnode100006647",
-          "name": "descriptor",
-          "type": "Identifier",
-          "value": "descriptor"
-        }
-      },
-      "undocumented": true,
-      "name": "descriptor",
-      "longname": "descriptor",
-      "kind": "member",
-      "scope": "global"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          14256,
-          14264
-        ],
-        "filename": "wardenCore.mjs",
-        "lineno": 438,
-        "columnno": 28,
-        "path": "/workspace/Noona/services/warden/shared",
-        "code": {
-          "id": "astnode100006649",
-          "name": "category",
-          "type": "Identifier",
-          "value": "category"
-        }
-      },
-      "undocumented": true,
-      "name": "category",
-      "longname": "category",
-      "kind": "member",
-      "scope": "global"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          14290,
-          14327
-        ],
-        "filename": "wardenCore.mjs",
-        "lineno": 439,
+        "lineno": 561,
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006653",
-          "name": "healthUrl",
-          "type": "LogicalExpression",
+          "id": "astnode100007094",
+          "name": "attempted",
+          "type": "NewExpression",
           "value": ""
         }
       },
       "undocumented": true,
-      "name": "healthUrl",
-      "longname": "createWarden~api.installService~healthUrl",
+      "name": "attempted",
+      "longname": "createWarden~api.installService~attempted",
       "kind": "constant",
       "memberof": "createWarden~api.installService",
       "scope": "inner",
@@ -18408,23 +19612,23 @@
       "comment": "",
       "meta": {
         "range": [
-          14341,
-          14363
+          18059,
+          18078
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 440,
+        "lineno": 562,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006661",
-          "name": "kavitaDetection",
+          "id": "astnode100007099",
+          "name": "targetResult",
           "type": "Literal",
           "value": null
         }
       },
       "undocumented": true,
-      "name": "kavitaDetection",
-      "longname": "createWarden~api.installService~kavitaDetection",
+      "name": "targetResult",
+      "longname": "createWarden~api.installService~targetResult",
       "kind": "member",
       "memberof": "createWarden~api.installService",
       "scope": "inner",
@@ -18434,129 +19638,21 @@
       "comment": "",
       "meta": {
         "range": [
-          14377,
-          14399
+          18100,
+          18111
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 441,
-        "columnno": 12,
+        "lineno": 564,
+        "columnno": 19,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006665",
-          "name": "kavitaDataMount",
-          "type": "Literal",
-          "value": null
+          "id": "astnode100007104",
+          "name": "serviceName"
         }
       },
       "undocumented": true,
-      "name": "kavitaDataMount",
-      "longname": "createWarden~api.installService~kavitaDataMount",
-      "kind": "member",
-      "memberof": "createWarden~api.installService",
-      "scope": "inner",
-      "params": []
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          14413,
-          14443
-        ],
-        "filename": "wardenCore.mjs",
-        "lineno": 442,
-        "columnno": 12,
-        "path": "/workspace/Noona/services/warden/shared",
-        "code": {
-          "id": "astnode100006669",
-          "name": "serviceDescriptor",
-          "type": "Identifier",
-          "value": "descriptor"
-        }
-      },
-      "undocumented": true,
-      "name": "serviceDescriptor",
-      "longname": "createWarden~api.installService~serviceDescriptor",
-      "kind": "member",
-      "memberof": "createWarden~api.installService",
-      "scope": "inner",
-      "params": []
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          14507,
-          14554
-        ],
-        "filename": "wardenCore.mjs",
-        "lineno": 445,
-        "columnno": 12,
-        "path": "/workspace/Noona/services/warden/shared",
-        "code": {
-          "id": "astnode100006680",
-          "name": "kavitaDetection",
-          "type": "AwaitExpression",
-          "funcscope": "createWarden~api.installService",
-          "value": "",
-          "paramnames": []
-        }
-      },
-      "undocumented": true,
-      "name": "kavitaDetection",
-      "longname": "createWarden~api.installService~kavitaDetection",
-      "kind": "member",
-      "memberof": "createWarden~api.installService",
-      "scope": "inner"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          14568,
-          14620
-        ],
-        "filename": "wardenCore.mjs",
-        "lineno": 446,
-        "columnno": 12,
-        "path": "/workspace/Noona/services/warden/shared",
-        "code": {
-          "id": "astnode100006686",
-          "name": "kavitaDataMount",
-          "type": "LogicalExpression",
-          "funcscope": "createWarden~api.installService",
-          "value": "",
-          "paramnames": []
-        }
-      },
-      "undocumented": true,
-      "name": "kavitaDataMount",
-      "longname": "createWarden~api.installService~kavitaDataMount",
-      "kind": "member",
-      "memberof": "createWarden~api.installService",
-      "scope": "inner"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          14680,
-          14746
-        ],
-        "filename": "wardenCore.mjs",
-        "lineno": 449,
-        "columnno": 22,
-        "path": "/workspace/Noona/services/warden/shared",
-        "code": {
-          "id": "astnode100006695",
-          "name": "baseEnv",
-          "type": "ConditionalExpression",
-          "value": ""
-        }
-      },
-      "undocumented": true,
-      "name": "baseEnv",
-      "longname": "createWarden~api.installService~baseEnv",
+      "name": "serviceName",
+      "longname": "createWarden~api.installService~serviceName",
       "kind": "constant",
       "memberof": "createWarden~api.installService",
       "scope": "inner",
@@ -18566,121 +19662,18 @@
       "comment": "",
       "meta": {
         "range": [
-          14770,
-          14844
+          18269,
+          18323
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 450,
-        "columnno": 22,
+        "lineno": 570,
+        "columnno": 18,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006712",
-          "name": "volumes",
-          "type": "ConditionalExpression",
-          "value": ""
-        }
-      },
-      "undocumented": true,
-      "name": "volumes",
-      "longname": "createWarden~api.installService~volumes",
-      "kind": "constant",
-      "memberof": "createWarden~api.installService",
-      "scope": "inner",
-      "params": []
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          15017,
-          15154
-        ],
-        "filename": "wardenCore.mjs",
-        "lineno": 455,
-        "columnno": 16,
-        "path": "/workspace/Noona/services/warden/shared",
-        "code": {
-          "id": "astnode100006745",
-          "name": "serviceDescriptor",
-          "type": "ObjectExpression",
-          "funcscope": "createWarden~api.installService",
-          "value": "{\"env\":\"\",\"volumes\":\"\"}",
-          "paramnames": []
-        }
-      },
-      "undocumented": true,
-      "name": "serviceDescriptor",
-      "longname": "createWarden~api.installService~serviceDescriptor",
-      "kind": "member",
-      "memberof": "createWarden~api.installService",
-      "scope": "inner"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          15094,
-          15106
-        ],
-        "filename": "wardenCore.mjs",
-        "lineno": 457,
-        "columnno": 20,
-        "path": "/workspace/Noona/services/warden/shared",
-        "code": {
-          "id": "astnode100006750",
-          "name": "env",
-          "type": "Identifier",
-          "value": "baseEnv"
-        }
-      },
-      "undocumented": true,
-      "name": "env",
-      "longname": "createWarden~api.installService~serviceDescriptor.env",
-      "kind": "member",
-      "memberof": "createWarden~api.installService~serviceDescriptor",
-      "scope": "static"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          15128,
-          15135
-        ],
-        "filename": "wardenCore.mjs",
-        "lineno": 458,
-        "columnno": 20,
-        "path": "/workspace/Noona/services/warden/shared",
-        "code": {
-          "id": "astnode100006752",
-          "name": "volumes",
-          "type": "Identifier",
-          "value": "volumes"
-        }
-      },
-      "undocumented": true,
-      "name": "volumes",
-      "longname": "createWarden~api.installService~serviceDescriptor.volumes",
-      "kind": "member",
-      "memberof": "createWarden~api.installService~serviceDescriptor",
-      "scope": "static"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          15258,
-          15515
-        ],
-        "filename": "wardenCore.mjs",
-        "lineno": 465,
-        "columnno": 14,
-        "path": "/workspace/Noona/services/warden/shared",
-        "code": {
-          "id": "astnode100006763",
+          "id": "astnode100007123",
           "name": "result",
-          "type": "ObjectExpression",
-          "value": "{\"name\":\"\",\"category\":\"\",\"status\":\"installed\",\"hostServiceUrl\":\"\",\"image\":\"\",\"port\":\"\"}"
+          "type": "AwaitExpression",
+          "value": ""
         }
       },
       "undocumented": true,
@@ -18695,219 +19688,42 @@
       "comment": "",
       "meta": {
         "range": [
-          15281,
-          15302
+          18389,
+          18410
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 466,
-        "columnno": 12,
+        "lineno": 573,
+        "columnno": 16,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006766",
-          "name": "name",
-          "type": "MemberExpression",
-          "value": "descriptor.name"
-        }
-      },
-      "undocumented": true,
-      "name": "name",
-      "longname": "createWarden~api.installService~result.name",
-      "kind": "member",
-      "memberof": "createWarden~api.installService~result",
-      "scope": "static"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          15316,
-          15324
-        ],
-        "filename": "wardenCore.mjs",
-        "lineno": 467,
-        "columnno": 12,
-        "path": "/workspace/Noona/services/warden/shared",
-        "code": {
-          "id": "astnode100006770",
-          "name": "category",
-          "type": "Identifier",
-          "value": "category"
-        }
-      },
-      "undocumented": true,
-      "name": "category",
-      "longname": "createWarden~api.installService~result.category",
-      "kind": "member",
-      "memberof": "createWarden~api.installService~result",
-      "scope": "static"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          15338,
-          15357
-        ],
-        "filename": "wardenCore.mjs",
-        "lineno": 468,
-        "columnno": 12,
-        "path": "/workspace/Noona/services/warden/shared",
-        "code": {
-          "id": "astnode100006772",
-          "name": "status",
-          "type": "Literal",
-          "value": "installed"
-        }
-      },
-      "undocumented": true,
-      "name": "status",
-      "longname": "createWarden~api.installService~result.status",
-      "kind": "member",
-      "memberof": "createWarden~api.installService~result",
-      "scope": "static"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          15371,
-          15424
-        ],
-        "filename": "wardenCore.mjs",
-        "lineno": 469,
-        "columnno": 12,
-        "path": "/workspace/Noona/services/warden/shared",
-        "code": {
-          "id": "astnode100006774",
-          "name": "hostServiceUrl",
-          "type": "CallExpression",
-          "value": ""
-        }
-      },
-      "undocumented": true,
-      "name": "hostServiceUrl",
-      "longname": "createWarden~api.installService~result.hostServiceUrl",
-      "kind": "member",
-      "memberof": "createWarden~api.installService~result",
-      "scope": "static"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          15438,
-          15461
-        ],
-        "filename": "wardenCore.mjs",
-        "lineno": 470,
-        "columnno": 12,
-        "path": "/workspace/Noona/services/warden/shared",
-        "code": {
-          "id": "astnode100006780",
-          "name": "image",
-          "type": "MemberExpression",
-          "value": "descriptor.image"
-        }
-      },
-      "undocumented": true,
-      "name": "image",
-      "longname": "createWarden~api.installService~result.image",
-      "kind": "member",
-      "memberof": "createWarden~api.installService~result",
-      "scope": "static"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          15475,
-          15504
-        ],
-        "filename": "wardenCore.mjs",
-        "lineno": 471,
-        "columnno": 12,
-        "path": "/workspace/Noona/services/warden/shared",
-        "code": {
-          "id": "astnode100006784",
-          "name": "port",
-          "type": "LogicalExpression",
-          "value": ""
-        }
-      },
-      "undocumented": true,
-      "name": "port",
-      "longname": "createWarden~api.installService~result.port",
-      "kind": "member",
-      "memberof": "createWarden~api.installService~result",
-      "scope": "static"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          15579,
-          15619
-        ],
-        "filename": "wardenCore.mjs",
-        "lineno": 475,
-        "columnno": 12,
-        "path": "/workspace/Noona/services/warden/shared",
-        "code": {
-          "id": "astnode100006798",
-          "name": "result.kavitaDataMount",
+          "id": "astnode100007135",
+          "name": "targetResult",
           "type": "Identifier",
           "funcscope": "createWarden~api.installService",
-          "value": "kavitaDataMount",
+          "value": "result",
           "paramnames": []
         }
       },
       "undocumented": true,
-      "name": "kavitaDataMount",
-      "longname": "createWarden~api.installService~result.kavitaDataMount",
+      "name": "targetResult",
+      "longname": "createWarden~api.installService~targetResult",
       "kind": "member",
-      "memberof": "createWarden~api.installService~result",
-      "scope": "static"
+      "memberof": "createWarden~api.installService",
+      "scope": "inner"
     },
     {
       "comment": "",
       "meta": {
         "range": [
-          15633,
-          15673
+          18604,
+          19779
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 476,
-        "columnno": 12,
-        "path": "/workspace/Noona/services/warden/shared",
-        "code": {
-          "id": "astnode100006804",
-          "name": "result.kavitaDetection",
-          "type": "Identifier",
-          "funcscope": "createWarden~api.installService",
-          "value": "kavitaDetection",
-          "paramnames": []
-        }
-      },
-      "undocumented": true,
-      "name": "kavitaDetection",
-      "longname": "createWarden~api.installService~result.kavitaDetection",
-      "kind": "member",
-      "memberof": "createWarden~api.installService~result",
-      "scope": "static"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          15721,
-          16558
-        ],
-        "filename": "wardenCore.mjs",
-        "lineno": 482,
+        "lineno": 584,
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006812",
+          "id": "astnode100007152",
           "name": "api.installServices",
           "type": "FunctionExpression",
           "funcscope": "createWarden",
@@ -18917,9 +19733,11 @@
           ]
         },
         "vars": {
+          "undefined": null,
           "results": "createWarden~api.installServices~results",
-          "candidate": "createWarden~api.installServices~candidate",
-          "name": "createWarden~api.installServices~name",
+          "order": "createWarden~api.installServices~order",
+          "attempted": "createWarden~api.installServices~attempted",
+          "serviceName": "createWarden~api.installServices~serviceName",
           "result": "createWarden~api.installServices~result"
         }
       },
@@ -18934,15 +19752,63 @@
       "comment": "",
       "meta": {
         "range": [
-          15802,
-          15814
+          18687,
+          18698
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 483,
+        "lineno": 585,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007165",
+          "name": "prioritized",
+          "type": "Identifier",
+          "value": "prioritized"
+        }
+      },
+      "undocumented": true,
+      "name": "prioritized",
+      "longname": "prioritized",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          18700,
+          18714
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 585,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007167",
+          "name": "invalidEntries",
+          "type": "Identifier",
+          "value": "invalidEntries"
+        }
+      },
+      "undocumented": true,
+      "name": "invalidEntries",
+      "longname": "invalidEntries",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          18763,
+          18775
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 586,
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006823",
+          "id": "astnode100007173",
           "name": "results",
           "type": "ArrayExpression",
           "value": "[]"
@@ -18960,22 +19826,22 @@
       "comment": "",
       "meta": {
         "range": [
-          15836,
-          15845
+          18789,
+          18794
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 485,
-        "columnno": 19,
+        "lineno": 587,
+        "columnno": 12,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006828",
-          "name": "candidate"
+          "id": "astnode100007177",
+          "name": "order"
         }
       },
       "undocumented": true,
-      "name": "candidate",
-      "longname": "createWarden~api.installServices~candidate",
-      "kind": "constant",
+      "name": "order",
+      "longname": "createWarden~api.installServices~order",
+      "kind": "member",
       "memberof": "createWarden~api.installServices",
       "scope": "inner",
       "params": []
@@ -18984,44 +19850,45 @@
       "comment": "",
       "meta": {
         "range": [
-          15876,
-          15936
+          18823,
+          18863
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 486,
-        "columnno": 18,
+        "lineno": 590,
+        "columnno": 12,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006833",
-          "name": "name",
-          "type": "ConditionalExpression",
-          "value": ""
+          "id": "astnode100007182",
+          "name": "order",
+          "type": "CallExpression",
+          "funcscope": "createWarden~api.installServices",
+          "value": "",
+          "paramnames": []
         }
       },
       "undocumented": true,
-      "name": "name",
-      "longname": "createWarden~api.installServices~name",
-      "kind": "constant",
+      "name": "order",
+      "longname": "createWarden~api.installServices~order",
+      "kind": "member",
       "memberof": "createWarden~api.installServices",
-      "scope": "inner",
-      "params": []
+      "scope": "inner"
     },
     {
       "comment": "",
       "meta": {
         "range": [
-          16015,
-          16038
+          19013,
+          19033
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 490,
+        "lineno": 596,
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006855",
+          "id": "astnode100007195",
           "name": "name",
-          "type": "LogicalExpression",
-          "value": ""
+          "type": "Literal",
+          "value": "installation"
         }
       },
       "undocumented": true,
@@ -19034,15 +19901,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16060,
-          16075
+          19055,
+          19070
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 491,
+        "lineno": 597,
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006859",
+          "id": "astnode100007197",
           "name": "status",
           "type": "Literal",
           "value": "error"
@@ -19058,18 +19925,18 @@
       "comment": "",
       "meta": {
         "range": [
-          16097,
-          16136
+          19092,
+          19112
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 492,
+        "lineno": 598,
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006861",
+          "id": "astnode100007199",
           "name": "error",
-          "type": "Literal",
-          "value": "Invalid service name provided."
+          "type": "MemberExpression",
+          "value": "error.message"
         }
       },
       "undocumented": true,
@@ -19082,15 +19949,65 @@
       "comment": "",
       "meta": {
         "range": [
-          16239,
-          16278
+          19173,
+          19194
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 498,
+        "lineno": 603,
+        "columnno": 14,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007204",
+          "name": "attempted",
+          "type": "NewExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "attempted",
+      "longname": "createWarden~api.installServices~attempted",
+      "kind": "constant",
+      "memberof": "createWarden~api.installServices",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          19216,
+          19227
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 605,
+        "columnno": 19,
+        "path": "/workspace/Noona/services/warden/shared",
+        "code": {
+          "id": "astnode100007210",
+          "name": "serviceName"
+        }
+      },
+      "undocumented": true,
+      "name": "serviceName",
+      "longname": "createWarden~api.installServices~serviceName",
+      "kind": "constant",
+      "memberof": "createWarden~api.installServices",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          19408,
+          19462
+        ],
+        "filename": "wardenCore.mjs",
+        "lineno": 613,
         "columnno": 22,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006867",
+          "id": "astnode100007231",
           "name": "result",
           "type": "AwaitExpression",
           "value": ""
@@ -19108,18 +20025,18 @@
       "comment": "",
       "meta": {
         "range": [
-          16399,
-          16403
+          19583,
+          19600
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 502,
+        "lineno": 617,
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006888",
+          "id": "astnode100007250",
           "name": "name",
           "type": "Identifier",
-          "value": "name"
+          "value": "serviceName"
         }
       },
       "undocumented": true,
@@ -19132,15 +20049,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16425,
-          16440
+          19622,
+          19637
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 503,
+        "lineno": 618,
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006890",
+          "id": "astnode100007252",
           "name": "status",
           "type": "Literal",
           "value": "error"
@@ -19156,15 +20073,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16462,
-          16482
+          19659,
+          19679
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 504,
+        "lineno": 619,
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006892",
+          "id": "astnode100007254",
           "name": "error",
           "type": "MemberExpression",
           "value": "error.message"
@@ -19180,15 +20097,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16565,
-          16976
+          19786,
+          20197
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 512,
+        "lineno": 627,
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006899",
+          "id": "astnode100007265",
           "name": "api.bootMinimal",
           "type": "FunctionExpression",
           "funcscope": "createWarden",
@@ -19212,15 +20129,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16628,
-          16665
+          19849,
+          19886
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 513,
+        "lineno": 628,
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006907",
+          "id": "astnode100007273",
           "name": "redis",
           "type": "MemberExpression",
           "value": "services.addon['noona-redis']"
@@ -19238,15 +20155,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16681,
-          16715
+          19902,
+          19936
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 514,
+        "lineno": 629,
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006915",
+          "id": "astnode100007281",
           "name": "moon",
           "type": "MemberExpression",
           "value": "services.core['noona-moon']"
@@ -19264,15 +20181,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16731,
-          16765
+          19952,
+          19986
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 515,
+        "lineno": 630,
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006923",
+          "id": "astnode100007289",
           "name": "sage",
           "type": "MemberExpression",
           "value": "services.core['noona-sage']"
@@ -19290,15 +20207,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16983,
-          17702
+          20204,
+          20923
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 522,
+        "lineno": 637,
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006955",
+          "id": "astnode100007321",
           "name": "api.bootFull",
           "type": "FunctionExpression",
           "funcscope": "createWarden",
@@ -19323,15 +20240,15 @@
       "comment": "",
       "meta": {
         "range": [
-          17040,
-          17126
+          20261,
+          20347
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 523,
+        "lineno": 638,
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006963",
+          "id": "astnode100007329",
           "name": "servicesMap",
           "type": "ObjectExpression",
           "value": "{}"
@@ -19349,15 +20266,15 @@
       "comment": "",
       "meta": {
         "range": [
-          17148,
-          17152
+          20369,
+          20373
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 528,
+        "lineno": 643,
         "columnno": 19,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006976",
+          "id": "astnode100007342",
           "name": "name"
         }
       },
@@ -19373,15 +20290,15 @@
       "comment": "",
       "meta": {
         "range": [
-          17187,
-          17210
+          20408,
+          20431
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 529,
+        "lineno": 644,
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100006981",
+          "id": "astnode100007347",
           "name": "svc",
           "type": "MemberExpression",
           "value": "servicesMap[undefined]"
@@ -19399,15 +20316,15 @@
       "comment": "",
       "meta": {
         "range": [
-          17386,
-          17632
+          20607,
+          20853
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 535,
+        "lineno": 650,
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007001",
+          "id": "astnode100007367",
           "name": "healthUrl",
           "type": "ConditionalExpression",
           "value": ""
@@ -19425,15 +20342,15 @@
       "comment": "",
       "meta": {
         "range": [
-          17709,
-          18276
+          20930,
+          21497
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 546,
+        "lineno": 661,
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007027",
+          "id": "astnode100007393",
           "name": "api.shutdownAll",
           "type": "FunctionExpression",
           "funcscope": "createWarden",
@@ -19456,15 +20373,15 @@
       "comment": "",
       "meta": {
         "range": [
-          17833,
-          17837
+          21054,
+          21058
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 548,
+        "lineno": 663,
         "columnno": 19,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007043",
+          "id": "astnode100007409",
           "name": "name"
         }
       },
@@ -19480,15 +20397,15 @@
       "comment": "",
       "meta": {
         "range": [
-          17902,
-          17947
+          21123,
+          21168
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 550,
+        "lineno": 665,
         "columnno": 22,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007050",
+          "id": "astnode100007416",
           "name": "container",
           "type": "CallExpression",
           "value": ""
@@ -19506,15 +20423,15 @@
       "comment": "",
       "meta": {
         "range": [
-          18283,
-          18878
+          21504,
+          22099
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 563,
+        "lineno": 678,
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007102",
+          "id": "astnode100007468",
           "name": "api.init",
           "type": "FunctionExpression",
           "funcscope": "createWarden",
@@ -19533,15 +20450,15 @@
       "comment": "",
       "meta": {
         "range": [
-          18831,
-          18869
+          22052,
+          22090
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 576,
+        "lineno": 691,
         "columnno": 17,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007162",
+          "id": "astnode100007528",
           "name": "mode",
           "type": "ConditionalExpression",
           "value": ""
@@ -19557,15 +20474,15 @@
       "comment": "",
       "meta": {
         "range": [
-          18900,
-          18928
+          22121,
+          22149
         ],
         "filename": "wardenCore.mjs",
-        "lineno": 582,
+        "lineno": 697,
         "columnno": 0,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007169",
+          "id": "astnode100007535",
           "name": "module.exports",
           "type": "Identifier"
         }
@@ -19589,7 +20506,7 @@
         "columnno": 6,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007190",
+          "id": "astnode100007556",
           "name": "defaultPort",
           "type": "ArrowFunctionExpression"
         }
@@ -19613,7 +20530,7 @@
         "columnno": 6,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007206",
+          "id": "astnode100007572",
           "name": "DEFAULT_HEADERS",
           "type": "ObjectExpression",
           "value": "{\"undefined\":\"GET,POST,OPTIONS\"}"
@@ -19638,7 +20555,7 @@
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007209",
+          "id": "astnode100007575",
           "name": "\"Access-Control-Allow-Origin\"",
           "type": "Literal",
           "value": "*"
@@ -19663,7 +20580,7 @@
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007211",
+          "id": "astnode100007577",
           "name": "\"Access-Control-Allow-Headers\"",
           "type": "Literal",
           "value": "Content-Type"
@@ -19688,7 +20605,7 @@
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007213",
+          "id": "astnode100007579",
           "name": "\"Access-Control-Allow-Methods\"",
           "type": "Literal",
           "value": "GET,POST,OPTIONS"
@@ -19713,7 +20630,7 @@
         "columnno": 6,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007216",
+          "id": "astnode100007582",
           "name": "resolveLogger",
           "type": "ArrowFunctionExpression"
         }
@@ -19737,7 +20654,7 @@
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007223",
+          "id": "astnode100007589",
           "name": "error",
           "type": "Identifier",
           "value": "errMSG"
@@ -19761,7 +20678,7 @@
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007225",
+          "id": "astnode100007591",
           "name": "log",
           "type": "Identifier",
           "value": "log"
@@ -19785,7 +20702,7 @@
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007227",
+          "id": "astnode100007593",
           "name": "warn",
           "type": "Identifier",
           "value": "warn"
@@ -19809,7 +20726,7 @@
         "columnno": 6,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007232",
+          "id": "astnode100007598",
           "name": "sendJson",
           "type": "ArrowFunctionExpression"
         }
@@ -19833,7 +20750,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007248",
+          "id": "astnode100007614",
           "name": "\"Content-Type\"",
           "type": "Literal",
           "value": "application/json"
@@ -19857,7 +20774,7 @@
         "columnno": 6,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007261",
+          "id": "astnode100007627",
           "name": "parseJsonBody",
           "type": "ArrowFunctionExpression"
         },
@@ -19884,7 +20801,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007272",
+          "id": "astnode100007638",
           "name": "chunks",
           "type": "ArrayExpression",
           "value": "[]"
@@ -19910,7 +20827,7 @@
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007313",
+          "id": "astnode100007679",
           "name": "parsed",
           "type": "CallExpression",
           "value": ""
@@ -19936,7 +20853,7 @@
         "columnno": 0,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007348",
+          "id": "astnode100007714",
           "name": "exports.startWardenServer",
           "type": "VariableDeclaration"
         }
@@ -19959,7 +20876,7 @@
         "columnno": 13,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007350",
+          "id": "astnode100007716",
           "name": "startWardenServer",
           "type": "ArrowFunctionExpression"
         },
@@ -19988,7 +20905,7 @@
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007355",
+          "id": "astnode100007721",
           "name": "warden",
           "type": "Identifier",
           "value": "warden"
@@ -20012,7 +20929,7 @@
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007357",
+          "id": "astnode100007723",
           "name": "port",
           "type": "AssignmentPattern",
           "value": "port"
@@ -20036,7 +20953,7 @@
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007362",
+          "id": "astnode100007728",
           "name": "logger",
           "type": "Identifier",
           "value": "loggerOverrides"
@@ -20060,7 +20977,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007375",
+          "id": "astnode100007741",
           "name": "logger",
           "type": "CallExpression",
           "value": ""
@@ -20086,7 +21003,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007381",
+          "id": "astnode100007747",
           "name": "server",
           "type": "CallExpression",
           "value": ""
@@ -20112,7 +21029,7 @@
         "columnno": 33,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007403",
+          "id": "astnode100007769",
           "name": "error",
           "type": "Literal",
           "value": "Invalid request URL."
@@ -20136,7 +21053,7 @@
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007427",
+          "id": "astnode100007793",
           "name": "url",
           "type": "NewExpression",
           "value": ""
@@ -20162,7 +21079,7 @@
         "columnno": 33,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007463",
+          "id": "astnode100007829",
           "name": "status",
           "type": "Literal",
           "value": "ok"
@@ -20186,7 +21103,7 @@
         "columnno": 22,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007482",
+          "id": "astnode100007848",
           "name": "includeParam",
           "type": "CallExpression",
           "value": ""
@@ -20212,7 +21129,7 @@
         "columnno": 22,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007492",
+          "id": "astnode100007858",
           "name": "includeInstalled",
           "type": "ConditionalExpression",
           "value": ""
@@ -20238,7 +21155,7 @@
         "columnno": 22,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007513",
+          "id": "astnode100007879",
           "name": "services",
           "type": "AwaitExpression",
           "value": ""
@@ -20264,7 +21181,7 @@
         "columnno": 61,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007521",
+          "id": "astnode100007887",
           "name": "includeInstalled",
           "type": "Identifier",
           "value": "includeInstalled"
@@ -20288,7 +21205,7 @@
         "columnno": 37,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007529",
+          "id": "astnode100007895",
           "name": "services",
           "type": "Identifier",
           "value": "services"
@@ -20312,7 +21229,7 @@
         "columnno": 37,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007549",
+          "id": "astnode100007915",
           "name": "error",
           "type": "Literal",
           "value": "Unable to list services."
@@ -20336,7 +21253,7 @@
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007566",
+          "id": "astnode100007932",
           "name": "body"
         }
       },
@@ -20360,7 +21277,7 @@
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007571",
+          "id": "astnode100007937",
           "name": "body",
           "type": "AwaitExpression",
           "funcscope": "<anonymous>",
@@ -20387,7 +21304,7 @@
         "columnno": 37,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007584",
+          "id": "astnode100007950",
           "name": "error",
           "type": "Literal",
           "value": "Request body must be valid JSON."
@@ -20411,7 +21328,7 @@
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007588",
+          "id": "astnode100007954",
           "name": "services",
           "type": "ChainExpression",
           "value": ""
@@ -20437,7 +21354,7 @@
         "columnno": 37,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007611",
+          "id": "astnode100007977",
           "name": "error",
           "type": "Literal",
           "value": "Body must include a non-empty \"services\" array."
@@ -20461,7 +21378,7 @@
         "columnno": 22,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007617",
+          "id": "astnode100007983",
           "name": "results",
           "type": "AwaitExpression",
           "value": ""
@@ -20487,7 +21404,7 @@
         "columnno": 22,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007626",
+          "id": "astnode100007992",
           "name": "hasErrors",
           "type": "CallExpression",
           "value": ""
@@ -20513,7 +21430,7 @@
         "columnno": 22,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007640",
+          "id": "astnode100008006",
           "name": "statusCode",
           "type": "ConditionalExpression",
           "value": ""
@@ -20539,7 +21456,7 @@
         "columnno": 44,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007652",
+          "id": "astnode100008018",
           "name": "results",
           "type": "Identifier",
           "value": "results"
@@ -20563,7 +21480,7 @@
         "columnno": 37,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007672",
+          "id": "astnode100008038",
           "name": "error",
           "type": "Literal",
           "value": "Failed to install requested services."
@@ -20587,7 +21504,7 @@
         "columnno": 29,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007696",
+          "id": "astnode100008062",
           "name": "error",
           "type": "Literal",
           "value": "Not Found"
@@ -20611,7 +21528,7 @@
         "columnno": 13,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007722",
+          "id": "astnode100008088",
           "name": "server",
           "type": "Identifier",
           "value": "server"
@@ -20635,7 +21552,7 @@
         "columnno": 0,
         "path": "/workspace/Noona/services/warden/shared",
         "code": {
-          "id": "astnode100007724",
+          "id": "astnode100008090",
           "name": "module.exports",
           "type": "Identifier"
         }
@@ -20659,7 +21576,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007753",
+          "id": "astnode100008119",
           "name": "stubRandom",
           "type": "ArrowFunctionExpression"
         }
@@ -20684,7 +21601,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007763",
+          "id": "astnode100008129",
           "name": "token",
           "type": "CallExpression",
           "value": ""
@@ -20710,7 +21627,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007796",
+          "id": "astnode100008162",
           "name": "registry",
           "type": "CallExpression",
           "value": ""
@@ -20736,7 +21653,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007805",
+          "id": "astnode100008171",
           "name": "env",
           "type": "ObjectExpression",
           "value": "{\"NOONA_SAGE_VAULT_TOKEN\":\"env-token\"}"
@@ -20760,7 +21677,7 @@
         "columnno": 15,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007807",
+          "id": "astnode100008173",
           "name": "NOONA_SAGE_VAULT_TOKEN",
           "type": "Literal",
           "value": "env-token"
@@ -20785,7 +21702,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007809",
+          "id": "astnode100008175",
           "name": "defaults",
           "type": "ObjectExpression",
           "value": "{\"undefined\":\"custom-default-token\"}"
@@ -20809,7 +21726,7 @@
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007811",
+          "id": "astnode100008177",
           "name": "\"custom-service\"",
           "type": "Literal",
           "value": "custom-default-token"
@@ -20834,7 +21751,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007813",
+          "id": "astnode100008179",
           "name": "generator",
           "type": "ArrowFunctionExpression"
         }
@@ -20857,7 +21774,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007823",
+          "id": "astnode100008189",
           "name": "\"noona-sage\"",
           "type": "Literal",
           "value": "env-token"
@@ -20881,7 +21798,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007825",
+          "id": "astnode100008191",
           "name": "\"noona-moon\"",
           "type": "Literal",
           "value": "generated-token"
@@ -20905,7 +21822,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007827",
+          "id": "astnode100008193",
           "name": "\"custom-service\"",
           "type": "Literal",
           "value": "custom-default-token"
@@ -20929,7 +21846,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007836",
+          "id": "astnode100008202",
           "name": "registry",
           "type": "CallExpression",
           "value": ""
@@ -20955,7 +21872,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007847",
+          "id": "astnode100008213",
           "name": "generator",
           "type": "ArrowFunctionExpression"
         }
@@ -20978,7 +21895,7 @@
         "columnno": 33,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007857",
+          "id": "astnode100008223",
           "name": "\"noona-portal\"",
           "type": "Literal",
           "value": "noona-portal-dev-token"
@@ -21002,7 +21919,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007866",
+          "id": "astnode100008232",
           "name": "map",
           "type": "CallExpression",
           "value": ""
@@ -21028,7 +21945,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007871",
+          "id": "astnode100008237",
           "name": "\"noona-zeta\"",
           "type": "Literal",
           "value": " token-z "
@@ -21052,7 +21969,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007873",
+          "id": "astnode100008239",
           "name": "\"noona-alpha\"",
           "type": "Literal",
           "value": "token-a"
@@ -21076,7 +21993,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007893",
+          "id": "astnode100008259",
           "name": "normalizeEnvKey",
           "type": "Identifier",
           "value": "normalizeEnvKey"
@@ -21100,7 +22017,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007935",
+          "id": "astnode100008301",
           "name": "warden",
           "type": "CallExpression",
           "value": ""
@@ -21126,7 +22043,7 @@
         "columnno": 34,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007940",
+          "id": "astnode100008306",
           "name": "services",
           "type": "ObjectExpression",
           "value": "{\"addon\":\"\",\"core\":\"\"}"
@@ -21150,7 +22067,7 @@
         "columnno": 46,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007942",
+          "id": "astnode100008308",
           "name": "addon",
           "type": "ObjectExpression",
           "value": "{}"
@@ -21175,7 +22092,7 @@
         "columnno": 57,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007944",
+          "id": "astnode100008310",
           "name": "core",
           "type": "ObjectExpression",
           "value": "{}"
@@ -21200,7 +22117,7 @@
         "columnno": 69,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007946",
+          "id": "astnode100008312",
           "name": "hostDockerSockets",
           "type": "ArrayExpression",
           "value": "[]"
@@ -21224,7 +22141,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007949",
+          "id": "astnode100008315",
           "name": "service",
           "type": "ObjectExpression",
           "value": "{\"hostServiceUrl\":\"http://custom.local\"}"
@@ -21250,7 +22167,7 @@
         "columnno": 22,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007952",
+          "id": "astnode100008318",
           "name": "hostServiceUrl",
           "type": "Literal",
           "value": "http://custom.local"
@@ -21275,7 +22192,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007972",
+          "id": "astnode100008338",
           "name": "warden",
           "type": "CallExpression",
           "value": ""
@@ -21301,7 +22218,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007977",
+          "id": "astnode100008343",
           "name": "services",
           "type": "ObjectExpression",
           "value": "{\"addon\":\"\",\"core\":\"\"}"
@@ -21325,7 +22242,7 @@
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007979",
+          "id": "astnode100008345",
           "name": "addon",
           "type": "ObjectExpression",
           "value": "{}"
@@ -21350,7 +22267,7 @@
         "columnno": 31,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007981",
+          "id": "astnode100008347",
           "name": "core",
           "type": "ObjectExpression",
           "value": "{}"
@@ -21375,7 +22292,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007983",
+          "id": "astnode100008349",
           "name": "env",
           "type": "ObjectExpression",
           "value": "{\"HOST_SERVICE_URL\":\"http://host.example\"}"
@@ -21399,7 +22316,7 @@
         "columnno": 15,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007985",
+          "id": "astnode100008351",
           "name": "HOST_SERVICE_URL",
           "type": "Literal",
           "value": "http://host.example"
@@ -21424,7 +22341,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007987",
+          "id": "astnode100008353",
           "name": "hostDockerSockets",
           "type": "ArrayExpression",
           "value": "[]"
@@ -21448,7 +22365,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007990",
+          "id": "astnode100008356",
           "name": "service",
           "type": "ObjectExpression",
           "value": "{\"port\":8080}"
@@ -21474,7 +22391,7 @@
         "columnno": 22,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100007993",
+          "id": "astnode100008359",
           "name": "port",
           "type": "Literal",
           "value": 8080
@@ -21499,7 +22416,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008013",
+          "id": "astnode100008379",
           "name": "calls",
           "type": "ArrayExpression",
           "value": "[]"
@@ -21525,7 +22442,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008017",
+          "id": "astnode100008383",
           "name": "dockerUtils",
           "type": "ObjectExpression",
           "value": "{\"ensureNetwork\":\"\",\"attachSelfToNetwork\":\"\",\"containerExists\":\"\",\"pullImageIfNeeded\":\"\",\"runContainerWithLogs\":\"\",\"waitForHealthyStatus\":\"\"}"
@@ -21551,7 +22468,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008020",
+          "id": "astnode100008386",
           "name": "ensureNetwork",
           "type": "ArrowFunctionExpression"
         }
@@ -21575,7 +22492,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008023",
+          "id": "astnode100008389",
           "name": "attachSelfToNetwork",
           "type": "ArrowFunctionExpression"
         }
@@ -21599,7 +22516,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008026",
+          "id": "astnode100008392",
           "name": "containerExists",
           "type": "ArrowFunctionExpression"
         }
@@ -21623,7 +22540,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008029",
+          "id": "astnode100008395",
           "name": "pullImageIfNeeded",
           "type": "ArrowFunctionExpression"
         }
@@ -21647,7 +22564,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008041",
+          "id": "astnode100008407",
           "name": "runContainerWithLogs",
           "type": "ArrowFunctionExpression"
         }
@@ -21671,7 +22588,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008068",
+          "id": "astnode100008434",
           "name": "waitForHealthyStatus",
           "type": "ArrowFunctionExpression"
         }
@@ -21695,7 +22612,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008083",
+          "id": "astnode100008449",
           "name": "logs",
           "type": "ArrayExpression",
           "value": "[]"
@@ -21721,7 +22638,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008087",
+          "id": "astnode100008453",
           "name": "warden",
           "type": "CallExpression",
           "value": ""
@@ -21747,7 +22664,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008092",
+          "id": "astnode100008458",
           "name": "dockerUtils",
           "type": "Identifier",
           "value": "dockerUtils"
@@ -21771,7 +22688,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008094",
+          "id": "astnode100008460",
           "name": "services",
           "type": "ObjectExpression",
           "value": "{\"addon\":\"\",\"core\":\"\"}"
@@ -21795,7 +22712,7 @@
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008096",
+          "id": "astnode100008462",
           "name": "addon",
           "type": "ObjectExpression",
           "value": "{}"
@@ -21820,7 +22737,7 @@
         "columnno": 31,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008098",
+          "id": "astnode100008464",
           "name": "core",
           "type": "ObjectExpression",
           "value": "{}"
@@ -21845,7 +22762,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008100",
+          "id": "astnode100008466",
           "name": "logger",
           "type": "ObjectExpression",
           "value": "{\"log\":\"\",\"warn\":\"\"}"
@@ -21869,7 +22786,7 @@
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008102",
+          "id": "astnode100008468",
           "name": "log",
           "type": "ArrowFunctionExpression"
         }
@@ -21893,7 +22810,7 @@
         "columnno": 56,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008110",
+          "id": "astnode100008476",
           "name": "warn",
           "type": "ArrowFunctionExpression"
         }
@@ -21917,7 +22834,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008113",
+          "id": "astnode100008479",
           "name": "env",
           "type": "ObjectExpression",
           "value": "{\"HOST_SERVICE_URL\":\"http://host\",\"DEBUG\":\"true\"}"
@@ -21941,7 +22858,7 @@
         "columnno": 15,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008115",
+          "id": "astnode100008481",
           "name": "HOST_SERVICE_URL",
           "type": "Literal",
           "value": "http://host"
@@ -21966,7 +22883,7 @@
         "columnno": 48,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008117",
+          "id": "astnode100008483",
           "name": "DEBUG",
           "type": "Literal",
           "value": "true"
@@ -21991,7 +22908,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008119",
+          "id": "astnode100008485",
           "name": "hostDockerSockets",
           "type": "ArrayExpression",
           "value": "[]"
@@ -22015,7 +22932,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008122",
+          "id": "astnode100008488",
           "name": "service",
           "type": "ObjectExpression",
           "value": "{\"name\":\"noona-test\",\"image\":\"noona/test:latest\",\"port\":1234}"
@@ -22041,7 +22958,7 @@
         "columnno": 22,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008125",
+          "id": "astnode100008491",
           "name": "name",
           "type": "Literal",
           "value": "noona-test"
@@ -22066,7 +22983,7 @@
         "columnno": 42,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008127",
+          "id": "astnode100008493",
           "name": "image",
           "type": "Literal",
           "value": "noona/test:latest"
@@ -22091,7 +23008,7 @@
         "columnno": 70,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008129",
+          "id": "astnode100008495",
           "name": "port",
           "type": "Literal",
           "value": 1234
@@ -22116,7 +23033,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008193",
+          "id": "astnode100008559",
           "name": "dockerUtils",
           "type": "ObjectExpression",
           "value": "{\"ensureNetwork\":\"\",\"attachSelfToNetwork\":\"\",\"containerExists\":\"\",\"pullImageIfNeeded\":\"\",\"runContainerWithLogs\":\"\",\"waitForHealthyStatus\":\"\"}"
@@ -22142,7 +23059,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008196",
+          "id": "astnode100008562",
           "name": "ensureNetwork",
           "type": "ArrowFunctionExpression"
         }
@@ -22166,7 +23083,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008199",
+          "id": "astnode100008565",
           "name": "attachSelfToNetwork",
           "type": "ArrowFunctionExpression"
         }
@@ -22190,7 +23107,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008202",
+          "id": "astnode100008568",
           "name": "containerExists",
           "type": "ArrowFunctionExpression"
         }
@@ -22214,7 +23131,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008205",
+          "id": "astnode100008571",
           "name": "pullImageIfNeeded",
           "type": "ArrowFunctionExpression"
         }
@@ -22238,7 +23155,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008212",
+          "id": "astnode100008578",
           "name": "runContainerWithLogs",
           "type": "ArrowFunctionExpression"
         }
@@ -22262,7 +23179,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008219",
+          "id": "astnode100008585",
           "name": "waitForHealthyStatus",
           "type": "ArrowFunctionExpression"
         }
@@ -22286,7 +23203,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008223",
+          "id": "astnode100008589",
           "name": "logs",
           "type": "ArrayExpression",
           "value": "[]"
@@ -22312,7 +23229,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008227",
+          "id": "astnode100008593",
           "name": "warden",
           "type": "CallExpression",
           "value": ""
@@ -22338,7 +23255,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008232",
+          "id": "astnode100008598",
           "name": "dockerUtils",
           "type": "Identifier",
           "value": "dockerUtils"
@@ -22362,7 +23279,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008234",
+          "id": "astnode100008600",
           "name": "services",
           "type": "ObjectExpression",
           "value": "{\"addon\":\"\",\"core\":\"\"}"
@@ -22386,7 +23303,7 @@
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008236",
+          "id": "astnode100008602",
           "name": "addon",
           "type": "ObjectExpression",
           "value": "{}"
@@ -22411,7 +23328,7 @@
         "columnno": 31,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008238",
+          "id": "astnode100008604",
           "name": "core",
           "type": "ObjectExpression",
           "value": "{}"
@@ -22436,7 +23353,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008240",
+          "id": "astnode100008606",
           "name": "logger",
           "type": "ObjectExpression",
           "value": "{\"log\":\"\",\"warn\":\"\"}"
@@ -22460,7 +23377,7 @@
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008242",
+          "id": "astnode100008608",
           "name": "log",
           "type": "ArrowFunctionExpression"
         }
@@ -22484,7 +23401,7 @@
         "columnno": 56,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008250",
+          "id": "astnode100008616",
           "name": "warn",
           "type": "ArrowFunctionExpression"
         }
@@ -22508,7 +23425,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008253",
+          "id": "astnode100008619",
           "name": "hostDockerSockets",
           "type": "ArrayExpression",
           "value": "[]"
@@ -22532,7 +23449,7 @@
         "columnno": 32,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008262",
+          "id": "astnode100008628",
           "name": "name",
           "type": "Literal",
           "value": "noona-test"
@@ -22556,7 +23473,7 @@
         "columnno": 52,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008264",
+          "id": "astnode100008630",
           "name": "image",
           "type": "Literal",
           "value": "ignored"
@@ -22580,7 +23497,7 @@
         "columnno": 70,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008266",
+          "id": "astnode100008632",
           "name": "hostServiceUrl",
           "type": "Literal",
           "value": "http://custom"
@@ -22604,7 +23521,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008307",
+          "id": "astnode100008673",
           "name": "containerChecks",
           "type": "ArrayExpression",
           "value": "[]"
@@ -22630,7 +23547,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008311",
+          "id": "astnode100008677",
           "name": "dockerUtils",
           "type": "ObjectExpression",
           "value": "{\"containerExists\":\"\"}"
@@ -22656,7 +23573,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008314",
+          "id": "astnode100008680",
           "name": "containerExists",
           "type": "ArrowFunctionExpression"
         }
@@ -22680,7 +23597,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008329",
+          "id": "astnode100008695",
           "name": "warnings",
           "type": "ArrayExpression",
           "value": "[]"
@@ -22706,7 +23623,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008333",
+          "id": "astnode100008699",
           "name": "warden",
           "type": "CallExpression",
           "value": ""
@@ -22732,7 +23649,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008338",
+          "id": "astnode100008704",
           "name": "services",
           "type": "ObjectExpression",
           "value": "{\"addon\":\"\",\"core\":\"\"}"
@@ -22756,7 +23673,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008340",
+          "id": "astnode100008706",
           "name": "addon",
           "type": "ObjectExpression",
           "value": "{\"undefined\":\"\"}"
@@ -22781,7 +23698,7 @@
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008342",
+          "id": "astnode100008708",
           "name": "\"noona-redis\"",
           "type": "ObjectExpression",
           "value": "{\"name\":\"noona-redis\",\"image\":\"redis\",\"port\":8001,\"description\":\"Cache\"}"
@@ -22806,7 +23723,7 @@
         "columnno": 33,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008344",
+          "id": "astnode100008710",
           "name": "name",
           "type": "Literal",
           "value": "noona-redis"
@@ -22831,7 +23748,7 @@
         "columnno": 54,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008346",
+          "id": "astnode100008712",
           "name": "image",
           "type": "Literal",
           "value": "redis"
@@ -22856,7 +23773,7 @@
         "columnno": 70,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008348",
+          "id": "astnode100008714",
           "name": "port",
           "type": "Literal",
           "value": 8001
@@ -22881,7 +23798,7 @@
         "columnno": 82,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008350",
+          "id": "astnode100008716",
           "name": "description",
           "type": "Literal",
           "value": "Cache"
@@ -22906,7 +23823,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008352",
+          "id": "astnode100008718",
           "name": "core",
           "type": "ObjectExpression",
           "value": "{\"undefined\":\"\"}"
@@ -22931,7 +23848,7 @@
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008354",
+          "id": "astnode100008720",
           "name": "\"noona-sage\"",
           "type": "ObjectExpression",
           "value": "{\"name\":\"noona-sage\",\"image\":\"sage\",\"hostServiceUrl\":\"http://custom-sage\",\"health\":\"http://health\"}"
@@ -22956,7 +23873,7 @@
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008356",
+          "id": "astnode100008722",
           "name": "name",
           "type": "Literal",
           "value": "noona-sage"
@@ -22981,7 +23898,7 @@
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008358",
+          "id": "astnode100008724",
           "name": "image",
           "type": "Literal",
           "value": "sage"
@@ -23006,7 +23923,7 @@
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008360",
+          "id": "astnode100008726",
           "name": "hostServiceUrl",
           "type": "Literal",
           "value": "http://custom-sage"
@@ -23031,7 +23948,7 @@
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008362",
+          "id": "astnode100008728",
           "name": "health",
           "type": "Literal",
           "value": "http://health"
@@ -23056,7 +23973,7 @@
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008364",
+          "id": "astnode100008730",
           "name": "\"noona-moon\"",
           "type": "ObjectExpression",
           "value": "{\"name\":\"noona-moon\",\"image\":\"moon\",\"port\":3000}"
@@ -23081,7 +23998,7 @@
         "columnno": 32,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008366",
+          "id": "astnode100008732",
           "name": "name",
           "type": "Literal",
           "value": "noona-moon"
@@ -23106,7 +24023,7 @@
         "columnno": 52,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008368",
+          "id": "astnode100008734",
           "name": "image",
           "type": "Literal",
           "value": "moon"
@@ -23131,7 +24048,7 @@
         "columnno": 67,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008370",
+          "id": "astnode100008736",
           "name": "port",
           "type": "Literal",
           "value": 3000
@@ -23156,7 +24073,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008372",
+          "id": "astnode100008738",
           "name": "dockerUtils",
           "type": "Identifier",
           "value": "dockerUtils"
@@ -23180,7 +24097,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008374",
+          "id": "astnode100008740",
           "name": "env",
           "type": "ObjectExpression",
           "value": "{\"HOST_SERVICE_URL\":\"http://localhost\"}"
@@ -23204,7 +24121,7 @@
         "columnno": 15,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008376",
+          "id": "astnode100008742",
           "name": "HOST_SERVICE_URL",
           "type": "Literal",
           "value": "http://localhost"
@@ -23229,7 +24146,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008378",
+          "id": "astnode100008744",
           "name": "hostDockerSockets",
           "type": "ArrayExpression",
           "value": "[]"
@@ -23253,7 +24170,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008380",
+          "id": "astnode100008746",
           "name": "logger",
           "type": "ObjectExpression",
           "value": "{\"warn\":\"\",\"log\":\"\"}"
@@ -23277,7 +24194,7 @@
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008382",
+          "id": "astnode100008748",
           "name": "warn",
           "type": "ArrowFunctionExpression"
         }
@@ -23301,7 +24218,7 @@
         "columnno": 61,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008390",
+          "id": "astnode100008756",
           "name": "log",
           "type": "ArrowFunctionExpression"
         }
@@ -23325,7 +24242,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008394",
+          "id": "astnode100008760",
           "name": "services",
           "type": "AwaitExpression",
           "value": ""
@@ -23351,7 +24268,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008409",
+          "id": "astnode100008775",
           "name": "name",
           "type": "Literal",
           "value": "noona-moon"
@@ -23375,7 +24292,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008411",
+          "id": "astnode100008777",
           "name": "category",
           "type": "Literal",
           "value": "core"
@@ -23399,7 +24316,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008413",
+          "id": "astnode100008779",
           "name": "image",
           "type": "Literal",
           "value": "moon"
@@ -23423,7 +24340,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008415",
+          "id": "astnode100008781",
           "name": "port",
           "type": "Literal",
           "value": 3000
@@ -23447,7 +24364,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008417",
+          "id": "astnode100008783",
           "name": "hostServiceUrl",
           "type": "Literal",
           "value": "http://localhost:3000"
@@ -23471,7 +24388,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008419",
+          "id": "astnode100008785",
           "name": "description",
           "type": "Literal",
           "value": null
@@ -23495,7 +24412,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008421",
+          "id": "astnode100008787",
           "name": "health",
           "type": "Literal",
           "value": null
@@ -23519,7 +24436,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008423",
+          "id": "astnode100008789",
           "name": "installed",
           "type": "Literal",
           "value": false
@@ -23543,7 +24460,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008426",
+          "id": "astnode100008792",
           "name": "name",
           "type": "Literal",
           "value": "noona-redis"
@@ -23567,7 +24484,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008428",
+          "id": "astnode100008794",
           "name": "category",
           "type": "Literal",
           "value": "addon"
@@ -23591,7 +24508,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008430",
+          "id": "astnode100008796",
           "name": "image",
           "type": "Literal",
           "value": "redis"
@@ -23615,7 +24532,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008432",
+          "id": "astnode100008798",
           "name": "port",
           "type": "Literal",
           "value": 8001
@@ -23639,7 +24556,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008434",
+          "id": "astnode100008800",
           "name": "hostServiceUrl",
           "type": "Literal",
           "value": "http://localhost:8001"
@@ -23663,7 +24580,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008436",
+          "id": "astnode100008802",
           "name": "description",
           "type": "Literal",
           "value": "Cache"
@@ -23687,7 +24604,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008438",
+          "id": "astnode100008804",
           "name": "health",
           "type": "Literal",
           "value": null
@@ -23711,7 +24628,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008440",
+          "id": "astnode100008806",
           "name": "installed",
           "type": "Literal",
           "value": true
@@ -23735,7 +24652,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008443",
+          "id": "astnode100008809",
           "name": "name",
           "type": "Literal",
           "value": "noona-sage"
@@ -23759,7 +24676,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008445",
+          "id": "astnode100008811",
           "name": "category",
           "type": "Literal",
           "value": "core"
@@ -23783,7 +24700,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008447",
+          "id": "astnode100008813",
           "name": "image",
           "type": "Literal",
           "value": "sage"
@@ -23807,7 +24724,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008449",
+          "id": "astnode100008815",
           "name": "port",
           "type": "Literal",
           "value": null
@@ -23831,7 +24748,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008451",
+          "id": "astnode100008817",
           "name": "hostServiceUrl",
           "type": "Literal",
           "value": "http://custom-sage"
@@ -23855,7 +24772,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008453",
+          "id": "astnode100008819",
           "name": "description",
           "type": "Literal",
           "value": null
@@ -23879,7 +24796,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008455",
+          "id": "astnode100008821",
           "name": "health",
           "type": "Literal",
           "value": "http://health"
@@ -23903,7 +24820,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008457",
+          "id": "astnode100008823",
           "name": "installed",
           "type": "Literal",
           "value": false
@@ -23927,7 +24844,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008479",
+          "id": "astnode100008845",
           "name": "installable",
           "type": "AwaitExpression",
           "value": ""
@@ -23953,7 +24870,7 @@
         "columnno": 52,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008487",
+          "id": "astnode100008853",
           "name": "includeInstalled",
           "type": "Literal",
           "value": false
@@ -23970,14 +24887,14 @@
       "meta": {
         "range": [
           5795,
-          6123
+          6401
         ],
         "filename": "wardenCore.test.mjs",
         "lineno": 165,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008513",
+          "id": "astnode100008879",
           "name": "warden",
           "type": "CallExpression",
           "value": ""
@@ -23996,14 +24913,14 @@
       "meta": {
         "range": [
           5827,
-          6084
+          6362
         ],
         "filename": "wardenCore.test.mjs",
         "lineno": 166,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008518",
+          "id": "astnode100008884",
           "name": "services",
           "type": "ObjectExpression",
           "value": "{\"addon\":\"\",\"core\":\"\"}"
@@ -24020,14 +24937,14 @@
       "meta": {
         "range": [
           5851,
-          5957
+          6151
         ],
         "filename": "wardenCore.test.mjs",
         "lineno": 167,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008520",
+          "id": "astnode100008886",
           "name": "addon",
           "type": "ObjectExpression",
           "value": "{\"undefined\":\"\"}"
@@ -24052,7 +24969,7 @@
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008522",
+          "id": "astnode100008888",
           "name": "\"noona-redis\"",
           "type": "ObjectExpression",
           "value": "{\"name\":\"noona-redis\",\"image\":\"redis\",\"port\":8001}"
@@ -24077,7 +24994,7 @@
         "columnno": 33,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008524",
+          "id": "astnode100008890",
           "name": "name",
           "type": "Literal",
           "value": "noona-redis"
@@ -24102,7 +25019,7 @@
         "columnno": 54,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008526",
+          "id": "astnode100008892",
           "name": "image",
           "type": "Literal",
           "value": "redis"
@@ -24127,7 +25044,7 @@
         "columnno": 70,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008528",
+          "id": "astnode100008894",
           "name": "port",
           "type": "Literal",
           "value": 8001
@@ -24144,15 +25061,115 @@
       "comment": "",
       "meta": {
         "range": [
-          5971,
-          6073
+          5960,
+          6136
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 169,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008896",
+          "name": "\"noona-mongo\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-mongo\",\"image\":\"mongo\",\"hostServiceUrl\":\"mongodb://localhost:27017\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-mongo\"",
+      "longname": "services.addon.\"noona-mongo\"",
+      "kind": "member",
+      "memberof": "services.addon",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          5997,
+          6016
         ],
         "filename": "wardenCore.test.mjs",
         "lineno": 170,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008898",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-mongo"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.addon.\"noona-mongo\".name",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6038,
+          6052
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 171,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008900",
+          "name": "image",
+          "type": "Literal",
+          "value": "mongo"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "services.addon.\"noona-mongo\".image",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6074,
+          6117
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 172,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008902",
+          "name": "hostServiceUrl",
+          "type": "Literal",
+          "value": "mongodb://localhost:27017"
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "services.addon.\"noona-mongo\".hostServiceUrl",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6165,
+          6351
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 175,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008530",
+          "id": "astnode100008904",
           "name": "core",
           "type": "ObjectExpression",
           "value": "{\"undefined\":\"\"}"
@@ -24169,15 +25186,15 @@
       "comment": "",
       "meta": {
         "range": [
-          5995,
-          6058
+          6189,
+          6252
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 171,
+        "lineno": 176,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008532",
+          "id": "astnode100008906",
           "name": "\"noona-sage\"",
           "type": "ObjectExpression",
           "value": "{\"name\":\"noona-sage\",\"image\":\"sage\",\"port\":3004}"
@@ -24194,15 +25211,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6011,
-          6029
+          6205,
+          6223
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 171,
+        "lineno": 176,
         "columnno": 32,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008534",
+          "id": "astnode100008908",
           "name": "name",
           "type": "Literal",
           "value": "noona-sage"
@@ -24219,15 +25236,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6031,
-          6044
+          6225,
+          6238
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 171,
+        "lineno": 176,
         "columnno": 52,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008536",
+          "id": "astnode100008910",
           "name": "image",
           "type": "Literal",
           "value": "sage"
@@ -24244,15 +25261,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6046,
-          6056
+          6240,
+          6250
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 171,
+        "lineno": 176,
         "columnno": 67,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008538",
+          "id": "astnode100008912",
           "name": "port",
           "type": "Literal",
           "value": 3004
@@ -24269,15 +25286,115 @@
       "comment": "",
       "meta": {
         "range": [
-          6094,
-          6115
+          6270,
+          6336
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 174,
+        "lineno": 177,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008914",
+          "name": "\"noona-vault\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-vault\",\"image\":\"vault\",\"port\":3005}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-vault\"",
+      "longname": "services.core.\"noona-vault\"",
+      "kind": "member",
+      "memberof": "services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6287,
+          6306
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 177,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008916",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-vault"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.core.\"noona-vault\".name",
+      "kind": "member",
+      "memberof": "services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6308,
+          6322
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 177,
+        "columnno": 54,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008918",
+          "name": "image",
+          "type": "Literal",
+          "value": "vault"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "services.core.\"noona-vault\".image",
+      "kind": "member",
+      "memberof": "services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6324,
+          6334
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 177,
+        "columnno": 70,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008920",
+          "name": "port",
+          "type": "Literal",
+          "value": 3005
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "services.core.\"noona-vault\".port",
+      "kind": "member",
+      "memberof": "services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6372,
+          6393
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 180,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008540",
+          "id": "astnode100008922",
           "name": "hostDockerSockets",
           "type": "ArrayExpression",
           "value": "[]"
@@ -24293,15 +25410,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6136,
-          6148
+          6414,
+          6426
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 177,
+        "lineno": 183,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008543",
+          "id": "astnode100008925",
           "name": "started",
           "type": "ArrayExpression",
           "value": "[]"
@@ -24319,15 +25436,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6154,
-          6238
+          6432,
+          6516
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 178,
+        "lineno": 184,
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008547",
+          "id": "astnode100008929",
           "name": "warden.startService",
           "type": "ArrowFunctionExpression",
           "funcscope": "<anonymous>",
@@ -24347,15 +25464,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6251,
-          6335
+          6529,
+          6613
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 182,
+        "lineno": 188,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008563",
+          "id": "astnode100008945",
           "name": "results",
           "type": "AwaitExpression",
           "value": ""
@@ -24373,18 +25490,18 @@
       "comment": "",
       "meta": {
         "range": [
-          6392,
-          6410
+          6670,
+          6689
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 186,
+        "lineno": 192,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008583",
+          "id": "astnode100008965",
           "name": "name",
           "type": "Literal",
-          "value": "noona-sage"
+          "value": "noona-mongo"
         }
       },
       "undocumented": true,
@@ -24397,159 +25514,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6424,
-          6440
+          6703,
+          6720
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 187,
+        "lineno": 193,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008585",
-          "name": "category",
-          "type": "Literal",
-          "value": "core"
-        }
-      },
-      "undocumented": true,
-      "name": "category",
-      "longname": "category",
-      "kind": "member",
-      "scope": "global"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          6454,
-          6473
-        ],
-        "filename": "wardenCore.test.mjs",
-        "lineno": 188,
-        "columnno": 12,
-        "path": "/workspace/Noona/services/warden/tests",
-        "code": {
-          "id": "astnode100008587",
-          "name": "status",
-          "type": "Literal",
-          "value": "installed"
-        }
-      },
-      "undocumented": true,
-      "name": "status",
-      "longname": "status",
-      "kind": "member",
-      "scope": "global"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          6487,
-          6526
-        ],
-        "filename": "wardenCore.test.mjs",
-        "lineno": 189,
-        "columnno": 12,
-        "path": "/workspace/Noona/services/warden/tests",
-        "code": {
-          "id": "astnode100008589",
-          "name": "hostServiceUrl",
-          "type": "Literal",
-          "value": "http://localhost:3004"
-        }
-      },
-      "undocumented": true,
-      "name": "hostServiceUrl",
-      "longname": "hostServiceUrl",
-      "kind": "member",
-      "scope": "global"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          6540,
-          6553
-        ],
-        "filename": "wardenCore.test.mjs",
-        "lineno": 190,
-        "columnno": 12,
-        "path": "/workspace/Noona/services/warden/tests",
-        "code": {
-          "id": "astnode100008591",
-          "name": "image",
-          "type": "Literal",
-          "value": "sage"
-        }
-      },
-      "undocumented": true,
-      "name": "image",
-      "longname": "image",
-      "kind": "member",
-      "scope": "global"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          6567,
-          6577
-        ],
-        "filename": "wardenCore.test.mjs",
-        "lineno": 191,
-        "columnno": 12,
-        "path": "/workspace/Noona/services/warden/tests",
-        "code": {
-          "id": "astnode100008593",
-          "name": "port",
-          "type": "Literal",
-          "value": 3004
-        }
-      },
-      "undocumented": true,
-      "name": "port",
-      "longname": "port",
-      "kind": "member",
-      "scope": "global"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          6612,
-          6631
-        ],
-        "filename": "wardenCore.test.mjs",
-        "lineno": 194,
-        "columnno": 12,
-        "path": "/workspace/Noona/services/warden/tests",
-        "code": {
-          "id": "astnode100008596",
-          "name": "name",
-          "type": "Literal",
-          "value": "noona-redis"
-        }
-      },
-      "undocumented": true,
-      "name": "name",
-      "longname": "name",
-      "kind": "member",
-      "scope": "global"
-    },
-    {
-      "comment": "",
-      "meta": {
-        "range": [
-          6645,
-          6662
-        ],
-        "filename": "wardenCore.test.mjs",
-        "lineno": 195,
-        "columnno": 12,
-        "path": "/workspace/Noona/services/warden/tests",
-        "code": {
-          "id": "astnode100008598",
+          "id": "astnode100008967",
           "name": "category",
           "type": "Literal",
           "value": "addon"
@@ -24565,15 +25538,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6676,
-          6695
+          6734,
+          6753
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 196,
+        "lineno": 194,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008600",
+          "id": "astnode100008969",
           "name": "status",
           "type": "Literal",
           "value": "installed"
@@ -24589,15 +25562,159 @@
       "comment": "",
       "meta": {
         "range": [
-          6709,
-          6748
+          6767,
+          6810
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 195,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008971",
+          "name": "hostServiceUrl",
+          "type": "Literal",
+          "value": "mongodb://localhost:27017"
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "hostServiceUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6824,
+          6838
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 196,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008973",
+          "name": "image",
+          "type": "Literal",
+          "value": "mongo"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6852,
+          6862
         ],
         "filename": "wardenCore.test.mjs",
         "lineno": 197,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008602",
+          "id": "astnode100008975",
+          "name": "port",
+          "type": "Literal",
+          "value": null
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6897,
+          6916
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 200,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008978",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-redis"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6930,
+          6947
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 201,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008980",
+          "name": "category",
+          "type": "Literal",
+          "value": "addon"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6961,
+          6980
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 202,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008982",
+          "name": "status",
+          "type": "Literal",
+          "value": "installed"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          6994,
+          7033
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 203,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008984",
           "name": "hostServiceUrl",
           "type": "Literal",
           "value": "http://localhost:8001"
@@ -24613,15 +25730,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6762,
-          6776
+          7047,
+          7061
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 198,
+        "lineno": 204,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008604",
+          "id": "astnode100008986",
           "name": "image",
           "type": "Literal",
           "value": "redis"
@@ -24637,15 +25754,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6790,
-          6800
+          7075,
+          7085
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 199,
+        "lineno": 205,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008606",
+          "id": "astnode100008988",
           "name": "port",
           "type": "Literal",
           "value": 8001
@@ -24661,15 +25778,303 @@
       "comment": "",
       "meta": {
         "range": [
-          6835,
-          6850
+          7120,
+          7139
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 202,
+        "lineno": 208,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008609",
+          "id": "astnode100008991",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-vault"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7153,
+          7169
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 209,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008993",
+          "name": "category",
+          "type": "Literal",
+          "value": "core"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7183,
+          7202
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 210,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008995",
+          "name": "status",
+          "type": "Literal",
+          "value": "installed"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7216,
+          7255
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 211,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008997",
+          "name": "hostServiceUrl",
+          "type": "Literal",
+          "value": "http://localhost:3005"
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "hostServiceUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7269,
+          7283
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 212,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100008999",
+          "name": "image",
+          "type": "Literal",
+          "value": "vault"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7297,
+          7307
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 213,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009001",
+          "name": "port",
+          "type": "Literal",
+          "value": 3005
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7342,
+          7360
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 216,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009004",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7374,
+          7390
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 217,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009006",
+          "name": "category",
+          "type": "Literal",
+          "value": "core"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7404,
+          7423
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 218,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009008",
+          "name": "status",
+          "type": "Literal",
+          "value": "installed"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7437,
+          7476
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 219,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009010",
+          "name": "hostServiceUrl",
+          "type": "Literal",
+          "value": "http://localhost:3004"
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "hostServiceUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7490,
+          7503
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 220,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009012",
+          "name": "image",
+          "type": "Literal",
+          "value": "sage"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7517,
+          7527
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 221,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009014",
+          "name": "port",
+          "type": "Literal",
+          "value": 3004
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          7562,
+          7577
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 224,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009017",
           "name": "name",
           "type": "Literal",
           "value": "unknown"
@@ -24685,15 +26090,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6864,
-          6879
+          7591,
+          7606
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 203,
+        "lineno": 225,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008611",
+          "id": "astnode100009019",
           "name": "status",
           "type": "Literal",
           "value": "error"
@@ -24709,15 +26114,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6893,
-          6948
+          7620,
+          7675
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 204,
+        "lineno": 226,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008613",
+          "id": "astnode100009021",
           "name": "error",
           "type": "Literal",
           "value": "Service unknown is not registered with Warden."
@@ -24733,15 +26138,15 @@
       "comment": "",
       "meta": {
         "range": [
-          6983,
-          6991
+          7710,
+          7718
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 207,
+        "lineno": 229,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008616",
+          "id": "astnode100009024",
           "name": "name",
           "type": "Literal",
           "value": ""
@@ -24757,15 +26162,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7005,
-          7020
+          7732,
+          7747
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 208,
+        "lineno": 230,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008618",
+          "id": "astnode100009026",
           "name": "status",
           "type": "Literal",
           "value": "error"
@@ -24781,15 +26186,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7034,
-          7073
+          7761,
+          7800
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 209,
+        "lineno": 231,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008620",
+          "id": "astnode100009028",
           "name": "error",
           "type": "Literal",
           "value": "Invalid service name provided."
@@ -24805,15 +26210,1555 @@
       "comment": "",
       "meta": {
         "range": [
-          7254,
-          7695
+          8025,
+          8522
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 217,
+        "lineno": 239,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008638",
+          "id": "astnode100009048",
+          "name": "warden",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "<anonymous>~warden",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8057,
+          8483
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 240,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009053",
+          "name": "services",
+          "type": "ObjectExpression",
+          "value": "{\"addon\":\"\",\"core\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8081,
+          8272
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 241,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009055",
+          "name": "addon",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "addon",
+      "longname": "services.addon",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8106,
+          8172
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 242,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009057",
+          "name": "\"noona-redis\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-redis\",\"image\":\"redis\",\"port\":8001}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-redis\"",
+      "longname": "services.addon.\"noona-redis\"",
+      "kind": "member",
+      "memberof": "services.addon",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8123,
+          8142
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 242,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009059",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-redis"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.addon.\"noona-redis\".name",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8144,
+          8158
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 242,
+        "columnno": 54,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009061",
+          "name": "image",
+          "type": "Literal",
+          "value": "redis"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "services.addon.\"noona-redis\".image",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8160,
+          8170
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 242,
+        "columnno": 70,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009063",
+          "name": "port",
+          "type": "Literal",
+          "value": 8001
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "services.addon.\"noona-redis\".port",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8190,
+          8257
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 243,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009065",
+          "name": "\"noona-mongo\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-mongo\",\"image\":\"mongo\",\"port\":27017}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-mongo\"",
+      "longname": "services.addon.\"noona-mongo\"",
+      "kind": "member",
+      "memberof": "services.addon",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8207,
+          8226
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 243,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009067",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-mongo"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.addon.\"noona-mongo\".name",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8228,
+          8242
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 243,
+        "columnno": 54,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009069",
+          "name": "image",
+          "type": "Literal",
+          "value": "mongo"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "services.addon.\"noona-mongo\".image",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8244,
+          8255
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 243,
+        "columnno": 70,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009071",
+          "name": "port",
+          "type": "Literal",
+          "value": 27017
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "services.addon.\"noona-mongo\".port",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8286,
+          8472
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 245,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009073",
+          "name": "core",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "core",
+      "longname": "services.core",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8310,
+          8376
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 246,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009075",
+          "name": "\"noona-vault\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-vault\",\"image\":\"vault\",\"port\":3005}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-vault\"",
+      "longname": "services.core.\"noona-vault\"",
+      "kind": "member",
+      "memberof": "services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8327,
+          8346
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 246,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009077",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-vault"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.core.\"noona-vault\".name",
+      "kind": "member",
+      "memberof": "services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8348,
+          8362
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 246,
+        "columnno": 54,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009079",
+          "name": "image",
+          "type": "Literal",
+          "value": "vault"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "services.core.\"noona-vault\".image",
+      "kind": "member",
+      "memberof": "services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8364,
+          8374
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 246,
+        "columnno": 70,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009081",
+          "name": "port",
+          "type": "Literal",
+          "value": 3005
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "services.core.\"noona-vault\".port",
+      "kind": "member",
+      "memberof": "services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8394,
+          8457
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 247,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009083",
+          "name": "\"noona-sage\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-sage\",\"image\":\"sage\",\"port\":3004}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-sage\"",
+      "longname": "services.core.\"noona-sage\"",
+      "kind": "member",
+      "memberof": "services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8410,
+          8428
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 247,
+        "columnno": 32,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009085",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-sage"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.core.\"noona-sage\".name",
+      "kind": "member",
+      "memberof": "services.core.\"noona-sage\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8430,
+          8443
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 247,
+        "columnno": 52,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009087",
+          "name": "image",
+          "type": "Literal",
+          "value": "sage"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "services.core.\"noona-sage\".image",
+      "kind": "member",
+      "memberof": "services.core.\"noona-sage\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8445,
+          8455
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 247,
+        "columnno": 67,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009089",
+          "name": "port",
+          "type": "Literal",
+          "value": 3004
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "services.core.\"noona-sage\".port",
+      "kind": "member",
+      "memberof": "services.core.\"noona-sage\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8493,
+          8514
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 250,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009091",
+          "name": "hostDockerSockets",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "hostDockerSockets",
+      "longname": "hostDockerSockets",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8535,
+          8545
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 253,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009094",
+          "name": "order",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "order",
+      "longname": "<anonymous>~order",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8551,
+          8633
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 254,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009098",
+          "name": "warden.startService",
+          "type": "ArrowFunctionExpression",
+          "funcscope": "<anonymous>",
+          "paramnames": [
+            "service"
+          ]
+        }
+      },
+      "undocumented": true,
+      "name": "startService",
+      "longname": "<anonymous>~warden.startService",
+      "kind": "function",
+      "memberof": "<anonymous>~warden",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8646,
+          8696
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 258,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009114",
+          "name": "result",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "result",
+      "longname": "<anonymous>~result",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8944,
+          9469
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 265,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009149",
+          "name": "warden",
+          "type": "CallExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "warden",
+      "longname": "<anonymous>~warden",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          8976,
+          9430
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 266,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009154",
+          "name": "services",
+          "type": "ObjectExpression",
+          "value": "{\"addon\":\"\",\"core\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "services",
+      "longname": "services",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9000,
+          9300
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 267,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009156",
+          "name": "addon",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "addon",
+      "longname": "services.addon",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9025,
+          9091
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 268,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009158",
+          "name": "\"noona-redis\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-redis\",\"image\":\"redis\",\"port\":8001}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-redis\"",
+      "longname": "services.addon.\"noona-redis\"",
+      "kind": "member",
+      "memberof": "services.addon",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9042,
+          9061
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 268,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009160",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-redis"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.addon.\"noona-redis\".name",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9063,
+          9077
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 268,
+        "columnno": 54,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009162",
+          "name": "image",
+          "type": "Literal",
+          "value": "redis"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "services.addon.\"noona-redis\".image",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9079,
+          9089
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 268,
+        "columnno": 70,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009164",
+          "name": "port",
+          "type": "Literal",
+          "value": 8001
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "services.addon.\"noona-redis\".port",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9109,
+          9285
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 269,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009166",
+          "name": "\"noona-mongo\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-mongo\",\"image\":\"mongo\",\"hostServiceUrl\":\"mongodb://localhost:27017\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-mongo\"",
+      "longname": "services.addon.\"noona-mongo\"",
+      "kind": "member",
+      "memberof": "services.addon",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9146,
+          9165
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 270,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009168",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-mongo"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.addon.\"noona-mongo\".name",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9187,
+          9201
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 271,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009170",
+          "name": "image",
+          "type": "Literal",
+          "value": "mongo"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "services.addon.\"noona-mongo\".image",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9223,
+          9266
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 272,
+        "columnno": 20,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009172",
+          "name": "hostServiceUrl",
+          "type": "Literal",
+          "value": "mongodb://localhost:27017"
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "services.addon.\"noona-mongo\".hostServiceUrl",
+      "kind": "member",
+      "memberof": "services.addon.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9314,
+          9419
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 275,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009174",
+          "name": "core",
+          "type": "ObjectExpression",
+          "value": "{\"undefined\":\"\"}"
+        }
+      },
+      "undocumented": true,
+      "name": "core",
+      "longname": "services.core",
+      "kind": "member",
+      "memberof": "services",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9338,
+          9404
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 276,
+        "columnno": 16,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009176",
+          "name": "\"noona-vault\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-vault\",\"image\":\"vault\",\"port\":3005}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-vault\"",
+      "longname": "services.core.\"noona-vault\"",
+      "kind": "member",
+      "memberof": "services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9355,
+          9374
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 276,
+        "columnno": 33,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009178",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-vault"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "services.core.\"noona-vault\".name",
+      "kind": "member",
+      "memberof": "services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9376,
+          9390
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 276,
+        "columnno": 54,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009180",
+          "name": "image",
+          "type": "Literal",
+          "value": "vault"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "services.core.\"noona-vault\".image",
+      "kind": "member",
+      "memberof": "services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9392,
+          9402
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 276,
+        "columnno": 70,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009182",
+          "name": "port",
+          "type": "Literal",
+          "value": 3005
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "services.core.\"noona-vault\".port",
+      "kind": "member",
+      "memberof": "services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9440,
+          9461
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 279,
+        "columnno": 8,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009184",
+          "name": "hostDockerSockets",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "hostDockerSockets",
+      "longname": "hostDockerSockets",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9482,
+          9492
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 282,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009187",
+          "name": "order",
+          "type": "ArrayExpression",
+          "value": "[]"
+        }
+      },
+      "undocumented": true,
+      "name": "order",
+      "longname": "<anonymous>~order",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9498,
+          9580
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 283,
+        "columnno": 4,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009191",
+          "name": "warden.startService",
+          "type": "ArrowFunctionExpression",
+          "funcscope": "<anonymous>",
+          "paramnames": [
+            "service"
+          ]
+        }
+      },
+      "undocumented": true,
+      "name": "startService",
+      "longname": "<anonymous>~warden.startService",
+      "kind": "function",
+      "memberof": "<anonymous>~warden",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9593,
+          9648
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 287,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009207",
+          "name": "results",
+          "type": "AwaitExpression",
+          "value": ""
+        }
+      },
+      "undocumented": true,
+      "name": "results",
+      "longname": "<anonymous>~results",
+      "kind": "constant",
+      "memberof": "<anonymous>",
+      "scope": "inner",
+      "params": []
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9781,
+          9800
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 292,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009234",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-mongo"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9814,
+          9831
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 293,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009236",
+          "name": "category",
+          "type": "Literal",
+          "value": "addon"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9845,
+          9864
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 294,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009238",
+          "name": "status",
+          "type": "Literal",
+          "value": "installed"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9878,
+          9921
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 295,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009240",
+          "name": "hostServiceUrl",
+          "type": "Literal",
+          "value": "mongodb://localhost:27017"
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "hostServiceUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9935,
+          9949
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 296,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009242",
+          "name": "image",
+          "type": "Literal",
+          "value": "mongo"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          9963,
+          9973
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 297,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009244",
+          "name": "port",
+          "type": "Literal",
+          "value": null
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10008,
+          10027
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 300,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009247",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-redis"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10041,
+          10058
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 301,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009249",
+          "name": "category",
+          "type": "Literal",
+          "value": "addon"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10072,
+          10091
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 302,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009251",
+          "name": "status",
+          "type": "Literal",
+          "value": "installed"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10105,
+          10144
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 303,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009253",
+          "name": "hostServiceUrl",
+          "type": "Literal",
+          "value": "http://localhost:8001"
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "hostServiceUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10158,
+          10172
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 304,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009255",
+          "name": "image",
+          "type": "Literal",
+          "value": "redis"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10186,
+          10196
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 305,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009257",
+          "name": "port",
+          "type": "Literal",
+          "value": 8001
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10231,
+          10250
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 308,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009260",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-vault"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "name",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10264,
+          10280
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 309,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009262",
+          "name": "category",
+          "type": "Literal",
+          "value": "core"
+        }
+      },
+      "undocumented": true,
+      "name": "category",
+      "longname": "category",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10294,
+          10313
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 310,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009264",
+          "name": "status",
+          "type": "Literal",
+          "value": "installed"
+        }
+      },
+      "undocumented": true,
+      "name": "status",
+      "longname": "status",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10327,
+          10366
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 311,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009266",
+          "name": "hostServiceUrl",
+          "type": "Literal",
+          "value": "http://localhost:3005"
+        }
+      },
+      "undocumented": true,
+      "name": "hostServiceUrl",
+      "longname": "hostServiceUrl",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10380,
+          10394
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 312,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009268",
+          "name": "image",
+          "type": "Literal",
+          "value": "vault"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "image",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10408,
+          10418
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 313,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009270",
+          "name": "port",
+          "type": "Literal",
+          "value": 3005
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "port",
+      "kind": "member",
+      "scope": "global"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          10536,
+          10977
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 319,
+        "columnno": 10,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009279",
           "name": "dockerInstance",
           "type": "ObjectExpression",
           "value": "{\"listContainers\":\"\",\"getContainer\":\"\",\"modem\":\"\"}"
@@ -24831,15 +27776,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7281,
-          7416
+          10563,
+          10698
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 218,
+        "lineno": 320,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008641",
+          "id": "astnode100009282",
           "name": "listContainers",
           "type": "ArrowFunctionExpression"
         }
@@ -24855,15 +27800,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7325,
-          7334
+          10607,
+          10616
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 219,
+        "lineno": 321,
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008645",
+          "id": "astnode100009286",
           "name": "Id",
           "type": "Literal",
           "value": "abc"
@@ -24879,15 +27824,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7336,
-          7374
+          10618,
+          10656
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 219,
+        "lineno": 321,
         "columnno": 25,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008647",
+          "id": "astnode100009288",
           "name": "Image",
           "type": "Literal",
           "value": "ghcr.io/example/kavita:latest"
@@ -24903,15 +27848,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7376,
-          7403
+          10658,
+          10685
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 219,
+        "lineno": 321,
         "columnno": 65,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008649",
+          "id": "astnode100009290",
           "name": "Names",
           "type": "ArrayExpression",
           "value": "[\"/kavita-instance\"]"
@@ -24927,15 +27872,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7426,
-          7633
+          10708,
+          10915
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 221,
+        "lineno": 323,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008652",
+          "id": "astnode100009293",
           "name": "getContainer",
           "type": "ArrowFunctionExpression"
         },
@@ -24954,15 +27899,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7463,
-          7621
+          10745,
+          10903
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 222,
+        "lineno": 324,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008656",
+          "id": "astnode100009297",
           "name": "inspect",
           "type": "ArrowFunctionExpression"
         }
@@ -24977,15 +27922,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7503,
-          7605
+          10785,
+          10887
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 223,
+        "lineno": 325,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008659",
+          "id": "astnode100009300",
           "name": "Mounts",
           "type": "ArrayExpression",
           "value": "[\"{\\\"Destination\\\":\\\"/data\\\",\\\"Source\\\":\\\"/host/kavita-data\\\"}\"]"
@@ -25001,15 +27946,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7535,
-          7555
+          10817,
+          10837
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 224,
+        "lineno": 326,
         "columnno": 22,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008662",
+          "id": "astnode100009303",
           "name": "Destination",
           "type": "Literal",
           "value": "/data"
@@ -25025,15 +27970,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7557,
-          7584
+          10839,
+          10866
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 224,
+        "lineno": 326,
         "columnno": 44,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008664",
+          "id": "astnode100009305",
           "name": "Source",
           "type": "Literal",
           "value": "/host/kavita-data"
@@ -25049,15 +27994,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7643,
-          7688
+          10925,
+          10970
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 228,
+        "lineno": 330,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008666",
+          "id": "astnode100009307",
           "name": "modem",
           "type": "ObjectExpression",
           "value": "{\"socketPath\":\"/var/run/docker.sock\"}"
@@ -25074,15 +28019,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7652,
-          7686
+          10934,
+          10968
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 228,
+        "lineno": 330,
         "columnno": 17,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008668",
+          "id": "astnode100009309",
           "name": "socketPath",
           "type": "Literal",
           "value": "/var/run/docker.sock"
@@ -25099,15 +28044,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7707,
-          7949
+          10989,
+          11481
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 230,
+        "lineno": 332,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008671",
+          "id": "astnode100009312",
           "name": "services",
           "type": "ObjectExpression",
           "value": "{\"addon\":\"\",\"core\":\"\"}"
@@ -25125,18 +28070,18 @@
       "comment": "",
       "meta": {
         "range": [
-          7728,
-          7737
+          11010,
+          11189
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 231,
+        "lineno": 333,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008674",
+          "id": "astnode100009315",
           "name": "addon",
           "type": "ObjectExpression",
-          "value": "{}"
+          "value": "{\"undefined\":\"\"}"
         }
       },
       "undocumented": true,
@@ -25150,15 +28095,215 @@
       "comment": "",
       "meta": {
         "range": [
-          7747,
-          7942
+          11031,
+          11097
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 232,
+        "lineno": 334,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009317",
+          "name": "\"noona-redis\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-redis\",\"image\":\"redis\",\"port\":8001}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-redis\"",
+      "longname": "<anonymous>~services.addon.\"noona-redis\"",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11048,
+          11067
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 334,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009319",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-redis"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "<anonymous>~services.addon.\"noona-redis\".name",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11069,
+          11083
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 334,
+        "columnno": 50,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009321",
+          "name": "image",
+          "type": "Literal",
+          "value": "redis"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "<anonymous>~services.addon.\"noona-redis\".image",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11085,
+          11095
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 334,
+        "columnno": 66,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009323",
+          "name": "port",
+          "type": "Literal",
+          "value": 8001
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "<anonymous>~services.addon.\"noona-redis\".port",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11111,
+          11178
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 335,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009325",
+          "name": "\"noona-mongo\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-mongo\",\"image\":\"mongo\",\"port\":27017}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-mongo\"",
+      "longname": "<anonymous>~services.addon.\"noona-mongo\"",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11128,
+          11147
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 335,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009327",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-mongo"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "<anonymous>~services.addon.\"noona-mongo\".name",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11149,
+          11163
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 335,
+        "columnno": 50,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009329",
+          "name": "image",
+          "type": "Literal",
+          "value": "mongo"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "<anonymous>~services.addon.\"noona-mongo\".image",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11165,
+          11176
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 335,
+        "columnno": 66,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009331",
+          "name": "port",
+          "type": "Literal",
+          "value": 27017
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "<anonymous>~services.addon.\"noona-mongo\".port",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11199,
+          11474
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 337,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008676",
+          "id": "astnode100009333",
           "name": "core",
           "type": "ObjectExpression",
           "value": "{\"undefined\":\"\"}"
@@ -25175,15 +28320,115 @@
       "comment": "",
       "meta": {
         "range": [
-          7767,
-          7931
+          11219,
+          11285
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 233,
+        "lineno": 338,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008678",
+          "id": "astnode100009335",
+          "name": "\"noona-vault\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-vault\",\"image\":\"vault\",\"port\":3005}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-vault\"",
+      "longname": "<anonymous>~services.core.\"noona-vault\"",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11236,
+          11255
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 338,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009337",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-vault"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "<anonymous>~services.core.\"noona-vault\".name",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11257,
+          11271
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 338,
+        "columnno": 50,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009339",
+          "name": "image",
+          "type": "Literal",
+          "value": "vault"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "<anonymous>~services.core.\"noona-vault\".image",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11273,
+          11283
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 338,
+        "columnno": 66,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009341",
+          "name": "port",
+          "type": "Literal",
+          "value": 3005
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "<anonymous>~services.core.\"noona-vault\".port",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          11299,
+          11463
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 339,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009343",
           "name": "\"noona-raven\"",
           "type": "ObjectExpression",
           "value": "{\"name\":\"noona-raven\",\"image\":\"captainpax/noona-raven:latest\",\"env\":\"\"}"
@@ -25200,15 +28445,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7800,
-          7819
+          11332,
+          11351
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 234,
+        "lineno": 340,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008680",
+          "id": "astnode100009345",
           "name": "name",
           "type": "Literal",
           "value": "noona-raven"
@@ -25225,15 +28470,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7837,
-          7875
+          11369,
+          11407
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 235,
+        "lineno": 341,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008682",
+          "id": "astnode100009347",
           "name": "image",
           "type": "Literal",
           "value": "captainpax/noona-raven:latest"
@@ -25250,15 +28495,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7893,
-          7916
+          11425,
+          11448
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 236,
+        "lineno": 342,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008684",
+          "id": "astnode100009349",
           "name": "env",
           "type": "ArrayExpression",
           "value": "[\"EXISTING_ENV=1\"]"
@@ -25275,15 +28520,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7962,
-          8116
+          11494,
+          11648
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 241,
+        "lineno": 347,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008688",
+          "id": "astnode100009353",
           "name": "warden",
           "type": "CallExpression",
           "value": ""
@@ -25301,15 +28546,15 @@
       "comment": "",
       "meta": {
         "range": [
-          7994,
-          8008
+          11526,
+          11540
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 242,
+        "lineno": 348,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008693",
+          "id": "astnode100009358",
           "name": "dockerInstance",
           "type": "Identifier",
           "value": "dockerInstance"
@@ -25325,15 +28570,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8018,
-          8026
+          11550,
+          11558
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 243,
+        "lineno": 349,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008695",
+          "id": "astnode100009360",
           "name": "services",
           "type": "Identifier",
           "value": "services"
@@ -25349,15 +28594,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8036,
-          8077
+          11568,
+          11609
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 244,
+        "lineno": 350,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008697",
+          "id": "astnode100009362",
           "name": "logger",
           "type": "ObjectExpression",
           "value": "{\"log\":\"\",\"warn\":\"\"}"
@@ -25373,15 +28618,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8046,
-          8059
+          11578,
+          11591
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 244,
+        "lineno": 350,
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008699",
+          "id": "astnode100009364",
           "name": "log",
           "type": "ArrowFunctionExpression"
         }
@@ -25397,15 +28642,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8061,
-          8075
+          11593,
+          11607
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 244,
+        "lineno": 350,
         "columnno": 33,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008702",
+          "id": "astnode100009367",
           "name": "warn",
           "type": "ArrowFunctionExpression"
         }
@@ -25421,15 +28666,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8087,
-          8108
+          11619,
+          11640
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 245,
+        "lineno": 351,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008705",
+          "id": "astnode100009370",
           "name": "hostDockerSockets",
           "type": "ArrayExpression",
           "value": "[]"
@@ -25445,15 +28690,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8127,
-          8149
+          11659,
+          11681
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 248,
+        "lineno": 354,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008708",
+          "id": "astnode100009373",
           "name": "receivedService",
           "type": "Literal",
           "value": null
@@ -25471,15 +28716,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8155,
-          8238
+          11687,
+          11770
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 249,
+        "lineno": 355,
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008712",
+          "id": "astnode100009377",
           "name": "warden.startService",
           "type": "ArrowFunctionExpression",
           "funcscope": "<anonymous>",
@@ -25502,15 +28747,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8206,
-          8231
+          11738,
+          11763
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 250,
+        "lineno": 356,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008720",
+          "id": "astnode100009385",
           "name": "receivedService",
           "type": "Identifier",
           "funcscope": "<anonymous>~warden.startService",
@@ -25529,15 +28774,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8251,
-          8302
+          11783,
+          11834
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 253,
+        "lineno": 359,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008724",
+          "id": "astnode100009389",
           "name": "result",
           "type": "AwaitExpression",
           "value": ""
@@ -25555,15 +28800,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8783,
-          8813
+          12315,
+          12345
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 262,
+        "lineno": 368,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008805",
+          "id": "astnode100009470",
           "name": "mountPath",
           "type": "Literal",
           "value": "/host/kavita-data"
@@ -25579,15 +28824,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8823,
-          8857
+          12355,
+          12389
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 263,
+        "lineno": 369,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008807",
+          "id": "astnode100009472",
           "name": "socketPath",
           "type": "Literal",
           "value": "/var/run/docker.sock"
@@ -25603,15 +28848,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8867,
-          8885
+          12399,
+          12417
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 264,
+        "lineno": 370,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008809",
+          "id": "astnode100009474",
           "name": "containerId",
           "type": "Literal",
           "value": "abc"
@@ -25627,15 +28872,15 @@
       "comment": "",
       "meta": {
         "range": [
-          8895,
-          8927
+          12427,
+          12459
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 265,
+        "lineno": 371,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008811",
+          "id": "astnode100009476",
           "name": "containerName",
           "type": "Literal",
           "value": "kavita-instance"
@@ -25651,15 +28896,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9037,
-          9050
+          12569,
+          12582
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 270,
+        "lineno": 376,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008820",
+          "id": "astnode100009485",
           "name": "listCalls",
           "type": "Literal",
           "value": 0
@@ -25677,15 +28922,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9062,
-          9186
+          12594,
+          12718
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 271,
+        "lineno": 377,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008824",
+          "id": "astnode100009489",
           "name": "dockerInstance",
           "type": "ObjectExpression",
           "value": "{\"listContainers\":\"\"}"
@@ -25703,15 +28948,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9089,
-          9179
+          12621,
+          12711
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 272,
+        "lineno": 378,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008827",
+          "id": "astnode100009492",
           "name": "listContainers",
           "type": "ArrowFunctionExpression"
         },
@@ -25730,15 +28975,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9131,
-          9145
+          12663,
+          12677
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 273,
+        "lineno": 379,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008831",
+          "id": "astnode100009496",
           "name": "listCalls",
           "type": "Literal",
           "funcscope": "<anonymous>~dockerInstance.listContainers",
@@ -25757,15 +29002,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9198,
-          9436
+          12730,
+          13218
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 277,
+        "lineno": 383,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008837",
+          "id": "astnode100009502",
           "name": "services",
           "type": "ObjectExpression",
           "value": "{\"addon\":\"\",\"core\":\"\"}"
@@ -25783,18 +29028,18 @@
       "comment": "",
       "meta": {
         "range": [
-          9219,
-          9228
+          12751,
+          12930
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 278,
+        "lineno": 384,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008840",
+          "id": "astnode100009505",
           "name": "addon",
           "type": "ObjectExpression",
-          "value": "{}"
+          "value": "{\"undefined\":\"\"}"
         }
       },
       "undocumented": true,
@@ -25808,15 +29053,215 @@
       "comment": "",
       "meta": {
         "range": [
-          9238,
-          9429
+          12772,
+          12838
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 279,
+        "lineno": 385,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009507",
+          "name": "\"noona-redis\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-redis\",\"image\":\"redis\",\"port\":8001}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-redis\"",
+      "longname": "<anonymous>~services.addon.\"noona-redis\"",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12789,
+          12808
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 385,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009509",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-redis"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "<anonymous>~services.addon.\"noona-redis\".name",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12810,
+          12824
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 385,
+        "columnno": 50,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009511",
+          "name": "image",
+          "type": "Literal",
+          "value": "redis"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "<anonymous>~services.addon.\"noona-redis\".image",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12826,
+          12836
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 385,
+        "columnno": 66,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009513",
+          "name": "port",
+          "type": "Literal",
+          "value": 8001
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "<anonymous>~services.addon.\"noona-redis\".port",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12852,
+          12919
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 386,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009515",
+          "name": "\"noona-mongo\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-mongo\",\"image\":\"mongo\",\"port\":27017}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-mongo\"",
+      "longname": "<anonymous>~services.addon.\"noona-mongo\"",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12869,
+          12888
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 386,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009517",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-mongo"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "<anonymous>~services.addon.\"noona-mongo\".name",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12890,
+          12904
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 386,
+        "columnno": 50,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009519",
+          "name": "image",
+          "type": "Literal",
+          "value": "mongo"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "<anonymous>~services.addon.\"noona-mongo\".image",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12906,
+          12917
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 386,
+        "columnno": 66,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009521",
+          "name": "port",
+          "type": "Literal",
+          "value": 27017
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "<anonymous>~services.addon.\"noona-mongo\".port",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12940,
+          13211
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 388,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008842",
+          "id": "astnode100009523",
           "name": "core",
           "type": "ObjectExpression",
           "value": "{\"undefined\":\"\"}"
@@ -25833,15 +29278,115 @@
       "comment": "",
       "meta": {
         "range": [
-          9258,
-          9418
+          12960,
+          13026
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 280,
+        "lineno": 389,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008844",
+          "id": "astnode100009525",
+          "name": "\"noona-vault\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-vault\",\"image\":\"vault\",\"port\":3005}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-vault\"",
+      "longname": "<anonymous>~services.core.\"noona-vault\"",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12977,
+          12996
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 389,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009527",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-vault"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "<anonymous>~services.core.\"noona-vault\".name",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          12998,
+          13012
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 389,
+        "columnno": 50,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009529",
+          "name": "image",
+          "type": "Literal",
+          "value": "vault"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "<anonymous>~services.core.\"noona-vault\".image",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13014,
+          13024
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 389,
+        "columnno": 66,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009531",
+          "name": "port",
+          "type": "Literal",
+          "value": 3005
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "<anonymous>~services.core.\"noona-vault\".port",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          13040,
+          13200
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 390,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009533",
           "name": "\"noona-raven\"",
           "type": "ObjectExpression",
           "value": "{\"name\":\"noona-raven\",\"image\":\"captainpax/noona-raven:latest\",\"env\":\"\"}"
@@ -25858,15 +29403,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9291,
-          9310
+          13073,
+          13092
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 281,
+        "lineno": 391,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008846",
+          "id": "astnode100009535",
           "name": "name",
           "type": "Literal",
           "value": "noona-raven"
@@ -25883,15 +29428,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9328,
-          9366
+          13110,
+          13148
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 282,
+        "lineno": 392,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008848",
+          "id": "astnode100009537",
           "name": "image",
           "type": "Literal",
           "value": "captainpax/noona-raven:latest"
@@ -25908,15 +29453,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9384,
-          9403
+          13166,
+          13185
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 283,
+        "lineno": 393,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008850",
+          "id": "astnode100009539",
           "name": "env",
           "type": "ArrayExpression",
           "value": "[\"BASE_ENV=1\"]"
@@ -25933,15 +29478,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9449,
-          9603
+          13231,
+          13385
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 288,
+        "lineno": 398,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008854",
+          "id": "astnode100009543",
           "name": "warden",
           "type": "CallExpression",
           "value": ""
@@ -25959,15 +29504,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9481,
-          9495
+          13263,
+          13277
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 289,
+        "lineno": 399,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008859",
+          "id": "astnode100009548",
           "name": "dockerInstance",
           "type": "Identifier",
           "value": "dockerInstance"
@@ -25983,15 +29528,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9505,
-          9513
+          13287,
+          13295
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 290,
+        "lineno": 400,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008861",
+          "id": "astnode100009550",
           "name": "services",
           "type": "Identifier",
           "value": "services"
@@ -26007,15 +29552,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9523,
-          9564
+          13305,
+          13346
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 291,
+        "lineno": 401,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008863",
+          "id": "astnode100009552",
           "name": "logger",
           "type": "ObjectExpression",
           "value": "{\"log\":\"\",\"warn\":\"\"}"
@@ -26031,15 +29576,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9533,
-          9546
+          13315,
+          13328
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 291,
+        "lineno": 401,
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008865",
+          "id": "astnode100009554",
           "name": "log",
           "type": "ArrowFunctionExpression"
         }
@@ -26055,15 +29600,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9548,
-          9562
+          13330,
+          13344
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 291,
+        "lineno": 401,
         "columnno": 33,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008868",
+          "id": "astnode100009557",
           "name": "warn",
           "type": "ArrowFunctionExpression"
         }
@@ -26079,15 +29624,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9574,
-          9595
+          13356,
+          13377
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 292,
+        "lineno": 402,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008871",
+          "id": "astnode100009560",
           "name": "hostDockerSockets",
           "type": "ArrayExpression",
           "value": "[]"
@@ -26103,15 +29648,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9614,
-          9636
+          13396,
+          13418
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 295,
+        "lineno": 405,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008874",
+          "id": "astnode100009563",
           "name": "receivedService",
           "type": "Literal",
           "value": null
@@ -26129,15 +29674,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9642,
-          9725
+          13424,
+          13507
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 296,
+        "lineno": 406,
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008878",
+          "id": "astnode100009567",
           "name": "warden.startService",
           "type": "ArrowFunctionExpression",
           "funcscope": "<anonymous>",
@@ -26160,15 +29705,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9693,
-          9718
+          13475,
+          13500
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 297,
+        "lineno": 407,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008886",
+          "id": "astnode100009575",
           "name": "receivedService",
           "type": "Identifier",
           "funcscope": "<anonymous>~warden.startService",
@@ -26187,15 +29732,15 @@
       "comment": "",
       "meta": {
         "range": [
-          9738,
-          9789
+          13520,
+          13571
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 300,
+        "lineno": 410,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008890",
+          "id": "astnode100009579",
           "name": "result",
           "type": "AwaitExpression",
           "value": ""
@@ -26213,15 +29758,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10215,
-          10373
+          13997,
+          14155
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 311,
+        "lineno": 421,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008956",
+          "id": "astnode100009645",
           "name": "dockerInstance",
           "type": "ObjectExpression",
           "value": "{\"listContainers\":\"\",\"getContainer\":\"\"}"
@@ -26239,15 +29784,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10242,
-          10272
+          14024,
+          14054
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 312,
+        "lineno": 422,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008959",
+          "id": "astnode100009648",
           "name": "listContainers",
           "type": "ArrowFunctionExpression"
         }
@@ -26263,15 +29808,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10282,
-          10366
+          14064,
+          14148
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 313,
+        "lineno": 423,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008962",
+          "id": "astnode100009651",
           "name": "getContainer",
           "type": "ArrowFunctionExpression"
         },
@@ -26290,15 +29835,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10317,
-          10354
+          14099,
+          14136
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 314,
+        "lineno": 424,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008965",
+          "id": "astnode100009654",
           "name": "inspect",
           "type": "ArrowFunctionExpression"
         }
@@ -26313,15 +29858,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10341,
-          10351
+          14123,
+          14133
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 314,
+        "lineno": 424,
         "columnno": 36,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008968",
+          "id": "astnode100009657",
           "name": "Mounts",
           "type": "ArrayExpression",
           "value": "[]"
@@ -26337,15 +29882,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10386,
-          10778
+          14168,
+          14560
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 318,
+        "lineno": 428,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008971",
+          "id": "astnode100009660",
           "name": "alternateClient",
           "type": "ObjectExpression",
           "value": "{\"listContainers\":\"\",\"getContainer\":\"\"}"
@@ -26363,15 +29908,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10414,
-          10557
+          14196,
+          14339
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 319,
+        "lineno": 429,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008974",
+          "id": "astnode100009663",
           "name": "listContainers",
           "type": "ArrowFunctionExpression"
         }
@@ -26387,15 +29932,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10458,
-          10473
+          14240,
+          14255
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 320,
+        "lineno": 430,
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008978",
+          "id": "astnode100009667",
           "name": "Id",
           "type": "Literal",
           "value": "secondary"
@@ -26411,15 +29956,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10475,
-          10514
+          14257,
+          14296
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 320,
+        "lineno": 430,
         "columnno": 31,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008980",
+          "id": "astnode100009669",
           "name": "Image",
           "type": "Literal",
           "value": "ghcr.io/example/kavita:nightly"
@@ -26435,15 +29980,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10516,
-          10544
+          14298,
+          14326
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 320,
+        "lineno": 430,
         "columnno": 72,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008982",
+          "id": "astnode100009671",
           "name": "Names",
           "type": "ArrayExpression",
           "value": "[\"/secondary-kavita\"]"
@@ -26459,15 +30004,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10567,
-          10771
+          14349,
+          14553
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 322,
+        "lineno": 432,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008985",
+          "id": "astnode100009674",
           "name": "getContainer",
           "type": "ArrowFunctionExpression"
         },
@@ -26486,15 +30031,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10602,
-          10759
+          14384,
+          14541
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 323,
+        "lineno": 433,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008988",
+          "id": "astnode100009677",
           "name": "inspect",
           "type": "ArrowFunctionExpression"
         }
@@ -26509,15 +30054,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10642,
-          10743
+          14424,
+          14525
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 324,
+        "lineno": 434,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008991",
+          "id": "astnode100009680",
           "name": "Mounts",
           "type": "ArrayExpression",
           "value": "[\"{\\\"Destination\\\":\\\"/data\\\",\\\"Source\\\":\\\"/alt/kavita-data\\\"}\"]"
@@ -26533,15 +30078,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10674,
-          10694
+          14456,
+          14476
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 325,
+        "lineno": 435,
         "columnno": 22,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008994",
+          "id": "astnode100009683",
           "name": "Destination",
           "type": "Literal",
           "value": "/data"
@@ -26557,15 +30102,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10696,
-          10722
+          14478,
+          14504
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 325,
+        "lineno": 435,
         "columnno": 44,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008996",
+          "id": "astnode100009685",
           "name": "Source",
           "type": "Literal",
           "value": "/alt/kavita-data"
@@ -26581,15 +30126,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10791,
-          10992
+          14573,
+          15024
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 331,
+        "lineno": 441,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100008999",
+          "id": "astnode100009688",
           "name": "services",
           "type": "ObjectExpression",
           "value": "{\"addon\":\"\",\"core\":\"\"}"
@@ -26607,18 +30152,18 @@
       "comment": "",
       "meta": {
         "range": [
-          10812,
-          10821
+          14594,
+          14773
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 332,
+        "lineno": 442,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009002",
+          "id": "astnode100009691",
           "name": "addon",
           "type": "ObjectExpression",
-          "value": "{}"
+          "value": "{\"undefined\":\"\"}"
         }
       },
       "undocumented": true,
@@ -26632,15 +30177,215 @@
       "comment": "",
       "meta": {
         "range": [
-          10831,
-          10985
+          14615,
+          14681
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 333,
+        "lineno": 443,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009693",
+          "name": "\"noona-redis\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-redis\",\"image\":\"redis\",\"port\":8001}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-redis\"",
+      "longname": "<anonymous>~services.addon.\"noona-redis\"",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14632,
+          14651
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 443,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009695",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-redis"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "<anonymous>~services.addon.\"noona-redis\".name",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14653,
+          14667
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 443,
+        "columnno": 50,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009697",
+          "name": "image",
+          "type": "Literal",
+          "value": "redis"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "<anonymous>~services.addon.\"noona-redis\".image",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14669,
+          14679
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 443,
+        "columnno": 66,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009699",
+          "name": "port",
+          "type": "Literal",
+          "value": 8001
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "<anonymous>~services.addon.\"noona-redis\".port",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon.\"noona-redis\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14695,
+          14762
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 444,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009701",
+          "name": "\"noona-mongo\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-mongo\",\"image\":\"mongo\",\"port\":27017}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-mongo\"",
+      "longname": "<anonymous>~services.addon.\"noona-mongo\"",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14712,
+          14731
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 444,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009703",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-mongo"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "<anonymous>~services.addon.\"noona-mongo\".name",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14733,
+          14747
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 444,
+        "columnno": 50,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009705",
+          "name": "image",
+          "type": "Literal",
+          "value": "mongo"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "<anonymous>~services.addon.\"noona-mongo\".image",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14749,
+          14760
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 444,
+        "columnno": 66,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009707",
+          "name": "port",
+          "type": "Literal",
+          "value": 27017
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "<anonymous>~services.addon.\"noona-mongo\".port",
+      "kind": "member",
+      "memberof": "<anonymous>~services.addon.\"noona-mongo\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14783,
+          15017
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 446,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009004",
+          "id": "astnode100009709",
           "name": "core",
           "type": "ObjectExpression",
           "value": "{\"undefined\":\"\"}"
@@ -26657,15 +30402,115 @@
       "comment": "",
       "meta": {
         "range": [
-          10851,
-          10974
+          14803,
+          14869
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 334,
+        "lineno": 447,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009006",
+          "id": "astnode100009711",
+          "name": "\"noona-vault\"",
+          "type": "ObjectExpression",
+          "value": "{\"name\":\"noona-vault\",\"image\":\"vault\",\"port\":3005}"
+        }
+      },
+      "undocumented": true,
+      "name": "\"noona-vault\"",
+      "longname": "<anonymous>~services.core.\"noona-vault\"",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14820,
+          14839
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 447,
+        "columnno": 29,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009713",
+          "name": "name",
+          "type": "Literal",
+          "value": "noona-vault"
+        }
+      },
+      "undocumented": true,
+      "name": "name",
+      "longname": "<anonymous>~services.core.\"noona-vault\".name",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14841,
+          14855
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 447,
+        "columnno": 50,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009715",
+          "name": "image",
+          "type": "Literal",
+          "value": "vault"
+        }
+      },
+      "undocumented": true,
+      "name": "image",
+      "longname": "<anonymous>~services.core.\"noona-vault\".image",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14857,
+          14867
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 447,
+        "columnno": 66,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009717",
+          "name": "port",
+          "type": "Literal",
+          "value": 3005
+        }
+      },
+      "undocumented": true,
+      "name": "port",
+      "longname": "<anonymous>~services.core.\"noona-vault\".port",
+      "kind": "member",
+      "memberof": "<anonymous>~services.core.\"noona-vault\"",
+      "scope": "static"
+    },
+    {
+      "comment": "",
+      "meta": {
+        "range": [
+          14883,
+          15006
+        ],
+        "filename": "wardenCore.test.mjs",
+        "lineno": 448,
+        "columnno": 12,
+        "path": "/workspace/Noona/services/warden/tests",
+        "code": {
+          "id": "astnode100009719",
           "name": "\"noona-raven\"",
           "type": "ObjectExpression",
           "value": "{\"name\":\"noona-raven\",\"image\":\"captainpax/noona-raven:latest\"}"
@@ -26682,15 +30527,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10884,
-          10903
+          14916,
+          14935
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 335,
+        "lineno": 449,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009008",
+          "id": "astnode100009721",
           "name": "name",
           "type": "Literal",
           "value": "noona-raven"
@@ -26707,15 +30552,15 @@
       "comment": "",
       "meta": {
         "range": [
-          10921,
-          10959
+          14953,
+          14991
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 336,
+        "lineno": 450,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009010",
+          "id": "astnode100009723",
           "name": "image",
           "type": "Literal",
           "value": "captainpax/noona-raven:latest"
@@ -26732,15 +30577,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11005,
-          11145
+          15037,
+          15177
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 341,
+        "lineno": 455,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009013",
+          "id": "astnode100009726",
           "name": "fsStub",
           "type": "ObjectExpression",
           "value": "{\"existsSync\":\"\",\"statSync\":\"\"}"
@@ -26758,15 +30603,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11024,
-          11086
+          15056,
+          15118
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 342,
+        "lineno": 456,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009016",
+          "id": "astnode100009729",
           "name": "existsSync",
           "type": "ArrowFunctionExpression"
         }
@@ -26782,15 +30627,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11096,
-          11138
+          15128,
+          15170
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 343,
+        "lineno": 457,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009022",
+          "id": "astnode100009735",
           "name": "statSync",
           "type": "ArrowFunctionExpression"
         },
@@ -26809,15 +30654,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11115,
-          11135
+          15147,
+          15167
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 343,
+        "lineno": 457,
         "columnno": 27,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009025",
+          "id": "astnode100009738",
           "name": "isSocket",
           "type": "ArrowFunctionExpression"
         }
@@ -26832,15 +30677,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11158,
-          11589
+          15190,
+          15621
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 346,
+        "lineno": 460,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009029",
+          "id": "astnode100009742",
           "name": "warden",
           "type": "CallExpression",
           "value": ""
@@ -26858,15 +30703,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11190,
-          11204
+          15222,
+          15236
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 347,
+        "lineno": 461,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009034",
+          "id": "astnode100009747",
           "name": "dockerInstance",
           "type": "Identifier",
           "value": "dockerInstance"
@@ -26882,15 +30727,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11214,
-          11222
+          15246,
+          15254
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 348,
+        "lineno": 462,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009036",
+          "id": "astnode100009749",
           "name": "services",
           "type": "Identifier",
           "value": "services"
@@ -26906,15 +30751,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11232,
-          11273
+          15264,
+          15305
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 349,
+        "lineno": 463,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009038",
+          "id": "astnode100009751",
           "name": "logger",
           "type": "ObjectExpression",
           "value": "{\"log\":\"\",\"warn\":\"\"}"
@@ -26930,15 +30775,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11242,
-          11255
+          15274,
+          15287
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 349,
+        "lineno": 463,
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009040",
+          "id": "astnode100009753",
           "name": "log",
           "type": "ArrowFunctionExpression"
         }
@@ -26954,15 +30799,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11257,
-          11271
+          15289,
+          15303
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 349,
+        "lineno": 463,
         "columnno": 33,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009043",
+          "id": "astnode100009756",
           "name": "warn",
           "type": "ArrowFunctionExpression"
         }
@@ -26978,15 +30823,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11283,
-          11325
+          15315,
+          15357
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 350,
+        "lineno": 464,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009046",
+          "id": "astnode100009759",
           "name": "hostDockerSockets",
           "type": "ArrayExpression",
           "value": "[\"/remote/docker.sock\"]"
@@ -27002,15 +30847,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11335,
-          11561
+          15367,
+          15593
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 351,
+        "lineno": 465,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009049",
+          "id": "astnode100009762",
           "name": "dockerFactory",
           "type": "ArrowFunctionExpression"
         }
@@ -27025,15 +30870,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11571,
-          11581
+          15603,
+          15613
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 358,
+        "lineno": 472,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009067",
+          "id": "astnode100009780",
           "name": "fs",
           "type": "Identifier",
           "value": "fsStub"
@@ -27049,15 +30894,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11600,
-          11622
+          15632,
+          15654
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 361,
+        "lineno": 475,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009070",
+          "id": "astnode100009783",
           "name": "receivedService",
           "type": "Literal",
           "value": null
@@ -27075,15 +30920,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11628,
-          11711
+          15660,
+          15743
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 362,
+        "lineno": 476,
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009074",
+          "id": "astnode100009787",
           "name": "warden.startService",
           "type": "ArrowFunctionExpression",
           "funcscope": "<anonymous>",
@@ -27106,15 +30951,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11679,
-          11704
+          15711,
+          15736
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 363,
+        "lineno": 477,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009082",
+          "id": "astnode100009795",
           "name": "receivedService",
           "type": "Identifier",
           "funcscope": "<anonymous>~warden.startService",
@@ -27133,15 +30978,15 @@
       "comment": "",
       "meta": {
         "range": [
-          11724,
-          11775
+          15756,
+          15807
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 366,
+        "lineno": 480,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009086",
+          "id": "astnode100009799",
           "name": "result",
           "type": "AwaitExpression",
           "value": ""
@@ -27159,15 +31004,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12043,
-          12072
+          16075,
+          16104
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 372,
+        "lineno": 486,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009131",
+          "id": "astnode100009844",
           "name": "mountPath",
           "type": "Literal",
           "value": "/alt/kavita-data"
@@ -27183,15 +31028,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12082,
-          12115
+          16114,
+          16147
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 373,
+        "lineno": 487,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009133",
+          "id": "astnode100009846",
           "name": "socketPath",
           "type": "Literal",
           "value": "/remote/docker.sock"
@@ -27207,15 +31052,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12125,
-          12149
+          16157,
+          16181
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 374,
+        "lineno": 488,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009135",
+          "id": "astnode100009848",
           "name": "containerId",
           "type": "Literal",
           "value": "secondary"
@@ -27231,15 +31076,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12159,
-          12192
+          16191,
+          16224
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 375,
+        "lineno": 489,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009137",
+          "id": "astnode100009850",
           "name": "containerName",
           "type": "Literal",
           "value": "secondary-kavita"
@@ -27255,15 +31100,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12311,
-          12594
+          16343,
+          16626
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 380,
+        "lineno": 494,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009146",
+          "id": "astnode100009859",
           "name": "dockerUtils",
           "type": "ObjectExpression",
           "value": "{\"ensureNetwork\":\"\",\"attachSelfToNetwork\":\"\",\"containerExists\":\"\",\"pullImageIfNeeded\":\"\",\"runContainerWithLogs\":\"\",\"waitForHealthyStatus\":\"\"}"
@@ -27281,15 +31126,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12335,
-          12364
+          16367,
+          16396
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 381,
+        "lineno": 495,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009149",
+          "id": "astnode100009862",
           "name": "ensureNetwork",
           "type": "ArrowFunctionExpression"
         }
@@ -27305,15 +31150,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12374,
-          12409
+          16406,
+          16441
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 382,
+        "lineno": 496,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009152",
+          "id": "astnode100009865",
           "name": "attachSelfToNetwork",
           "type": "ArrowFunctionExpression"
         }
@@ -27329,15 +31174,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12419,
-          12452
+          16451,
+          16484
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 383,
+        "lineno": 497,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009155",
+          "id": "astnode100009868",
           "name": "containerExists",
           "type": "ArrowFunctionExpression"
         }
@@ -27353,15 +31198,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12462,
-          12495
+          16494,
+          16527
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 384,
+        "lineno": 498,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009158",
+          "id": "astnode100009871",
           "name": "pullImageIfNeeded",
           "type": "ArrowFunctionExpression"
         }
@@ -27377,15 +31222,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12505,
-          12541
+          16537,
+          16573
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 385,
+        "lineno": 499,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009161",
+          "id": "astnode100009874",
           "name": "runContainerWithLogs",
           "type": "ArrowFunctionExpression"
         }
@@ -27401,15 +31246,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12551,
-          12587
+          16583,
+          16619
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 386,
+        "lineno": 500,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009164",
+          "id": "astnode100009877",
           "name": "waitForHealthyStatus",
           "type": "ArrowFunctionExpression"
         }
@@ -27425,15 +31270,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12606,
-          12619
+          16638,
+          16651
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 388,
+        "lineno": 502,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009168",
+          "id": "astnode100009881",
           "name": "warnings",
           "type": "ArrayExpression",
           "value": "[]"
@@ -27451,15 +31296,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12631,
-          13286
+          16663,
+          17318
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 389,
+        "lineno": 503,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009172",
+          "id": "astnode100009885",
           "name": "warden",
           "type": "CallExpression",
           "value": ""
@@ -27477,15 +31322,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12663,
-          12674
+          16695,
+          16706
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 390,
+        "lineno": 504,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009177",
+          "id": "astnode100009890",
           "name": "dockerUtils",
           "type": "Identifier",
           "value": "dockerUtils"
@@ -27501,15 +31346,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12684,
-          13200
+          16716,
+          17232
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 391,
+        "lineno": 505,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009179",
+          "id": "astnode100009892",
           "name": "services",
           "type": "ObjectExpression",
           "value": "{\"addon\":\"\",\"core\":\"\"}"
@@ -27525,15 +31370,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12708,
-          12786
+          16740,
+          16818
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 392,
+        "lineno": 506,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009181",
+          "id": "astnode100009894",
           "name": "addon",
           "type": "ObjectExpression",
           "value": "{\"undefined\":\"\"}"
@@ -27550,15 +31395,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12733,
-          12771
+          16765,
+          16803
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 393,
+        "lineno": 507,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009183",
+          "id": "astnode100009896",
           "name": "\"noona-redis\"",
           "type": "ObjectExpression",
           "value": "{\"name\":\"noona-redis\"}"
@@ -27575,15 +31420,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12750,
-          12769
+          16782,
+          16801
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 393,
+        "lineno": 507,
         "columnno": 33,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009185",
+          "id": "astnode100009898",
           "name": "name",
           "type": "Literal",
           "value": "noona-redis"
@@ -27600,15 +31445,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12800,
-          13189
+          16832,
+          17221
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 395,
+        "lineno": 509,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009187",
+          "id": "astnode100009900",
           "name": "core",
           "type": "ObjectExpression",
           "value": "{\"undefined\":\"\"}"
@@ -27625,15 +31470,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12824,
-          12893
+          16856,
+          16925
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 396,
+        "lineno": 510,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009189",
+          "id": "astnode100009902",
           "name": "\"noona-mongo\"",
           "type": "ObjectExpression",
           "value": "{\"name\":\"noona-mongo\",\"health\":\"http://mongo/health\"}"
@@ -27650,15 +31495,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12841,
-          12860
+          16873,
+          16892
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 396,
+        "lineno": 510,
         "columnno": 33,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009191",
+          "id": "astnode100009904",
           "name": "name",
           "type": "Literal",
           "value": "noona-mongo"
@@ -27675,15 +31520,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12862,
-          12891
+          16894,
+          16923
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 396,
+        "lineno": 510,
         "columnno": 54,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009193",
+          "id": "astnode100009906",
           "name": "health",
           "type": "Literal",
           "value": "http://mongo/health"
@@ -27700,15 +31545,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12911,
-          12947
+          16943,
+          16979
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 397,
+        "lineno": 511,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009195",
+          "id": "astnode100009908",
           "name": "\"noona-sage\"",
           "type": "ObjectExpression",
           "value": "{\"name\":\"noona-sage\"}"
@@ -27725,15 +31570,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12927,
-          12945
+          16959,
+          16977
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 397,
+        "lineno": 511,
         "columnno": 32,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009197",
+          "id": "astnode100009910",
           "name": "name",
           "type": "Literal",
           "value": "noona-sage"
@@ -27750,15 +31595,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12965,
-          13031
+          16997,
+          17063
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 398,
+        "lineno": 512,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009199",
+          "id": "astnode100009912",
           "name": "\"noona-moon\"",
           "type": "ObjectExpression",
           "value": "{\"name\":\"noona-moon\",\"health\":\"http://moon/health\"}"
@@ -27775,15 +31620,15 @@
       "comment": "",
       "meta": {
         "range": [
-          12981,
-          12999
+          17013,
+          17031
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 398,
+        "lineno": 512,
         "columnno": 32,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009201",
+          "id": "astnode100009914",
           "name": "name",
           "type": "Literal",
           "value": "noona-moon"
@@ -27800,15 +31645,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13001,
-          13029
+          17033,
+          17061
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 398,
+        "lineno": 512,
         "columnno": 52,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009203",
+          "id": "astnode100009916",
           "name": "health",
           "type": "Literal",
           "value": "http://moon/health"
@@ -27825,15 +31670,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13049,
-          13118
+          17081,
+          17150
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 399,
+        "lineno": 513,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009205",
+          "id": "astnode100009918",
           "name": "\"noona-vault\"",
           "type": "ObjectExpression",
           "value": "{\"name\":\"noona-vault\",\"health\":\"http://vault/health\"}"
@@ -27850,15 +31695,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13066,
-          13085
+          17098,
+          17117
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 399,
+        "lineno": 513,
         "columnno": 33,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009207",
+          "id": "astnode100009920",
           "name": "name",
           "type": "Literal",
           "value": "noona-vault"
@@ -27875,15 +31720,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13087,
-          13116
+          17119,
+          17148
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 399,
+        "lineno": 513,
         "columnno": 54,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009209",
+          "id": "astnode100009922",
           "name": "health",
           "type": "Literal",
           "value": "http://vault/health"
@@ -27900,15 +31745,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13136,
-          13174
+          17168,
+          17206
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 400,
+        "lineno": 514,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009211",
+          "id": "astnode100009924",
           "name": "\"noona-raven\"",
           "type": "ObjectExpression",
           "value": "{\"name\":\"noona-raven\"}"
@@ -27925,15 +31770,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13153,
-          13172
+          17185,
+          17204
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 400,
+        "lineno": 514,
         "columnno": 33,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009213",
+          "id": "astnode100009926",
           "name": "name",
           "type": "Literal",
           "value": "noona-raven"
@@ -27950,15 +31795,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13210,
-          13278
+          17242,
+          17310
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 403,
+        "lineno": 517,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009215",
+          "id": "astnode100009928",
           "name": "logger",
           "type": "ObjectExpression",
           "value": "{\"log\":\"\",\"warn\":\"\"}"
@@ -27974,15 +31819,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13220,
-          13233
+          17252,
+          17265
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 403,
+        "lineno": 517,
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009217",
+          "id": "astnode100009930",
           "name": "log",
           "type": "ArrowFunctionExpression"
         }
@@ -27998,15 +31843,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13235,
-          13276
+          17267,
+          17308
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 403,
+        "lineno": 517,
         "columnno": 33,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009220",
+          "id": "astnode100009933",
           "name": "warn",
           "type": "ArrowFunctionExpression"
         }
@@ -28022,15 +31867,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13299,
-          13309
+          17331,
+          17341
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 406,
+        "lineno": 520,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009229",
+          "id": "astnode100009942",
           "name": "order",
           "type": "ArrayExpression",
           "value": "[]"
@@ -28048,15 +31893,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13315,
-          13421
+          17347,
+          17453
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 407,
+        "lineno": 521,
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009233",
+          "id": "astnode100009946",
           "name": "warden.startService",
           "type": "ArrowFunctionExpression",
           "funcscope": "<anonymous>",
@@ -28077,15 +31922,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13924,
-          13935
+          17956,
+          17967
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 425,
+        "lineno": 539,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009298",
+          "id": "astnode100010011",
           "name": "events",
           "type": "ArrayExpression",
           "value": "[]"
@@ -28103,15 +31948,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13947,
-          14374
+          17979,
+          18406
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 426,
+        "lineno": 540,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009302",
+          "id": "astnode100010015",
           "name": "dockerUtils",
           "type": "ObjectExpression",
           "value": "{\"ensureNetwork\":\"\",\"attachSelfToNetwork\":\"\",\"containerExists\":\"\",\"pullImageIfNeeded\":\"\",\"runContainerWithLogs\":\"\",\"waitForHealthyStatus\":\"\"}"
@@ -28129,15 +31974,15 @@
       "comment": "",
       "meta": {
         "range": [
-          13971,
-          14019
+          18003,
+          18051
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 427,
+        "lineno": 541,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009305",
+          "id": "astnode100010018",
           "name": "ensureNetwork",
           "type": "ArrowFunctionExpression"
         }
@@ -28153,15 +31998,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14029,
-          14083
+          18061,
+          18115
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 428,
+        "lineno": 542,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009312",
+          "id": "astnode100010025",
           "name": "attachSelfToNetwork",
           "type": "ArrowFunctionExpression"
         }
@@ -28177,15 +32022,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14093,
-          14232
+          18125,
+          18264
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 429,
+        "lineno": 543,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009319",
+          "id": "astnode100010032",
           "name": "containerExists",
           "type": "ArrowFunctionExpression"
         }
@@ -28201,15 +32046,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14242,
-          14275
+          18274,
+          18307
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 432,
+        "lineno": 546,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009326",
+          "id": "astnode100010039",
           "name": "pullImageIfNeeded",
           "type": "ArrowFunctionExpression"
         }
@@ -28225,15 +32070,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14285,
-          14321
+          18317,
+          18353
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 433,
+        "lineno": 547,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009329",
+          "id": "astnode100010042",
           "name": "runContainerWithLogs",
           "type": "ArrowFunctionExpression"
         }
@@ -28249,15 +32094,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14331,
-          14367
+          18363,
+          18399
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 434,
+        "lineno": 548,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009332",
+          "id": "astnode100010045",
           "name": "waitForHealthyStatus",
           "type": "ArrowFunctionExpression"
         }
@@ -28273,15 +32118,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14386,
-          14509
+          18418,
+          18541
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 436,
+        "lineno": 550,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009336",
+          "id": "astnode100010049",
           "name": "logger",
           "type": "ObjectExpression",
           "value": "{\"log\":\"\",\"warn\":\"\"}"
@@ -28299,15 +32144,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14405,
-          14443
+          18437,
+          18475
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 437,
+        "lineno": 551,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009339",
+          "id": "astnode100010052",
           "name": "log",
           "type": "ArrowFunctionExpression"
         }
@@ -28323,15 +32168,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14453,
-          14502
+          18485,
+          18534
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 438,
+        "lineno": 552,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009347",
+          "id": "astnode100010060",
           "name": "warn",
           "type": "ArrowFunctionExpression"
         }
@@ -28347,15 +32192,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14521,
-          14854
+          18553,
+          18886
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 440,
+        "lineno": 554,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009359",
+          "id": "astnode100010072",
           "name": "warden",
           "type": "CallExpression",
           "value": ""
@@ -28373,15 +32218,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14553,
-          14564
+          18585,
+          18596
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 441,
+        "lineno": 555,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009364",
+          "id": "astnode100010077",
           "name": "dockerUtils",
           "type": "Identifier",
           "value": "dockerUtils"
@@ -28397,15 +32242,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14574,
-          14830
+          18606,
+          18862
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 442,
+        "lineno": 556,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009366",
+          "id": "astnode100010079",
           "name": "services",
           "type": "ObjectExpression",
           "value": "{\"addon\":\"\",\"core\":\"\"}"
@@ -28421,15 +32266,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14598,
-          14676
+          18630,
+          18708
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 443,
+        "lineno": 557,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009368",
+          "id": "astnode100010081",
           "name": "addon",
           "type": "ObjectExpression",
           "value": "{\"undefined\":\"\"}"
@@ -28446,15 +32291,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14623,
-          14661
+          18655,
+          18693
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 444,
+        "lineno": 558,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009370",
+          "id": "astnode100010083",
           "name": "\"noona-redis\"",
           "type": "ObjectExpression",
           "value": "{\"name\":\"noona-redis\"}"
@@ -28471,15 +32316,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14640,
-          14659
+          18672,
+          18691
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 444,
+        "lineno": 558,
         "columnno": 33,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009372",
+          "id": "astnode100010085",
           "name": "name",
           "type": "Literal",
           "value": "noona-redis"
@@ -28496,15 +32341,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14690,
-          14819
+          18722,
+          18851
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 446,
+        "lineno": 560,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009374",
+          "id": "astnode100010087",
           "name": "core",
           "type": "ObjectExpression",
           "value": "{\"undefined\":\"\"}"
@@ -28521,15 +32366,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14714,
-          14750
+          18746,
+          18782
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 447,
+        "lineno": 561,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009376",
+          "id": "astnode100010089",
           "name": "\"noona-moon\"",
           "type": "ObjectExpression",
           "value": "{\"name\":\"noona-moon\"}"
@@ -28546,15 +32391,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14730,
-          14748
+          18762,
+          18780
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 447,
+        "lineno": 561,
         "columnno": 32,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009378",
+          "id": "astnode100010091",
           "name": "name",
           "type": "Literal",
           "value": "noona-moon"
@@ -28571,15 +32416,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14768,
-          14804
+          18800,
+          18836
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 448,
+        "lineno": 562,
         "columnno": 16,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009380",
+          "id": "astnode100010093",
           "name": "\"noona-sage\"",
           "type": "ObjectExpression",
           "value": "{\"name\":\"noona-sage\"}"
@@ -28596,15 +32441,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14784,
-          14802
+          18816,
+          18834
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 448,
+        "lineno": 562,
         "columnno": 32,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009382",
+          "id": "astnode100010095",
           "name": "name",
           "type": "Literal",
           "value": "noona-sage"
@@ -28621,15 +32466,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14840,
-          14846
+          18872,
+          18878
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 451,
+        "lineno": 565,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009384",
+          "id": "astnode100010097",
           "name": "logger",
           "type": "Identifier",
           "value": "logger"
@@ -28645,15 +32490,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14861,
-          14979
+          18893,
+          19011
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 454,
+        "lineno": 568,
         "columnno": 4,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009387",
+          "id": "astnode100010100",
           "name": "warden.startService",
           "type": "ArrowFunctionExpression",
           "funcscope": "<anonymous>",
@@ -28674,15 +32519,15 @@
       "comment": "",
       "meta": {
         "range": [
-          14992,
-          15020
+          19024,
+          19052
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 458,
+        "lineno": 572,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009409",
+          "id": "astnode100010122",
           "name": "result",
           "type": "AwaitExpression",
           "value": ""
@@ -28700,15 +32545,15 @@
       "comment": "",
       "meta": {
         "range": [
-          15621,
-          15636
+          19653,
+          19668
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 471,
+        "lineno": 585,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009508",
+          "id": "astnode100010221",
           "name": "operations",
           "type": "ArrayExpression",
           "value": "[]"
@@ -28726,15 +32571,15 @@
       "comment": "",
       "meta": {
         "range": [
-          15648,
-          15980
+          19680,
+          20012
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 472,
+        "lineno": 586,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009512",
+          "id": "astnode100010225",
           "name": "containers",
           "type": "ObjectExpression",
           "value": "{\"undefined\":\"\"}"
@@ -28752,15 +32597,15 @@
       "comment": "",
       "meta": {
         "range": [
-          15671,
-          15817
+          19703,
+          19849
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 473,
+        "lineno": 587,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009515",
+          "id": "astnode100010228",
           "name": "\"svc-1\"",
           "type": "ObjectExpression",
           "value": "{\"stop\":\"\",\"remove\":\"\"}"
@@ -28777,15 +32622,15 @@
       "comment": "",
       "meta": {
         "range": [
-          15694,
-          15741
+          19726,
+          19773
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 474,
+        "lineno": 588,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009517",
+          "id": "astnode100010230",
           "name": "stop",
           "type": "ArrowFunctionExpression"
         }
@@ -28801,15 +32646,15 @@
       "comment": "",
       "meta": {
         "range": [
-          15755,
-          15806
+          19787,
+          19838
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 475,
+        "lineno": 589,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009524",
+          "id": "astnode100010237",
           "name": "remove",
           "type": "ArrowFunctionExpression"
         }
@@ -28825,15 +32670,15 @@
       "comment": "",
       "meta": {
         "range": [
-          15827,
-          15973
+          19859,
+          20005
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 477,
+        "lineno": 591,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009531",
+          "id": "astnode100010244",
           "name": "\"svc-2\"",
           "type": "ObjectExpression",
           "value": "{\"stop\":\"\",\"remove\":\"\"}"
@@ -28850,15 +32695,15 @@
       "comment": "",
       "meta": {
         "range": [
-          15850,
-          15897
+          19882,
+          19929
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 478,
+        "lineno": 592,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009533",
+          "id": "astnode100010246",
           "name": "stop",
           "type": "ArrowFunctionExpression"
         }
@@ -28874,15 +32719,15 @@
       "comment": "",
       "meta": {
         "range": [
-          15911,
-          15962
+          19943,
+          19994
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 479,
+        "lineno": 593,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009540",
+          "id": "astnode100010253",
           "name": "remove",
           "type": "ArrowFunctionExpression"
         }
@@ -28898,15 +32743,15 @@
       "comment": "",
       "meta": {
         "range": [
-          15992,
-          16066
+          20024,
+          20098
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 482,
+        "lineno": 596,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009548",
+          "id": "astnode100010261",
           "name": "dockerInstance",
           "type": "ObjectExpression",
           "value": "{\"getContainer\":\"\"}"
@@ -28924,15 +32769,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16019,
-          16059
+          20051,
+          20091
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 483,
+        "lineno": 597,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009551",
+          "id": "astnode100010264",
           "name": "getContainer",
           "type": "ArrowFunctionExpression"
         }
@@ -28948,15 +32793,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16078,
-          16125
+          20110,
+          20157
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 485,
+        "lineno": 599,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009558",
+          "id": "astnode100010271",
           "name": "trackedContainers",
           "type": "NewExpression",
           "value": ""
@@ -28974,15 +32819,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16135,
-          16150
+          20167,
+          20182
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 486,
+        "lineno": 600,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009566",
+          "id": "astnode100010279",
           "name": "exitCode",
           "type": "Literal",
           "value": null
@@ -29000,15 +32845,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16162,
-          16445
+          20194,
+          20477
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 487,
+        "lineno": 601,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009570",
+          "id": "astnode100010283",
           "name": "dockerUtils",
           "type": "ObjectExpression",
           "value": "{\"ensureNetwork\":\"\",\"attachSelfToNetwork\":\"\",\"containerExists\":\"\",\"pullImageIfNeeded\":\"\",\"runContainerWithLogs\":\"\",\"waitForHealthyStatus\":\"\"}"
@@ -29026,15 +32871,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16186,
-          16215
+          20218,
+          20247
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 488,
+        "lineno": 602,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009573",
+          "id": "astnode100010286",
           "name": "ensureNetwork",
           "type": "ArrowFunctionExpression"
         }
@@ -29050,15 +32895,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16225,
-          16260
+          20257,
+          20292
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 489,
+        "lineno": 603,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009576",
+          "id": "astnode100010289",
           "name": "attachSelfToNetwork",
           "type": "ArrowFunctionExpression"
         }
@@ -29074,15 +32919,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16270,
-          16303
+          20302,
+          20335
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 490,
+        "lineno": 604,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009579",
+          "id": "astnode100010292",
           "name": "containerExists",
           "type": "ArrowFunctionExpression"
         }
@@ -29098,15 +32943,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16313,
-          16346
+          20345,
+          20378
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 491,
+        "lineno": 605,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009582",
+          "id": "astnode100010295",
           "name": "pullImageIfNeeded",
           "type": "ArrowFunctionExpression"
         }
@@ -29122,15 +32967,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16356,
-          16392
+          20388,
+          20424
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 492,
+        "lineno": 606,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009585",
+          "id": "astnode100010298",
           "name": "runContainerWithLogs",
           "type": "ArrowFunctionExpression"
         }
@@ -29146,15 +32991,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16402,
-          16438
+          20434,
+          20470
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 493,
+        "lineno": 607,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009588",
+          "id": "astnode100010301",
           "name": "waitForHealthyStatus",
           "type": "ArrowFunctionExpression"
         }
@@ -29170,15 +33015,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16457,
-          16588
+          20489,
+          20620
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 495,
+        "lineno": 609,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009592",
+          "id": "astnode100010305",
           "name": "logger",
           "type": "ObjectExpression",
           "value": "{\"log\":\"\",\"warn\":\"\"}"
@@ -29196,15 +33041,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16476,
-          16518
+          20508,
+          20550
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 496,
+        "lineno": 610,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009595",
+          "id": "astnode100010308",
           "name": "log",
           "type": "ArrowFunctionExpression"
         }
@@ -29220,15 +33065,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16528,
-          16581
+          20560,
+          20613
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 497,
+        "lineno": 611,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009603",
+          "id": "astnode100010316",
           "name": "warn",
           "type": "ArrowFunctionExpression"
         }
@@ -29244,15 +33089,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16601,
-          16792
+          20633,
+          20824
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 500,
+        "lineno": 614,
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009615",
+          "id": "astnode100010328",
           "name": "warden",
           "type": "CallExpression",
           "value": ""
@@ -29270,15 +33115,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16633,
-          16647
+          20665,
+          20679
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 501,
+        "lineno": 615,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009620",
+          "id": "astnode100010333",
           "name": "dockerInstance",
           "type": "Identifier",
           "value": "dockerInstance"
@@ -29294,15 +33139,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16657,
-          16674
+          20689,
+          20706
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 502,
+        "lineno": 616,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009622",
+          "id": "astnode100010335",
           "name": "trackedContainers",
           "type": "Identifier",
           "value": "trackedContainers"
@@ -29318,15 +33163,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16684,
-          16695
+          20716,
+          20727
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 503,
+        "lineno": 617,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009624",
+          "id": "astnode100010337",
           "name": "dockerUtils",
           "type": "Identifier",
           "value": "dockerUtils"
@@ -29342,15 +33187,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16705,
-          16711
+          20737,
+          20743
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 504,
+        "lineno": 618,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009626",
+          "id": "astnode100010339",
           "name": "logger",
           "type": "Identifier",
           "value": "logger"
@@ -29366,15 +33211,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16721,
-          16784
+          20753,
+          20816
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 505,
+        "lineno": 619,
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009628",
+          "id": "astnode100010341",
           "name": "processExit",
           "type": "ArrowFunctionExpression"
         },
@@ -29392,15 +33237,15 @@
       "comment": "",
       "meta": {
         "range": [
-          16758,
-          16773
+          20790,
+          20805
         ],
         "filename": "wardenCore.test.mjs",
-        "lineno": 506,
+        "lineno": 620,
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009633",
+          "id": "astnode100010346",
           "name": "exitCode",
           "type": "Identifier",
           "funcscope": "processExit",
@@ -29427,7 +33272,7 @@
         "columnno": 6,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009691",
+          "id": "astnode100010404",
           "name": "listen",
           "type": "ArrowFunctionExpression"
         },
@@ -29456,7 +33301,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009701",
+          "id": "astnode100010414",
           "name": "server",
           "type": "Identifier",
           "value": "server"
@@ -29480,7 +33325,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009706",
+          "id": "astnode100010419",
           "name": "warden",
           "type": "MemberExpression",
           "value": "options.warden"
@@ -29504,7 +33349,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009710",
+          "id": "astnode100010423",
           "name": "port",
           "type": "Literal",
           "value": 0
@@ -29528,7 +33373,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009712",
+          "id": "astnode100010425",
           "name": "logger",
           "type": "MemberExpression",
           "value": "options.logger"
@@ -29552,7 +33397,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009723",
+          "id": "astnode100010436",
           "name": "address",
           "type": "CallExpression",
           "value": ""
@@ -29578,7 +33423,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009744",
+          "id": "astnode100010457",
           "name": "server",
           "type": "Identifier",
           "value": "server"
@@ -29602,7 +33447,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009746",
+          "id": "astnode100010459",
           "name": "baseUrl",
           "type": "TemplateLiteral",
           "value": ""
@@ -29626,7 +33471,7 @@
         "columnno": 6,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009754",
+          "id": "astnode100010467",
           "name": "closeServer",
           "type": "ArrowFunctionExpression"
         },
@@ -29653,7 +33498,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009791",
+          "id": "astnode100010504",
           "name": "calls",
           "type": "ArrayExpression",
           "value": "[]"
@@ -29679,7 +33524,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009795",
+          "id": "astnode100010508",
           "name": "warden",
           "type": "ObjectExpression",
           "value": "{\"listServices\":\"\",\"installServices\":\"\"}"
@@ -29705,7 +33550,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009798",
+          "id": "astnode100010511",
           "name": "listServices",
           "type": "FunctionExpression"
         }
@@ -29729,7 +33574,7 @@
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009811",
+          "id": "astnode100010524",
           "name": "name",
           "type": "Literal",
           "value": "noona-sage"
@@ -29753,7 +33598,7 @@
         "columnno": 38,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009813",
+          "id": "astnode100010526",
           "name": "category",
           "type": "Literal",
           "value": "core"
@@ -29777,7 +33622,7 @@
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009816",
+          "id": "astnode100010529",
           "name": "name",
           "type": "Literal",
           "value": "noona-redis"
@@ -29801,7 +33646,7 @@
         "columnno": 39,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009818",
+          "id": "astnode100010531",
           "name": "category",
           "type": "Literal",
           "value": "addon"
@@ -29825,7 +33670,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009820",
+          "id": "astnode100010533",
           "name": "installServices",
           "type": "ArrowFunctionExpression"
         }
@@ -29849,7 +33694,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009830",
+          "id": "astnode100010543",
           "name": "server",
           "type": "Identifier",
           "value": "server"
@@ -29873,7 +33718,7 @@
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009832",
+          "id": "astnode100010545",
           "name": "baseUrl",
           "type": "Identifier",
           "value": "baseUrl"
@@ -29897,7 +33742,7 @@
         "columnno": 47,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009838",
+          "id": "astnode100010551",
           "name": "warden",
           "type": "Identifier",
           "value": "warden"
@@ -29921,7 +33766,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009850",
+          "id": "astnode100010563",
           "name": "response",
           "type": "AwaitExpression",
           "value": ""
@@ -29947,7 +33792,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009879",
+          "id": "astnode100010592",
           "name": "services",
           "type": "ArrayExpression",
           "value": "[\"{\\\"name\\\":\\\"noona-sage\\\",\\\"category\\\":\\\"core\\\"}\",\"{\\\"name\\\":\\\"noona-redis\\\",\\\"category\\\":\\\"addon\\\"}\"]"
@@ -29971,7 +33816,7 @@
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009882",
+          "id": "astnode100010595",
           "name": "name",
           "type": "Literal",
           "value": "noona-sage"
@@ -29995,7 +33840,7 @@
         "columnno": 34,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009884",
+          "id": "astnode100010597",
           "name": "category",
           "type": "Literal",
           "value": "core"
@@ -30019,7 +33864,7 @@
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009887",
+          "id": "astnode100010600",
           "name": "name",
           "type": "Literal",
           "value": "noona-redis"
@@ -30043,7 +33888,7 @@
         "columnno": 35,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009889",
+          "id": "astnode100010602",
           "name": "category",
           "type": "Literal",
           "value": "addon"
@@ -30067,7 +33912,7 @@
         "columnno": 31,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009899",
+          "id": "astnode100010612",
           "name": "includeInstalled",
           "type": "Literal",
           "value": false
@@ -30091,7 +33936,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009909",
+          "id": "astnode100010622",
           "name": "calls",
           "type": "ArrayExpression",
           "value": "[]"
@@ -30117,7 +33962,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009913",
+          "id": "astnode100010626",
           "name": "warden",
           "type": "ObjectExpression",
           "value": "{\"listServices\":\"\",\"installServices\":\"\"}"
@@ -30143,7 +33988,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009916",
+          "id": "astnode100010629",
           "name": "listServices",
           "type": "FunctionExpression"
         }
@@ -30167,7 +34012,7 @@
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009929",
+          "id": "astnode100010642",
           "name": "name",
           "type": "Literal",
           "value": "noona-sage"
@@ -30191,7 +34036,7 @@
         "columnno": 38,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009931",
+          "id": "astnode100010644",
           "name": "category",
           "type": "Literal",
           "value": "core"
@@ -30215,7 +34060,7 @@
         "columnno": 56,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009933",
+          "id": "astnode100010646",
           "name": "installed",
           "type": "Literal",
           "value": true
@@ -30239,7 +34084,7 @@
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009936",
+          "id": "astnode100010649",
           "name": "name",
           "type": "Literal",
           "value": "noona-redis"
@@ -30263,7 +34108,7 @@
         "columnno": 39,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009938",
+          "id": "astnode100010651",
           "name": "category",
           "type": "Literal",
           "value": "addon"
@@ -30287,7 +34132,7 @@
         "columnno": 58,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009940",
+          "id": "astnode100010653",
           "name": "installed",
           "type": "Literal",
           "value": false
@@ -30311,7 +34156,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009942",
+          "id": "astnode100010655",
           "name": "installServices",
           "type": "ArrowFunctionExpression"
         }
@@ -30335,7 +34180,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009952",
+          "id": "astnode100010665",
           "name": "server",
           "type": "Identifier",
           "value": "server"
@@ -30359,7 +34204,7 @@
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009954",
+          "id": "astnode100010667",
           "name": "baseUrl",
           "type": "Identifier",
           "value": "baseUrl"
@@ -30383,7 +34228,7 @@
         "columnno": 47,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009960",
+          "id": "astnode100010673",
           "name": "warden",
           "type": "Identifier",
           "value": "warden"
@@ -30407,7 +34252,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100009972",
+          "id": "astnode100010685",
           "name": "response",
           "type": "AwaitExpression",
           "value": ""
@@ -30433,7 +34278,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010001",
+          "id": "astnode100010714",
           "name": "services",
           "type": "ArrayExpression",
           "value": "[\"{\\\"name\\\":\\\"noona-sage\\\",\\\"category\\\":\\\"core\\\",\\\"installed\\\":true}\",\"{\\\"name\\\":\\\"noona-redis\\\",\\\"category\\\":\\\"addon\\\",\\\"installed\\\":false}\"]"
@@ -30457,7 +34302,7 @@
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010004",
+          "id": "astnode100010717",
           "name": "name",
           "type": "Literal",
           "value": "noona-sage"
@@ -30481,7 +34326,7 @@
         "columnno": 34,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010006",
+          "id": "astnode100010719",
           "name": "category",
           "type": "Literal",
           "value": "core"
@@ -30505,7 +34350,7 @@
         "columnno": 52,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010008",
+          "id": "astnode100010721",
           "name": "installed",
           "type": "Literal",
           "value": true
@@ -30529,7 +34374,7 @@
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010011",
+          "id": "astnode100010724",
           "name": "name",
           "type": "Literal",
           "value": "noona-redis"
@@ -30553,7 +34398,7 @@
         "columnno": 35,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010013",
+          "id": "astnode100010726",
           "name": "category",
           "type": "Literal",
           "value": "addon"
@@ -30577,7 +34422,7 @@
         "columnno": 54,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010015",
+          "id": "astnode100010728",
           "name": "installed",
           "type": "Literal",
           "value": false
@@ -30601,7 +34446,7 @@
         "columnno": 31,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010025",
+          "id": "astnode100010738",
           "name": "includeInstalled",
           "type": "Literal",
           "value": true
@@ -30625,7 +34470,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010035",
+          "id": "astnode100010748",
           "name": "installCalls",
           "type": "ArrayExpression",
           "value": "[]"
@@ -30651,7 +34496,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010039",
+          "id": "astnode100010752",
           "name": "warden",
           "type": "ObjectExpression",
           "value": "{\"listServices\":\"\",\"installServices\":\"\"}"
@@ -30677,7 +34522,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010042",
+          "id": "astnode100010755",
           "name": "listServices",
           "type": "ArrowFunctionExpression"
         }
@@ -30701,7 +34546,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010045",
+          "id": "astnode100010758",
           "name": "installServices",
           "type": "ArrowFunctionExpression"
         }
@@ -30725,7 +34570,7 @@
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010058",
+          "id": "astnode100010771",
           "name": "name",
           "type": "Literal",
           "value": "noona-sage"
@@ -30749,7 +34594,7 @@
         "columnno": 38,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010060",
+          "id": "astnode100010773",
           "name": "status",
           "type": "Literal",
           "value": "installed"
@@ -30773,7 +34618,7 @@
         "columnno": 59,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010062",
+          "id": "astnode100010775",
           "name": "category",
           "type": "Literal",
           "value": "core"
@@ -30797,7 +34642,7 @@
         "columnno": 18,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010065",
+          "id": "astnode100010778",
           "name": "name",
           "type": "Literal",
           "value": "noona-bad"
@@ -30821,7 +34666,7 @@
         "columnno": 37,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010067",
+          "id": "astnode100010780",
           "name": "status",
           "type": "Literal",
           "value": "error"
@@ -30845,7 +34690,7 @@
         "columnno": 54,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010069",
+          "id": "astnode100010782",
           "name": "error",
           "type": "Literal",
           "value": "boom"
@@ -30869,7 +34714,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010074",
+          "id": "astnode100010787",
           "name": "server",
           "type": "Identifier",
           "value": "server"
@@ -30893,7 +34738,7 @@
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010076",
+          "id": "astnode100010789",
           "name": "baseUrl",
           "type": "Identifier",
           "value": "baseUrl"
@@ -30917,7 +34762,7 @@
         "columnno": 47,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010082",
+          "id": "astnode100010795",
           "name": "warden",
           "type": "Identifier",
           "value": "warden"
@@ -30941,7 +34786,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010094",
+          "id": "astnode100010807",
           "name": "response",
           "type": "AwaitExpression",
           "value": ""
@@ -30967,7 +34812,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010104",
+          "id": "astnode100010817",
           "name": "method",
           "type": "Literal",
           "value": "POST"
@@ -30991,7 +34836,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010106",
+          "id": "astnode100010819",
           "name": "headers",
           "type": "ObjectExpression",
           "value": "{\"undefined\":\"application/json\"}"
@@ -31015,7 +34860,7 @@
         "columnno": 19,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010108",
+          "id": "astnode100010821",
           "name": "\"Content-Type\"",
           "type": "Literal",
           "value": "application/json"
@@ -31040,7 +34885,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010110",
+          "id": "astnode100010823",
           "name": "body",
           "type": "CallExpression",
           "value": ""
@@ -31064,7 +34909,7 @@
         "columnno": 31,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010116",
+          "id": "astnode100010829",
           "name": "services",
           "type": "ArrayExpression",
           "value": "[\"noona-sage\",\"noona-bad\"]"
@@ -31088,7 +34933,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010140",
+          "id": "astnode100010853",
           "name": "results",
           "type": "ArrayExpression",
           "value": "[\"{\\\"name\\\":\\\"noona-sage\\\",\\\"status\\\":\\\"installed\\\",\\\"category\\\":\\\"core\\\"}\",\"{\\\"name\\\":\\\"noona-bad\\\",\\\"status\\\":\\\"error\\\",\\\"error\\\":\\\"boom\\\"}\"]"
@@ -31112,7 +34957,7 @@
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010143",
+          "id": "astnode100010856",
           "name": "name",
           "type": "Literal",
           "value": "noona-sage"
@@ -31136,7 +34981,7 @@
         "columnno": 34,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010145",
+          "id": "astnode100010858",
           "name": "status",
           "type": "Literal",
           "value": "installed"
@@ -31160,7 +35005,7 @@
         "columnno": 55,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010147",
+          "id": "astnode100010860",
           "name": "category",
           "type": "Literal",
           "value": "core"
@@ -31184,7 +35029,7 @@
         "columnno": 14,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010150",
+          "id": "astnode100010863",
           "name": "name",
           "type": "Literal",
           "value": "noona-bad"
@@ -31208,7 +35053,7 @@
         "columnno": 33,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010152",
+          "id": "astnode100010865",
           "name": "status",
           "type": "Literal",
           "value": "error"
@@ -31232,7 +35077,7 @@
         "columnno": 50,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010154",
+          "id": "astnode100010867",
           "name": "error",
           "type": "Literal",
           "value": "boom"
@@ -31256,7 +35101,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010174",
+          "id": "astnode100010887",
           "name": "warden",
           "type": "ObjectExpression",
           "value": "{\"listServices\":\"\",\"installServices\":\"\"}"
@@ -31282,7 +35127,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010177",
+          "id": "astnode100010890",
           "name": "listServices",
           "type": "ArrowFunctionExpression"
         }
@@ -31306,7 +35151,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010180",
+          "id": "astnode100010893",
           "name": "installServices",
           "type": "ArrowFunctionExpression"
         }
@@ -31330,7 +35175,7 @@
         "columnno": 12,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010190",
+          "id": "astnode100010903",
           "name": "server",
           "type": "Identifier",
           "value": "server"
@@ -31354,7 +35199,7 @@
         "columnno": 20,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010192",
+          "id": "astnode100010905",
           "name": "baseUrl",
           "type": "Identifier",
           "value": "baseUrl"
@@ -31378,7 +35223,7 @@
         "columnno": 47,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010198",
+          "id": "astnode100010911",
           "name": "warden",
           "type": "Identifier",
           "value": "warden"
@@ -31402,7 +35247,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010210",
+          "id": "astnode100010923",
           "name": "response",
           "type": "AwaitExpression",
           "value": ""
@@ -31428,7 +35273,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010220",
+          "id": "astnode100010933",
           "name": "method",
           "type": "Literal",
           "value": "POST"
@@ -31452,7 +35297,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010222",
+          "id": "astnode100010935",
           "name": "headers",
           "type": "ObjectExpression",
           "value": "{\"undefined\":\"application/json\"}"
@@ -31476,7 +35321,7 @@
         "columnno": 19,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010224",
+          "id": "astnode100010937",
           "name": "\"Content-Type\"",
           "type": "Literal",
           "value": "application/json"
@@ -31501,7 +35346,7 @@
         "columnno": 8,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010226",
+          "id": "astnode100010939",
           "name": "body",
           "type": "CallExpression",
           "value": ""
@@ -31525,7 +35370,7 @@
         "columnno": 31,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010232",
+          "id": "astnode100010945",
           "name": "services",
           "type": "ArrayExpression",
           "value": "[]"
@@ -31549,7 +35394,7 @@
         "columnno": 10,
         "path": "/workspace/Noona/services/warden/tests",
         "code": {
-          "id": "astnode100010244",
+          "id": "astnode100010957",
           "name": "payload",
           "type": "AwaitExpression",
           "value": ""

--- a/services/warden/docker/addonDockers.mjs
+++ b/services/warden/docker/addonDockers.mjs
@@ -23,7 +23,7 @@ const rawList = [
     },
     {
         name: 'noona-mongo',
-        image: 'mongo:7',
+        image: 'mongo:8',
         port: 27017,
         internalPort: 27017,
         ports: {


### PR DESCRIPTION
## Summary
- update the noona-mongo addon descriptor to use the mongo:8 image tag
- regenerate the docs bundle so the published metadata reflects the new tag

## Testing
- npm test (services/warden)


------
https://chatgpt.com/codex/tasks/task_e_68dfdcac0694833184f33fb29650323a