### PR TITLE
Stop starting Redis during minimal Warden boot

### DIFF
--- a/services/warden/shared/wardenCore.mjs
+++ b/services/warden/shared/wardenCore.mjs
@@ -761,11 +761,9 @@ export function createWarden(options = {}) {
     };
 
     api.bootMinimal = async function bootMinimal() {
-        const redis = services.addon['noona-redis'];
         const moon = services.core['noona-moon'];
         const sage = services.core['noona-sage'];
 
-        await api.startService(redis, 'http://noona-redis:8001/');
         await api.startService(sage, 'http://noona-sage:3004/health');
         await api.startService(moon, 'http://noona-moon:3000/');
     };
@@ -819,7 +817,7 @@ export function createWarden(options = {}) {
             logger.log('[Warden] 💥 DEBUG=super — launching full stack in superBootOrder...');
             await api.bootFull();
         } else {
-            logger.log('[Warden] 🧪 Minimal mode — launching redis, sage, moon only');
+            logger.log('[Warden] 🧪 Minimal mode — launching sage and moon only');
             await api.bootMinimal();
         }
 

--- a/services/warden/tests/wardenCore.test.mjs
+++ b/services/warden/tests/wardenCore.test.mjs
@@ -638,7 +638,7 @@ test('init ensures network, attaches, and runs minimal boot sequence by default'
     assert.ok(events.includes('ensure'));
     assert.ok(events.includes('attach'));
     assert.ok(events.some(event => event.includes('Minimal mode')));
-    assert.ok(events.includes('start:noona-redis:http://noona-redis:8001/'));
+    assert.ok(!events.includes('start:noona-redis:http://noona-redis:8001/'));
     assert.ok(events.includes('start:noona-sage:http://noona-sage:3004/health'));
     assert.ok(events.includes('start:noona-moon:http://noona-moon:3000/'));
     assert.ok(events.includes('✅ Warden is ready.'));


### PR DESCRIPTION
## Summary
- update the minimal boot sequence to launch only Sage and Moon
- adjust the minimal-mode log message to reflect the reduced service set
- update the Warden core tests to expect Redis to be skipped in minimal mode

## Testing
- npm test (services/warden)


------
https://chatgpt.com/codex/tasks/task_e_68e06f7bc30483318753c0d7aca91ead