### PR TITLE
Lock required services in Warden and Moon setup wizard

### DIFF
--- a/services/moon/package.json
+++ b/services/moon/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
@@ -16,7 +17,10 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.0",
+    "@vue/test-utils": "^2.4.6",
     "connect-history-api-fallback": "^2.0.0",
-    "vite": "^7.0.0"
+    "jsdom": "^25.0.1",
+    "vite": "^7.0.0",
+    "vitest": "^2.1.4"
   }
 }

--- a/services/moon/src/components/SetupListItem.vue
+++ b/services/moon/src/components/SetupListItem.vue
@@ -11,6 +11,7 @@ interface ServiceOption {
   hostServiceUrl?: string | null;
   port?: number | null;
   health?: string | null;
+  required?: boolean;
 }
 
 const props = defineProps<{
@@ -34,8 +35,10 @@ const categoryLabel = computed(() => {
     .replace(/\b\w/g, (char) => char.toUpperCase());
 });
 
+const isLocked = computed(() => props.service.required === true);
+
 const handleToggle = () => {
-  if (props.disabled) return;
+  if (props.disabled || isLocked.value) return;
   emit('toggle', props.service.name);
 };
 
@@ -62,12 +65,14 @@ const descriptionText = computed(() => {
     :class="{
       'setup-list-item--selected': selected,
       'setup-list-item--disabled': disabled,
+      'setup-list-item--locked': isLocked,
     }"
     role="checkbox"
     :aria-checked="selected"
-    :aria-disabled="disabled"
+    :aria-disabled="disabled || isLocked"
+    :aria-required="isLocked"
     :tabindex="disabled ? -1 : 0"
-    :ripple="!disabled"
+    :ripple="!disabled && !isLocked"
     @click="handleToggle"
     @keydown.enter.prevent="handleToggle"
     @keydown.space.prevent="handleToggle"
@@ -75,7 +80,7 @@ const descriptionText = computed(() => {
     <template #prepend>
       <v-checkbox-btn
         :model-value="selected"
-        :disabled="disabled"
+        :disabled="disabled || isLocked"
         color="primary"
         class="setup-list-item__checkbox"
         @click.stop="handleToggle"
@@ -94,6 +99,16 @@ const descriptionText = computed(() => {
           class="setup-list-item__chip text-uppercase font-weight-bold"
         >
           {{ categoryLabel }}
+        </v-chip>
+        <v-chip
+          v-if="isLocked"
+          color="error"
+          size="x-small"
+          variant="tonal"
+          class="setup-list-item__chip setup-list-item__chip--required text-uppercase font-weight-bold"
+        >
+          <v-icon icon="mdi-lock" size="small" class="mr-1" />
+          Required
         </v-chip>
       </div>
 
@@ -158,6 +173,10 @@ const descriptionText = computed(() => {
   cursor: not-allowed;
 }
 
+.setup-list-item--locked {
+  cursor: not-allowed;
+}
+
 .setup-list-item__checkbox {
   margin-inline-end: 12px;
 }
@@ -180,6 +199,12 @@ const descriptionText = computed(() => {
 
 .setup-list-item__chip {
   letter-spacing: 0.08em;
+}
+
+.setup-list-item__chip--required {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .setup-list-item__description {

--- a/services/moon/src/components/__tests__/SetupListItem.test.ts
+++ b/services/moon/src/components/__tests__/SetupListItem.test.ts
@@ -1,0 +1,58 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import SetupListItem from '../SetupListItem.vue';
+
+const stubs = {
+  'v-list-item': {
+    template:
+      '<div data-testid="item" @click="$emit(\'click\', $event)"><slot name="prepend"></slot><slot></slot></div>',
+  },
+  'v-checkbox-btn': {
+    props: ['modelValue', 'disabled'],
+    template:
+      '<input data-testid="checkbox" type="checkbox" :checked="modelValue" :disabled="disabled" @click.stop="$emit(\'click\', $event)" />',
+  },
+  'v-chip': {
+    template: '<span class="chip"><slot /></span>',
+  },
+  'v-icon': {
+    template: '<span class="icon"><slot /></span>',
+  },
+  'v-divider': {
+    template: '<hr />',
+  },
+};
+
+describe('SetupListItem', () => {
+  it('emits toggle when the item is clicked', async () => {
+    const wrapper = mount(SetupListItem, {
+      props: {
+        service: { name: 'noona-sage', category: 'core' },
+        selected: false,
+      },
+      global: { stubs },
+    });
+
+    await wrapper.find('[data-testid="item"]').trigger('click');
+    const events = wrapper.emitted('toggle');
+    expect(events).toBeTruthy();
+    expect(events?.[0]).toEqual(['noona-sage']);
+  });
+
+  it('prevents toggling when the service is required', async () => {
+    const wrapper = mount(SetupListItem, {
+      props: {
+        service: { name: 'noona-vault', category: 'core', required: true },
+        selected: true,
+      },
+      global: { stubs },
+    });
+
+    await wrapper.find('[data-testid="item"]').trigger('click');
+    expect(wrapper.emitted('toggle')).toBeUndefined();
+    expect(wrapper.html()).toContain('Required');
+
+    const checkbox = wrapper.find('[data-testid="checkbox"]');
+    expect(checkbox.attributes('disabled')).toBeDefined();
+  });
+});

--- a/services/moon/src/utils/serviceSelection.js
+++ b/services/moon/src/utils/serviceSelection.js
@@ -1,0 +1,48 @@
+export function isServiceRequired(service) {
+  return Boolean(service && service.required === true);
+}
+
+function normalizeName(service) {
+  if (!service) return '';
+  const name = typeof service.name === 'string' ? service.name.trim() : '';
+  return name;
+}
+
+export function mergeRequiredSelections(services = [], previousSelection = []) {
+  const selectableNames = new Set();
+  const requiredNames = [];
+  const requiredSet = new Set();
+
+  for (const service of services) {
+    const name = normalizeName(service);
+    if (!name || service?.installed === true) {
+      continue;
+    }
+
+    selectableNames.add(name);
+
+    if (isServiceRequired(service) && !requiredSet.has(name)) {
+      requiredNames.push(name);
+      requiredSet.add(name);
+    }
+  }
+
+  const merged = [...requiredNames];
+  const mergedSet = new Set(requiredNames);
+
+  for (const candidate of Array.isArray(previousSelection) ? previousSelection : []) {
+    if (typeof candidate !== 'string') {
+      continue;
+    }
+
+    const trimmed = candidate.trim();
+    if (!trimmed || mergedSet.has(trimmed) || !selectableNames.has(trimmed)) {
+      continue;
+    }
+
+    merged.push(trimmed);
+    mergedSet.add(trimmed);
+  }
+
+  return merged;
+}

--- a/services/moon/src/utils/serviceSelection.test.js
+++ b/services/moon/src/utils/serviceSelection.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { isServiceRequired, mergeRequiredSelections } from './serviceSelection.js';
+
+describe('serviceSelection utilities', () => {
+  it('detects required services', () => {
+    expect(isServiceRequired({ required: true })).toBe(true);
+    expect(isServiceRequired({ required: false })).toBe(false);
+    expect(isServiceRequired({})).toBe(false);
+    expect(isServiceRequired(null)).toBe(false);
+  });
+
+  it('merges required services with previous selections', () => {
+    const services = [
+      { name: 'noona-redis', required: true },
+      { name: 'noona-mongo', required: true },
+      { name: 'noona-sage', required: false },
+    ];
+
+    expect(mergeRequiredSelections(services, [])).toEqual([
+      'noona-redis',
+      'noona-mongo',
+    ]);
+
+    expect(
+      mergeRequiredSelections(services, ['noona-sage', 'noona-redis', 'noona-moon']),
+    ).toEqual([
+      'noona-redis',
+      'noona-mongo',
+      'noona-sage',
+    ]);
+  });
+
+  it('filters installed or invalid services from selections', () => {
+    const services = [
+      { name: ' noona-redis ', required: true, installed: false },
+      { name: 'noona-vault', required: true, installed: true },
+      { name: 'noona-moon', required: false, installed: false },
+    ];
+
+    expect(mergeRequiredSelections(services, ['noona-vault', 'noona-moon'])).toEqual([
+      'noona-redis',
+      'noona-moon',
+    ]);
+  });
+});

--- a/services/moon/vite.config.js
+++ b/services/moon/vite.config.js
@@ -13,5 +13,9 @@ export default defineConfig({
         changeOrigin: true,
       },
     },
-  }
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
 });

--- a/services/warden/shared/wardenCore.mjs
+++ b/services/warden/shared/wardenCore.mjs
@@ -270,7 +270,8 @@ export function createWarden(options = {}) {
     const dependencyGraph = new Map([
         ['noona-vault', ['noona-mongo', 'noona-redis']],
     ]);
-    const requiredServices = ['noona-vault'];
+    const requiredServices = ['noona-mongo', 'noona-redis', 'noona-vault'];
+    const requiredServiceSet = new Set(requiredServices);
 
     const dockerFactory = dockerFactoryOption || ((socketPath) => new Docker({ socketPath }));
 
@@ -471,6 +472,7 @@ export function createWarden(options = {}) {
                 description: descriptor.description ?? null,
                 health: descriptor.health ?? null,
                 envConfig: cloneEnvConfig(descriptor.envConfig),
+                required: requiredServiceSet.has(descriptor.name),
             }))
             .sort((a, b) => a.name.localeCompare(b.name));
 
@@ -669,6 +671,7 @@ export function createWarden(options = {}) {
             hostServiceUrl: api.resolveHostServiceUrl(descriptor),
             image: descriptor.image,
             port: descriptor.port ?? null,
+            required: requiredServiceSet.has(descriptor.name),
         };
 
         if (descriptor.name === 'noona-raven') {

--- a/services/warden/tests/wardenCore.test.mjs
+++ b/services/warden/tests/wardenCore.test.mjs
@@ -130,6 +130,7 @@ test('listServices returns sorted metadata with host URLs and install state', as
             health: null,
             envConfig: [],
             installed: false,
+            required: false,
         },
         {
             name: 'noona-redis',
@@ -141,6 +142,7 @@ test('listServices returns sorted metadata with host URLs and install state', as
             health: null,
             envConfig: [],
             installed: true,
+            required: true,
         },
         {
             name: 'noona-sage',
@@ -152,10 +154,15 @@ test('listServices returns sorted metadata with host URLs and install state', as
             health: 'http://health',
             envConfig: [],
             installed: false,
+            required: false,
         },
     ]);
     assert.deepEqual(containerChecks, ['noona-moon', 'noona-redis', 'noona-sage']);
     assert.equal(warnings.length, 0);
+
+    const redis = services.find((entry) => entry.name === 'noona-redis');
+    assert.equal(redis?.required, true);
+    assert.equal(services.find((entry) => entry.name === 'noona-moon')?.required, false);
 
     const installable = await warden.listServices({ includeInstalled: false });
     assert.deepEqual(
@@ -198,6 +205,7 @@ test('installServices returns per-service results with errors', async () => {
             hostServiceUrl: 'mongodb://localhost:27017',
             image: 'mongo',
             port: null,
+            required: true,
         },
         {
             name: 'noona-redis',
@@ -206,6 +214,7 @@ test('installServices returns per-service results with errors', async () => {
             hostServiceUrl: 'http://localhost:8001',
             image: 'redis',
             port: 8001,
+            required: true,
         },
         {
             name: 'noona-vault',
@@ -214,6 +223,7 @@ test('installServices returns per-service results with errors', async () => {
             hostServiceUrl: 'http://localhost:3005',
             image: 'vault',
             port: 3005,
+            required: true,
         },
         {
             name: 'noona-sage',
@@ -222,6 +232,7 @@ test('installServices returns per-service results with errors', async () => {
             hostServiceUrl: 'http://localhost:3004',
             image: 'sage',
             port: 3004,
+            required: false,
         },
         {
             name: 'unknown',
@@ -358,6 +369,7 @@ test('installServices installs vault and dependencies when selected explicitly',
             hostServiceUrl: 'mongodb://localhost:27017',
             image: 'mongo',
             port: null,
+            required: true,
         },
         {
             name: 'noona-redis',
@@ -366,6 +378,7 @@ test('installServices installs vault and dependencies when selected explicitly',
             hostServiceUrl: 'http://localhost:8001',
             image: 'redis',
             port: 8001,
+            required: true,
         },
         {
             name: 'noona-vault',
@@ -374,6 +387,7 @@ test('installServices installs vault and dependencies when selected explicitly',
             hostServiceUrl: 'http://localhost:3005',
             image: 'vault',
             port: 3005,
+            required: true,
         },
     ]);
 });

--- a/services/warden/tests/wardenServer.test.mjs
+++ b/services/warden/tests/wardenServer.test.mjs
@@ -41,8 +41,8 @@ test('GET /api/services returns installable services by default', async (t) => {
         async listServices(options) {
             calls.push(options);
             return [
-                { name: 'noona-sage', category: 'core' },
-                { name: 'noona-redis', category: 'addon' },
+                { name: 'noona-sage', category: 'core', required: false },
+                { name: 'noona-redis', category: 'addon', required: true },
             ];
         },
         installServices: async () => {
@@ -57,8 +57,8 @@ test('GET /api/services returns installable services by default', async (t) => {
     assert.equal(response.status, 200);
     assert.deepEqual(await response.json(), {
         services: [
-            { name: 'noona-sage', category: 'core' },
-            { name: 'noona-redis', category: 'addon' },
+            { name: 'noona-sage', category: 'core', required: false },
+            { name: 'noona-redis', category: 'addon', required: true },
         ],
     });
     assert.deepEqual(calls, [{ includeInstalled: false }]);
@@ -70,8 +70,8 @@ test('GET /api/services can include installed services when requested', async (t
         async listServices(options) {
             calls.push(options);
             return [
-                { name: 'noona-sage', category: 'core', installed: true },
-                { name: 'noona-redis', category: 'addon', installed: false },
+                { name: 'noona-sage', category: 'core', installed: true, required: false },
+                { name: 'noona-redis', category: 'addon', installed: false, required: true },
             ];
         },
         installServices: async () => {
@@ -86,8 +86,8 @@ test('GET /api/services can include installed services when requested', async (t
     assert.equal(response.status, 200);
     assert.deepEqual(await response.json(), {
         services: [
-            { name: 'noona-sage', category: 'core', installed: true },
-            { name: 'noona-redis', category: 'addon', installed: false },
+            { name: 'noona-sage', category: 'core', installed: true, required: false },
+            { name: 'noona-redis', category: 'addon', installed: false, required: true },
         ],
     });
     assert.deepEqual(calls, [{ includeInstalled: true }]);
@@ -100,8 +100,8 @@ test('POST /api/services/install returns results and status code for errors', as
         installServices: async (services) => {
             installCalls.push(services);
             return [
-                { name: 'noona-sage', status: 'installed', category: 'core' },
-                { name: 'noona-bad', status: 'error', error: 'boom' },
+                { name: 'noona-sage', status: 'installed', category: 'core', required: true },
+                { name: 'noona-bad', status: 'error', error: 'boom', required: false },
             ];
         },
     };
@@ -121,8 +121,8 @@ test('POST /api/services/install returns results and status code for errors', as
     assert.equal(response.status, 207);
     assert.deepEqual(await response.json(), {
         results: [
-            { name: 'noona-sage', status: 'installed', category: 'core' },
-            { name: 'noona-bad', status: 'error', error: 'boom' },
+            { name: 'noona-sage', status: 'installed', category: 'core', required: true },
+            { name: 'noona-bad', status: 'error', error: 'boom', required: false },
         ],
     });
     assert.deepEqual(installCalls, [[


### PR DESCRIPTION
## Summary
- mark Redis and Mongo as required in Warden, exposing `required` metadata through the API and install responses
- auto-select and lock required services in Moon's setup wizard with visible indicators and shared selection helpers
- enable Vitest in Moon and add unit/UI coverage for the new required-service behaviour alongside updated Warden tests

## Testing
- node --test services/warden/tests/*.mjs
- (cd services/moon && npm test)


------
https://chatgpt.com/codex/tasks/task_e_68e06f88180c83319468b49e86a5f05a