### PR TITLE
chore: pin redis-stack image

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -10506,7 +10506,7 @@
           "id": "astnode100003672",
           "name": "rawList",
           "type": "ArrayExpression",
-          "value": "[\"{\\\"name\\\":\\\"noona-redis\\\",\\\"image\\\":\\\"redis/redis-stack:latest\\\",\\\"port\\\":8001,\\\"internalPort\\\":8001,\\\"ports\\\":\\\"\\\",\\\"exposed\\\":\\\"\\\",\\\"env\\\":\\\"\\\",\\\"volumes\\\":\\\"\\\",\\\"health\\\":\\\"http://noona-redis:8001/\\\",\\\"hostServiceUrl\\\":\\\"\\\"}\",\"{\\\"name\\\":\\\"noona-mongo\\\",\\\"image\\\":\\\"mongo:8\\\",\\\"port\\\":27017,\\\"internalPort\\\":27017,\\\"ports\\\":\\\"\\\",\\\"exposed\\\":\\\"\\\",\\\"env\\\":\\\"\\\",\\\"volumes\\\":\\\"\\\",\\\"health\\\":null,\\\"hostServiceUrl\\\":\\\"\\\"}\"]"
+          "value": "[\"{\\\"name\\\":\\\"noona-redis\\\",\\\"image\\\":\\\"redis/redis-stack:7.2.0-v19\\\",\\\"port\\\":8001,\\\"internalPort\\\":8001,\\\"ports\\\":\\\"\\\",\\\"exposed\\\":\\\"\\\",\\\"env\\\":\\\"\\\",\\\"volumes\\\":\\\"\\\",\\\"health\\\":\\\"http://noona-redis:8001/\\\",\\\"hostServiceUrl\\\":\\\"\\\"}\",\"{\\\"name\\\":\\\"noona-mongo\\\",\\\"image\\\":\\\"mongo:8\\\",\\\"port\\\":27017,\\\"internalPort\\\":27017,\\\"ports\\\":\\\"\\\",\\\"exposed\\\":\\\"\\\",\\\"env\\\":\\\"\\\",\\\"volumes\\\":\\\"\\\",\\\"health\\\":null,\\\"hostServiceUrl\\\":\\\"\\\"}\"]"
         }
       },
       "undocumented": true,
@@ -10555,7 +10555,7 @@
           "id": "astnode100003678",
           "name": "image",
           "type": "Literal",
-          "value": "redis/redis-stack:latest"
+          "value": "redis/redis-stack:7.2.0-v19"
         }
       },
       "undocumented": true,

--- a/services/warden/docker/addonDockers.mjs
+++ b/services/warden/docker/addonDockers.mjs
@@ -21,7 +21,7 @@ const createEnvField = (key, defaultValue, {
 const rawList = [
     {
         name: 'noona-redis',
-        image: 'redis/redis-stack:latest',
+        image: 'redis/redis-stack:7.2.0-v19',
         port: 8001,
         internalPort: 8001,
         ports: {


### PR DESCRIPTION
## Summary
- pin the noona-redis addon Docker image to redis/redis-stack:7.2.0-v19 instead of latest
- update generated documentation to reflect the pinned image tag

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0762400ec83318fcd32589398f3d4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added in this release.

- Chores
  - Pinned Redis Stack container image to version 7.2.0-v19 for improved stability and predictable deployments.

- Documentation
  - Updated configuration references to reflect the pinned Redis image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->