### PR TITLE
Add env override support to Warden install flow

### DIFF
--- a/docs/moon-env-config.md
+++ b/docs/moon-env-config.md
@@ -1,0 +1,13 @@
+# Moon Setup Environment Configuration
+
+The Moon setup wizard now surfaces every configurable environment variable per service before installation. When you select one or more services you will see a configuration panel that lists the variables, their defaults, and any warnings associated with them. Read-only fields (for example auto-generated Vault tokens) appear with a lock icon and cannot be modified.
+
+The wizard submits your changes to Sage, which forwards a normalized payload to Warden. Warden merges the overrides into each container's descriptor before the Docker containers are created, ensuring that advanced users can tailor ports, base URLs, or other settings when necessary.
+
+## Usage tips
+
+- Leave the defaults in place unless you have a specific reason to change them. The panel includes a prominent warning to emphasise this.
+- Editable fields include descriptive hints and warnings pulled from the underlying service descriptors.
+- All submitted values are validated server-side. Invalid payloads are rejected with actionable error messages.
+
+This flow is covered by automated tests in `services/sage/tests` and `services/warden/tests`, and the Vue UI rendering the panel lives in `services/moon/src/pages/Setup.vue`.

--- a/services/warden/docker/addonDockers.mjs
+++ b/services/warden/docker/addonDockers.mjs
@@ -2,6 +2,22 @@
 
 const HOST_SERVICE_URL = process.env.HOST_SERVICE_URL || 'http://localhost';
 
+const createEnvField = (key, defaultValue, {
+    label = key,
+    description = null,
+    warning = null,
+    required = true,
+    readOnly = false,
+} = {}) => ({
+    key,
+    label,
+    defaultValue,
+    description,
+    warning,
+    required,
+    readOnly,
+});
+
 const rawList = [
     {
         name: 'noona-redis',
@@ -17,6 +33,13 @@ const rawList = [
             '8001/tcp': {},
         },
         env: ['SERVICE_NAME=noona-redis'],
+        envConfig: [
+            createEnvField('SERVICE_NAME', 'noona-redis', {
+                label: 'Service Name',
+                readOnly: true,
+                description: 'Identifier used when naming the Redis container.',
+            }),
+        ],
         volumes: ['/noona-redis-data:/data'],
         health: 'http://noona-redis:8001/',
         hostServiceUrl: `${HOST_SERVICE_URL}:8001`,
@@ -36,6 +59,21 @@ const rawList = [
             'MONGO_INITDB_ROOT_USERNAME=root',
             'MONGO_INITDB_ROOT_PASSWORD=example',
             'SERVICE_NAME=noona-mongo',
+        ],
+        envConfig: [
+            createEnvField('MONGO_INITDB_ROOT_USERNAME', 'root', {
+                label: 'Mongo Root Username',
+                warning: 'Changing the username requires updating every consumer that connects to Mongo.',
+            }),
+            createEnvField('MONGO_INITDB_ROOT_PASSWORD', 'example', {
+                label: 'Mongo Root Password',
+                warning: 'Use a strong password and store it securely. Changing it requires updating dependent services.',
+            }),
+            createEnvField('SERVICE_NAME', 'noona-mongo', {
+                label: 'Service Name',
+                readOnly: true,
+                description: 'Identifier used when naming the Mongo container.',
+            }),
         ],
         volumes: ['/noona-mongo-data:/data/db'],
         health: null, // Mongo doesn't expose an HTTP endpoint

--- a/services/warden/docker/noonaDockers.mjs
+++ b/services/warden/docker/noonaDockers.mjs
@@ -18,6 +18,22 @@ const rawList = [
 
 const tokensByService = buildVaultTokenRegistry(rawList);
 
+const createEnvField = (key, defaultValue, {
+    label = key,
+    description = null,
+    warning = null,
+    required = true,
+    readOnly = false,
+} = {}) => ({
+    key,
+    label,
+    defaultValue,
+    description,
+    warning,
+    required,
+    readOnly,
+});
+
 const serviceDefs = rawList.map(name => {
     const portMap = {
         'noona-sage': 3004,
@@ -36,17 +52,54 @@ const serviceDefs = rawList.map(name => {
         `SERVICE_NAME=${name}`
     ];
 
+    const envConfig = [
+        createEnvField('DEBUG', DEBUG, {
+            label: 'Debug Logging',
+            description: 'Controls verbose logging output inside the container.',
+            warning: 'Leave as "false" unless diagnosing issues to avoid noisy logs.',
+        }),
+        createEnvField('SERVICE_NAME', name, {
+            label: 'Service Name',
+            readOnly: true,
+            description: 'Identifier used for the container and internal routing.',
+        }),
+    ];
+
     if (token) {
         env.push(`VAULT_API_TOKEN=${token}`);
+        envConfig.push(
+            createEnvField('VAULT_API_TOKEN', token, {
+                label: 'Vault API Token',
+                readOnly: true,
+                description: 'Auto-generated token used for secure communication with Vault.',
+            }),
+        );
     }
 
     if (name === 'noona-sage') {
         env.push(`WARDEN_BASE_URL=${DOCKER_WARDEN_URL}`);
+        envConfig.push(
+            createEnvField('WARDEN_BASE_URL', DOCKER_WARDEN_URL, {
+                label: 'Warden Base URL',
+                warning: 'Adjust only if Warden is reachable at a custom URL within the Docker network.',
+            }),
+        );
     }
 
     if (name === 'noona-vault') {
         const tokenMapString = stringifyTokenMap(tokensByService);
         env.push(`PORT=3005`, `VAULT_TOKEN_MAP=${tokenMapString}`);
+        envConfig.push(
+            createEnvField('PORT', '3005', {
+                label: 'Vault Port',
+                warning: 'Changing the port requires updating every service that talks to Vault.',
+            }),
+            createEnvField('VAULT_TOKEN_MAP', tokenMapString, {
+                label: 'Vault Token Map',
+                readOnly: true,
+                description: 'Serialized lookup table allowing other services to authenticate with Vault.',
+            }),
+        );
     }
 
     const hostServiceUrl = portMap[name]
@@ -75,6 +128,7 @@ const serviceDefs = rawList.map(name => {
         port: portMap[name],
         internalPort,
         env,
+        envConfig,
         hostServiceUrl,
         health: healthChecks
     };

--- a/services/warden/tests/wardenServer.test.mjs
+++ b/services/warden/tests/wardenServer.test.mjs
@@ -112,7 +112,10 @@ test('POST /api/services/install returns results and status code for errors', as
     const response = await fetch(`${baseUrl}/api/services/install`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ services: ['noona-sage', 'noona-bad'] }),
+        body: JSON.stringify({ services: [
+            { name: 'noona-sage', env: { DEBUG: 'true' } },
+            { name: 'noona-bad' },
+        ] }),
     });
 
     assert.equal(response.status, 207);
@@ -122,7 +125,10 @@ test('POST /api/services/install returns results and status code for errors', as
             { name: 'noona-bad', status: 'error', error: 'boom' },
         ],
     });
-    assert.deepEqual(installCalls, [['noona-sage', 'noona-bad']]);
+    assert.deepEqual(installCalls, [[
+        { name: 'noona-sage', env: { DEBUG: 'true' } },
+        { name: 'noona-bad' },
+    ]]);
 });
 
 test('POST /api/services/install validates payload', async (t) => {


### PR DESCRIPTION
## Summary
- expose descriptive env metadata on every Warden-managed service so setup clients can surface defaults and warnings
- allow Sage and Warden to normalize per-service env overrides before launching containers
- expand Moon's setup wizard to collect env inputs and document the new configuration workflow

## Testing
- node --test services/sage/tests/sageApp.test.mjs
- node --test services/warden/tests/wardenCore.test.mjs
- node --test services/warden/tests/wardenServer.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68dfdcaa6b8c8331936dc4ecf7d2320a