### PR TITLE
Include portal service in deployment script

### DIFF
--- a/deployment/deploy.mjs
+++ b/deployment/deploy.mjs
@@ -10,7 +10,7 @@ const execAsync = promisify(exec);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = resolve(__dirname, '..');
 const DOCKERHUB_USER = 'captainpax';
-const SERVICES = ['moon', 'warden', 'raven', 'sage', 'vault'];
+const SERVICES = ['moon', 'warden', 'raven', 'sage', 'vault', 'portal'];
 const NETWORK_NAME = 'noona-network';
 
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });


### PR DESCRIPTION
## Summary
- add the portal service to the deployment script's service list so it is available for Docker actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe7ab0a1c8331bfbb1011a094f4ee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment tool now includes “Portal” as a selectable service. You can start, build, and push this service using existing commands and the interactive menu. The service list expands from five to six options, with the new entry supported by the current start workflow.
* **Chores**
  * Updated service catalog to include the new option without altering behavior for existing services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->