### PR TITLE
Add missing chalk and ioredis dependencies to portal service

### DIFF
--- a/services/portal/package.json
+++ b/services/portal/package.json
@@ -10,9 +10,11 @@
     "test": "node --test"
   },
   "dependencies": {
+    "chalk": "^5.4.1",
     "discord.js": "^14.16.3",
     "dotenv": "^16.4.5",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "ioredis": "^5.6.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.7"


### PR DESCRIPTION
## Summary
- add chalk and ioredis to the portal service's runtime dependencies so shared utilities resolve properly

## Testing
- npm test --prefix services/portal

------
https://chatgpt.com/codex/tasks/task_e_68e06d890e3c8331b7666d444a287a3c