### PR TITLE
Add portal service scaffold and shared integrations

### DIFF
--- a/services/portal/initmain.mjs
+++ b/services/portal/initmain.mjs
@@ -1,0 +1,125 @@
+// services/portal/initmain.mjs
+
+import { errMSG, log } from '../../utilities/etc/logger.mjs';
+import { safeLoadPortalConfig } from './shared/config.mjs';
+import createDiscordClient from './shared/discordClient.mjs';
+import createKavitaClient from './shared/kavitaClient.mjs';
+import createVaultClient from './shared/vaultClient.mjs';
+import createOnboardingStore from './shared/onboardingStore.mjs';
+import { startPortalServer } from './shared/portalApp.mjs';
+
+const runtime = {
+    config: null,
+    discord: null,
+    kavita: null,
+    vault: null,
+    onboardingStore: null,
+    server: null,
+    closeServer: null,
+};
+
+export const startPortal = async (overrides = {}) => {
+    const config = safeLoadPortalConfig(overrides.env ?? {});
+    runtime.config = config;
+
+    const discord = createDiscordClient({
+        token: config.discord.token,
+        guildId: config.discord.guildId,
+        defaultRoleId: config.discord.defaultRoleId,
+    });
+    runtime.discord = discord;
+
+    const kavita = createKavitaClient({
+        baseUrl: config.kavita.baseUrl,
+        apiKey: config.kavita.apiKey,
+        timeoutMs: config.http.timeoutMs,
+    });
+    runtime.kavita = kavita;
+
+    const vault = createVaultClient({
+        baseUrl: config.vault.baseUrl,
+        token: config.vault.token,
+        timeoutMs: config.http.timeoutMs,
+    });
+    runtime.vault = vault;
+
+    const onboardingStore = createOnboardingStore({
+        namespace: config.redis.namespace,
+        ttlSeconds: config.redis.ttlSeconds,
+    });
+    runtime.onboardingStore = onboardingStore;
+
+    await discord.login();
+
+    const { server, close } = await startPortalServer({
+        config,
+        discord,
+        kavita,
+        vault,
+        onboardingStore,
+    });
+
+    runtime.server = server;
+    runtime.closeServer = close;
+
+    log('[Portal] Service started successfully.');
+
+    return runtime;
+};
+
+export const stopPortal = async () => {
+    if (runtime.closeServer) {
+        await runtime.closeServer();
+    }
+
+    if (runtime.discord) {
+        runtime.discord.destroy();
+    }
+
+    runtime.server = null;
+    runtime.closeServer = null;
+    runtime.discord = null;
+    runtime.kavita = null;
+    runtime.vault = null;
+    runtime.onboardingStore = null;
+    runtime.config = null;
+
+    log('[Portal] Shutdown complete.');
+};
+
+const handleSignal = signal => {
+    log(`[Portal] Received ${signal}, shutting down.`);
+    stopPortal()
+        .then(() => process.exit(0))
+        .catch(error => {
+            errMSG(`[Portal] Shutdown error: ${error.message}`);
+            process.exit(1);
+        });
+};
+
+const isDirectRun = (() => {
+    if (!process.argv[1]) {
+        return false;
+    }
+
+    try {
+        const entryUrl = new URL(process.argv[1], 'file:');
+        return entryUrl.href === import.meta.url;
+    } catch (error) {
+        return false;
+    }
+})();
+
+if (isDirectRun) {
+    startPortal().catch(error => {
+        errMSG(`[Portal] Failed to start: ${error.message}`);
+        process.exit(1);
+    });
+
+    process.on('SIGINT', handleSignal);
+    process.on('SIGTERM', handleSignal);
+
+    setInterval(() => process.stdout.write('.'), 60000);
+}
+
+export default startPortal;

--- a/services/portal/package.json
+++ b/services/portal/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "noona-portal",
+  "version": "2.0.0",
+  "description": "Noona Portal service responsible for coordinating Discord onboarding with Kavita and Vault services.",
+  "main": "initmain.mjs",
+  "type": "module",
+  "scripts": {
+    "start": "node initmain.mjs",
+    "dev": "nodemon initmain.mjs",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "discord.js": "^14.16.3",
+    "dotenv": "^16.4.5",
+    "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.7"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/The-Noona-Project/Noona"
+  }
+}

--- a/services/portal/shared/config.mjs
+++ b/services/portal/shared/config.mjs
@@ -1,0 +1,132 @@
+// services/portal/shared/config.mjs
+
+import dotenv from 'dotenv';
+import { errMSG, log } from '../../../utilities/etc/logger.mjs';
+
+const DEFAULT_ENV_PATH = process.env.PORTAL_ENV_FILE || process.env.ENV_FILE || undefined;
+let envLoaded = false;
+
+const REQUIRED_STRINGS = [
+    'DISCORD_BOT_TOKEN',
+    'DISCORD_CLIENT_ID',
+    'DISCORD_GUILD_ID',
+    'KAVITA_BASE_URL',
+    'KAVITA_API_KEY',
+    'VAULT_BASE_URL',
+    'VAULT_ACCESS_TOKEN',
+];
+
+const numberOrDefault = (value, fallback) => {
+    if (value == null || value === '') {
+        return fallback;
+    }
+
+    const parsed = Number.parseInt(String(value), 10);
+    return Number.isNaN(parsed) ? fallback : parsed;
+};
+
+const normalizeString = value => {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+};
+
+const normalizeUrl = (value) => {
+    const normalized = normalizeString(value);
+    if (!normalized) {
+        return null;
+    }
+
+    try {
+        return new URL(normalized).toString();
+    } catch (error) {
+        return null;
+    }
+};
+
+const resolveEnv = (overrides = {}) => ({
+    ...process.env,
+    ...overrides,
+});
+
+const collectMissing = (env) => {
+    const missing = [];
+
+    for (const key of REQUIRED_STRINGS) {
+        if (!normalizeString(env[key])) {
+            missing.push(key);
+        }
+    }
+
+    return missing;
+};
+
+export const loadPortalConfig = (overrides = {}) => {
+    if (!envLoaded) {
+        dotenv.config({ path: DEFAULT_ENV_PATH });
+        envLoaded = true;
+    }
+
+    const env = resolveEnv(overrides);
+
+    const missing = collectMissing(env);
+    if (missing.length > 0) {
+        const error = new Error(`Missing required environment variables: ${missing.join(', ')}`);
+        error.code = 'PORTAL_ENV_VALIDATION_ERROR';
+        throw error;
+    }
+
+    const discordRole = normalizeString(env.DISCORD_GUILD_ROLE_ID) || normalizeString(env.DISCORD_DEFAULT_ROLE_ID) || null;
+
+    const config = {
+        serviceName: normalizeString(env.SERVICE_NAME) || 'noona-portal',
+        port: numberOrDefault(env.PORTAL_PORT ?? env.API_PORT, 3003),
+        discord: {
+            token: env.DISCORD_BOT_TOKEN,
+            clientId: env.DISCORD_CLIENT_ID,
+            guildId: env.DISCORD_GUILD_ID,
+            defaultRoleId: discordRole,
+        },
+        kavita: {
+            baseUrl: normalizeUrl(env.KAVITA_BASE_URL),
+            apiKey: env.KAVITA_API_KEY,
+        },
+        vault: {
+            baseUrl: normalizeUrl(env.VAULT_BASE_URL),
+            token: env.VAULT_ACCESS_TOKEN,
+        },
+        redis: {
+            namespace: normalizeString(env.PORTAL_REDIS_NAMESPACE) || 'portal:onboarding',
+            ttlSeconds: numberOrDefault(env.PORTAL_TOKEN_TTL, 900),
+        },
+        http: {
+            timeoutMs: numberOrDefault(env.PORTAL_HTTP_TIMEOUT, 10000),
+        },
+    };
+
+    if (!config.kavita.baseUrl) {
+        throw new Error('KAVITA_BASE_URL must be a valid absolute URL.');
+    }
+
+    if (!config.vault.baseUrl) {
+        throw new Error('VAULT_BASE_URL must be a valid absolute URL.');
+    }
+
+    log(`[${config.serviceName}] Loaded configuration for Discord guild ${config.discord.guildId}`);
+
+    return Object.freeze(config);
+};
+
+export const safeLoadPortalConfig = (overrides = {}) => {
+    try {
+        return loadPortalConfig(overrides);
+    } catch (error) {
+        errMSG(`[Portal Config] Failed to load configuration: ${error.message}`);
+        throw error;
+    }
+};
+
+export default loadPortalConfig;

--- a/services/portal/shared/discordClient.mjs
+++ b/services/portal/shared/discordClient.mjs
@@ -1,0 +1,116 @@
+// services/portal/shared/discordClient.mjs
+
+import {
+    Client,
+    Events,
+    GatewayIntentBits,
+    Partials,
+} from 'discord.js';
+import { errMSG, log } from '../../../utilities/etc/logger.mjs';
+
+const DEFAULT_INTENTS = [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMembers,
+];
+
+const DEFAULT_PARTIALS = [
+    Partials.GuildMember,
+    Partials.User,
+];
+
+export const createDiscordClient = ({
+    token,
+    guildId,
+    defaultRoleId = null,
+    intents = DEFAULT_INTENTS,
+    partials = DEFAULT_PARTIALS,
+} = {}) => {
+    if (!token) {
+        throw new Error('Discord token is required to initialise the Portal Discord client.');
+    }
+
+    if (!guildId) {
+        throw new Error('Discord guild id is required to initialise the Portal Discord client.');
+    }
+
+    const client = new Client({ intents, partials });
+
+    let readyResolve;
+    let readyReject;
+    const ready = new Promise((resolve, reject) => {
+        readyResolve = resolve;
+        readyReject = reject;
+    });
+
+    client.once(Events.ClientReady, bot => {
+        log(`[Portal/Discord] Logged in as ${bot.user.tag}`);
+        readyResolve(bot);
+    });
+
+    client.on('error', error => {
+        errMSG(`[Portal/Discord] Client error: ${error.message}`);
+    });
+
+    client.on('shardError', error => {
+        errMSG(`[Portal/Discord] Shard error: ${error.message}`);
+    });
+
+    const login = async () => {
+        try {
+            await client.login(token);
+            await ready;
+        } catch (error) {
+            errMSG(`[Portal/Discord] Failed to login: ${error.message}`);
+            readyReject?.(error);
+            throw error;
+        }
+
+        return client;
+    };
+
+    const fetchGuild = async () => {
+        await ready;
+        return client.guilds.fetch(guildId);
+    };
+
+    const fetchMember = async (memberId) => {
+        const guild = await fetchGuild();
+        return guild.members.fetch(memberId);
+    };
+
+    const assignDefaultRole = async (memberId) => {
+        if (!defaultRoleId) {
+            return null;
+        }
+
+        try {
+            const member = await fetchMember(memberId);
+            if (member.roles.cache.has(defaultRoleId)) {
+                return member;
+            }
+
+            await member.roles.add(defaultRoleId);
+            log(`[Portal/Discord] Added default role ${defaultRoleId} to member ${member.user.tag}`);
+            return member;
+        } catch (error) {
+            errMSG(`[Portal/Discord] Failed to assign default role to ${memberId}: ${error.message}`);
+            throw error;
+        }
+    };
+
+    const destroy = () => {
+        client.destroy();
+    };
+
+    return {
+        client,
+        login,
+        destroy,
+        fetchGuild,
+        fetchMember,
+        assignDefaultRole,
+        waitUntilReady: () => ready,
+    };
+};
+
+export default createDiscordClient;

--- a/services/portal/shared/kavitaClient.mjs
+++ b/services/portal/shared/kavitaClient.mjs
@@ -1,0 +1,150 @@
+// services/portal/shared/kavitaClient.mjs
+
+import { errMSG, log } from '../../../utilities/etc/logger.mjs';
+
+const DEFAULT_TIMEOUT = 10000;
+
+const serializeBody = body => (body == null ? undefined : JSON.stringify(body));
+
+const parseResponseBody = async response => {
+    if (response.status === 204) {
+        return null;
+    }
+
+    const text = await response.text();
+    if (!text) {
+        return null;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch (error) {
+        return text;
+    }
+};
+
+const createAbortController = (timeoutMs = DEFAULT_TIMEOUT) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const cleanup = () => clearTimeout(timer);
+    return { controller, cleanup };
+};
+
+export const createKavitaClient = ({
+    baseUrl,
+    apiKey,
+    timeoutMs = DEFAULT_TIMEOUT,
+    fetchImpl = fetch,
+} = {}) => {
+    if (!baseUrl) {
+        throw new Error('Kavita base URL is required.');
+    }
+
+    if (!apiKey) {
+        throw new Error('Kavita API key is required.');
+    }
+
+    const request = async (path, { method = 'GET', body, headers = {}, query } = {}) => {
+        const url = new URL(path, baseUrl);
+        if (query && typeof query === 'object') {
+            for (const [key, value] of Object.entries(query)) {
+                if (value == null) {
+                    continue;
+                }
+                url.searchParams.set(key, value);
+            }
+        }
+
+        const { controller, cleanup } = createAbortController(timeoutMs);
+
+        try {
+            const response = await fetchImpl(url.toString(), {
+                method,
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    'X-Api-Key': apiKey,
+                    ...headers,
+                },
+                body: serializeBody(body),
+                signal: controller.signal,
+            });
+
+            const payload = await parseResponseBody(response);
+
+            if (!response.ok) {
+                const error = new Error(`Kavita request failed with status ${response.status}`);
+                error.status = response.status;
+                error.body = payload;
+                throw error;
+            }
+
+            return payload;
+        } catch (error) {
+            if (error.name === 'AbortError') {
+                errMSG('[Portal/Kavita] Request timed out.');
+            } else {
+                errMSG(`[Portal/Kavita] Request error: ${error.message}`);
+            }
+            throw error;
+        } finally {
+            cleanup();
+        }
+    };
+
+    const createOrUpdateUser = async ({ username, email, password, displayName, libraries = [] }) => {
+        if (!username || !email) {
+            throw new Error('Username and email are required to create or update a Kavita user.');
+        }
+
+        const payload = {
+            username,
+            email,
+            password: password ?? undefined,
+            displayName: displayName ?? username,
+            libraries,
+        };
+
+        const response = await request('/api/portal/users', {
+            method: 'POST',
+            body: payload,
+        });
+
+        log(`[Portal/Kavita] Ensured user ${username}.`);
+        return response;
+    };
+
+    const fetchLibraries = async () => {
+        const libraries = await request('/api/library');
+        return Array.isArray(libraries) ? libraries : [];
+    };
+
+    const fetchUser = async (username) => {
+        if (!username) {
+            throw new Error('Username is required when fetching Kavita user.');
+        }
+
+        return request(`/api/portal/users/${encodeURIComponent(username)}`);
+    };
+
+    const assignLibraries = async (username, libraries = []) => {
+        if (!username) {
+            throw new Error('Username is required when assigning libraries in Kavita.');
+        }
+
+        return request(`/api/portal/users/${encodeURIComponent(username)}/libraries`, {
+            method: 'PUT',
+            body: { libraries },
+        });
+    };
+
+    return {
+        request,
+        createOrUpdateUser,
+        fetchLibraries,
+        fetchUser,
+        assignLibraries,
+    };
+};
+
+export default createKavitaClient;

--- a/services/portal/shared/onboardingStore.mjs
+++ b/services/portal/shared/onboardingStore.mjs
@@ -1,0 +1,79 @@
+// services/portal/shared/onboardingStore.mjs
+
+import crypto from 'node:crypto';
+import redis from '../../../utilities/database/redis/redisClient.mjs';
+import { errMSG, log } from '../../../utilities/etc/logger.mjs';
+
+const buildKey = (namespace, id) => `${namespace}:${id}`;
+
+export const createOnboardingStore = ({
+    namespace = 'portal:onboarding',
+    ttlSeconds = 900,
+} = {}) => {
+    const generateToken = () => crypto.randomUUID();
+
+    const setToken = async (discordId, payload = {}) => {
+        if (!discordId) {
+            throw new Error('Discord id is required when creating onboarding token.');
+        }
+
+        const token = payload?.token || generateToken();
+        const record = { ...payload, token, discordId, createdAt: new Date().toISOString() };
+        const key = buildKey(namespace, token);
+
+        try {
+            await redis.set(key, JSON.stringify(record), 'EX', ttlSeconds);
+            log(`[Portal/Onboarding] Stored onboarding token for ${discordId}.`);
+            return record;
+        } catch (error) {
+            errMSG(`[Portal/Onboarding] Failed to store token for ${discordId}: ${error.message}`);
+            throw error;
+        }
+    };
+
+    const getToken = async (token) => {
+        if (!token) {
+            return null;
+        }
+
+        const key = buildKey(namespace, token);
+        try {
+            const raw = await redis.get(key);
+            return raw ? JSON.parse(raw) : null;
+        } catch (error) {
+            errMSG(`[Portal/Onboarding] Failed to load token ${token}: ${error.message}`);
+            throw error;
+        }
+    };
+
+    const consumeToken = async (token) => {
+        if (!token) {
+            return null;
+        }
+
+        const record = await getToken(token);
+        if (!record) {
+            return null;
+        }
+
+        try {
+            await redis.del(buildKey(namespace, token));
+            log(`[Portal/Onboarding] Consumed onboarding token ${token}.`);
+        } catch (error) {
+            errMSG(`[Portal/Onboarding] Failed to consume token ${token}: ${error.message}`);
+            throw error;
+        }
+
+        return record;
+    };
+
+    return {
+        namespace,
+        ttlSeconds,
+        setToken,
+        getToken,
+        consumeToken,
+    };
+};
+
+export default createOnboardingStore;

--- a/services/portal/shared/portalApp.mjs
+++ b/services/portal/shared/portalApp.mjs
@@ -1,0 +1,142 @@
+// services/portal/shared/portalApp.mjs
+
+import express from 'express';
+import { errMSG, log } from '../../../utilities/etc/logger.mjs';
+
+const buildError = (status, message, details) => ({ status, message, details });
+
+const normalizeError = (error, fallbackStatus = 500) => {
+    if (!error) {
+        return buildError(fallbackStatus, 'Unknown error.');
+    }
+
+    if (typeof error === 'string') {
+        return buildError(fallbackStatus, error);
+    }
+
+    const status = error.status || fallbackStatus;
+    const message = error.message || 'Unexpected error.';
+
+    return buildError(status, message, error.body ?? error.details ?? null);
+};
+
+export const createPortalApp = ({
+    config,
+    discord,
+    kavita,
+    vault,
+    onboardingStore,
+} = {}) => {
+    if (!config) {
+        throw new Error('Portal configuration is required.');
+    }
+
+    const app = express();
+    app.disable('x-powered-by');
+    app.use(express.json());
+
+    app.get('/health', (_req, res) => {
+        res.json({
+            status: 'ok',
+            service: config.serviceName,
+            guildId: config.discord.guildId,
+            version: config.version ?? '2.0.0',
+        });
+    });
+
+    app.post('/api/portal/onboard', async (req, res) => {
+        const { discordId, email, username, password, displayName, libraries = [] } = req.body ?? {};
+
+        if (!discordId || !email || !username) {
+            res.status(400).json({ error: 'discordId, email and username are required.' });
+            return;
+        }
+
+        try {
+            const onboardingToken = await onboardingStore?.setToken(discordId, {
+                email,
+                username,
+                libraries,
+            });
+
+            await kavita?.createOrUpdateUser({ username, email, password, displayName, libraries });
+
+            if (vault) {
+                await vault.storePortalCredential(discordId, {
+                    username,
+                    email,
+                    libraries,
+                    issuedAt: new Date().toISOString(),
+                });
+            }
+
+            if (discord) {
+                await discord.assignDefaultRole(discordId).catch(error => {
+                    errMSG(`[Portal] Failed to assign default Discord role: ${error.message}`);
+                });
+            }
+
+            res.status(201).json({ token: onboardingToken?.token });
+        } catch (error) {
+            const normalised = normalizeError(error);
+            errMSG(`[Portal] Failed to onboard member ${discordId}: ${normalised.message}`);
+            res.status(normalised.status).json({ error: normalised.message, details: normalised.details });
+        }
+    });
+
+    app.post('/api/portal/tokens/consume', async (req, res) => {
+        const { token } = req.body ?? {};
+        if (!token) {
+            res.status(400).json({ error: 'token is required.' });
+            return;
+        }
+
+        try {
+            const record = await onboardingStore?.consumeToken(token);
+            if (!record) {
+                res.status(404).json({ error: 'Token not found or expired.' });
+                return;
+            }
+
+            res.json({ success: true, record });
+        } catch (error) {
+            const normalised = normalizeError(error);
+            errMSG(`[Portal] Failed to consume token ${token}: ${normalised.message}`);
+            res.status(normalised.status).json({ error: normalised.message, details: normalised.details });
+        }
+    });
+
+    app.use((err, _req, res, _next) => {
+        const normalised = normalizeError(err);
+        errMSG(`[Portal] Unhandled error: ${normalised.message}`);
+        res.status(normalised.status).json({ error: normalised.message, details: normalised.details });
+    });
+
+    return app;
+};
+
+export const startPortalServer = async ({ config, discord, kavita, vault, onboardingStore } = {}) => {
+    const app = createPortalApp({ config, discord, kavita, vault, onboardingStore });
+
+    const server = app.listen(config.port, () => {
+        log(`[Portal] Service listening on port ${config.port}`);
+    });
+
+    const close = () => new Promise((resolve, reject) => {
+        server.close(err => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve();
+            }
+        });
+    });
+
+    return {
+        app,
+        server,
+        close,
+    };
+};
+
+export default startPortalServer;

--- a/services/portal/shared/vaultClient.mjs
+++ b/services/portal/shared/vaultClient.mjs
@@ -1,0 +1,118 @@
+// services/portal/shared/vaultClient.mjs
+
+import { errMSG, log } from '../../../utilities/etc/logger.mjs';
+
+const DEFAULT_TIMEOUT = 10000;
+
+const buildUrl = (baseUrl, path) => new URL(path, baseUrl).toString();
+
+const createAbortController = timeoutMs => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const cleanup = () => clearTimeout(timer);
+    return { controller, cleanup };
+};
+
+const parseResponse = async response => {
+    if (response.status === 204) {
+        return null;
+    }
+
+    const text = await response.text();
+    if (!text) {
+        return null;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch (error) {
+        return text;
+    }
+};
+
+export const createVaultClient = ({
+    baseUrl,
+    token,
+    timeoutMs = DEFAULT_TIMEOUT,
+    fetchImpl = fetch,
+} = {}) => {
+    if (!baseUrl) {
+        throw new Error('Vault base URL is required.');
+    }
+
+    if (!token) {
+        throw new Error('Vault access token is required.');
+    }
+
+    const request = async (path, { method = 'GET', body, headers = {} } = {}) => {
+        const url = buildUrl(baseUrl, path);
+        const { controller, cleanup } = createAbortController(timeoutMs);
+
+        try {
+            const response = await fetchImpl(url, {
+                method,
+                headers: {
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${token}`,
+                    ...headers,
+                },
+                body: body == null ? undefined : JSON.stringify(body),
+                signal: controller.signal,
+            });
+
+            const payload = await parseResponse(response);
+
+            if (!response.ok) {
+                const error = new Error(`Vault request failed with status ${response.status}`);
+                error.status = response.status;
+                error.body = payload;
+                throw error;
+            }
+
+            return payload;
+        } catch (error) {
+            if (error.name === 'AbortError') {
+                errMSG('[Portal/Vault] Request timed out.');
+            } else {
+                errMSG(`[Portal/Vault] Request error: ${error.message}`);
+            }
+            throw error;
+        } finally {
+            cleanup();
+        }
+    };
+
+    const writeSecret = async (path, secret) => {
+        const payload = await request(`/api/secrets/${encodeURIComponent(path)}`, {
+            method: 'PUT',
+            body: { secret },
+        });
+        log(`[Portal/Vault] Wrote secret for ${path}.`);
+        return payload;
+    };
+
+    const readSecret = async path => request(`/api/secrets/${encodeURIComponent(path)}`);
+
+    const deleteSecret = async path => request(`/api/secrets/${encodeURIComponent(path)}`, {
+        method: 'DELETE',
+    });
+
+    const storePortalCredential = async (discordId, credential) => {
+        if (!discordId) {
+            throw new Error('Discord id is required when storing portal credential.');
+        }
+
+        return writeSecret(`portal/${discordId}`, credential);
+    };
+
+    return {
+        request,
+        writeSecret,
+        readSecret,
+        deleteSecret,
+        storePortalCredential,
+    };
+};
+
+export default createVaultClient;


### PR DESCRIPTION
## Summary
- add a new `services/portal` package with an init entrypoint wired to the Docker CMD
- implement environment validation plus Discord, Kavita, Vault, and onboarding helpers under `shared/`
- expose an Express portal API that uses the shared Redis client and fetch-based integrations

## Testing
- npm install --prefix services/portal --no-package-lock

------
https://chatgpt.com/codex/tasks/task_e_68dfe52ecc008331a253b108909123c0