### PR TITLE
Disable automatic Docker Compose startup for Raven

### DIFF
--- a/services/raven/src/main/resources/application.properties
+++ b/services/raven/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 spring.application.name=raven
+
+# Disable automatic Docker Compose lifecycle management unless explicitly enabled.
+# This prevents Spring Boot from failing to start during local development when no
+# docker-compose.yml is present alongside the service. Override by setting the
+# SPRING_DOCKER_COMPOSE_ENABLED environment variable to true when needed.
+spring.docker.compose.enabled=${SPRING_DOCKER_COMPOSE_ENABLED:false}


### PR DESCRIPTION
## Summary
- disable Spring Boot Docker Compose auto-start for Raven so the service no longer fails when no compose file is present
- allow opting back in via the SPRING_DOCKER_COMPOSE_ENABLED environment variable and document the behaviour in application.properties

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68e076d8344483318bf173fab4fe3a87