### PR TITLE
Handle missing chalk dependency in logger

### DIFF
--- a/utilities/etc/logger.mjs
+++ b/utilities/etc/logger.mjs
@@ -1,9 +1,40 @@
 ﻿// utilities/logger.mjs
-import chalk from 'chalk';
 import {stdout} from 'process';
+
+const identity = value => value;
+
+const fallbackChalk = {
+    gray: identity,
+    yellow: identity,
+    magenta: identity,
+    red: identity,
+    dim: identity,
+};
+
+let chalkLib = fallbackChalk;
+
+await import('chalk')
+    .then(module => {
+        const resolved = module?.default ?? module;
+        if (resolved) {
+            chalkLib = resolved;
+        }
+    })
+    .catch(() => {
+        chalkLib = fallbackChalk;
+    });
 
 function isTTY() {
     return stdout.isTTY;
+}
+
+function colorize(color, value) {
+    if (!isTTY()) {
+        return value;
+    }
+
+    const fn = chalkLib?.[color];
+    return typeof fn === 'function' ? fn(value) : value;
 }
 
 function formatPrefix(level = '') {
@@ -14,7 +45,7 @@ function formatPrefix(level = '') {
     const file = match?.[2] || 'unknown.mjs';
     const timestamp = new Date().toISOString();
     const prefix = `[${timestamp}] [${service}/${file}]${level ? ` [${level}]` : ''}`;
-    return isTTY() ? chalk.gray(prefix) : prefix;
+    return colorize('gray', prefix);
 }
 
 export function log(...args) {
@@ -23,22 +54,22 @@ export function log(...args) {
 
 export function warn(...args) {
     const prefix = formatPrefix('WARN');
-    console.warn(isTTY() ? chalk.yellow(prefix) : prefix, ...args);
+    console.warn(colorize('yellow', prefix), ...args);
 }
 
 export function alert(...args) {
     const prefix = formatPrefix('ALERT');
-    console.log(isTTY() ? chalk.magenta(prefix) : prefix, ...args);
+    console.log(colorize('magenta', prefix), ...args);
 }
 
 export function errMSG(...args) {
     const prefix = formatPrefix('ERROR');
-    console.error(isTTY() ? chalk.red(prefix) : prefix, ...args);
+    console.error(colorize('red', prefix), ...args);
 }
 
 export function debugMSG(...args) {
     if (process.env.DEBUG === 'true') {
         const prefix = formatPrefix('DEBUG');
-        console.log(isTTY() ? chalk.dim(prefix) : prefix, ...args);
+        console.log(colorize('dim', prefix), ...args);
     }
 }


### PR DESCRIPTION
## Summary
- fall back to no-op color functions when chalk is unavailable in the shared logger
- centralize color handling to avoid crashes when dependencies are missing

## Testing
- node -e "import('./utilities/etc/logger.mjs').then(m=>{m.log('hello'); m.warn('warn'); m.alert('alert'); m.errMSG('error'); process.env.DEBUG='true'; m.debugMSG('debug');});"

------
https://chatgpt.com/codex/tasks/task_e_68e076bcb74c8331b66b9bd9c881bb99