### PR TITLE
chore: bump chalk to 5.6.2

### DIFF
--- a/services/portal/package.json
+++ b/services/portal/package.json
@@ -10,7 +10,7 @@
     "test": "node --test"
   },
   "dependencies": {
-    "chalk": "^5.4.1",
+    "chalk": "^5.6.2",
     "discord.js": "^14.16.3",
     "dotenv": "^16.4.5",
     "express": "^5.1.0",

--- a/utilities/package-lock.json
+++ b/utilities/package-lock.json
@@ -8,7 +8,7 @@
       "name": "noona-utilities",
       "version": "1.0.0",
       "dependencies": {
-        "chalk": "^5.4.1",
+        "chalk": "^5.6.2",
         "fs-extra": "^11.3.0",
         "ioredis": "^5.6.1",
         "mongodb": "^6.17.0",
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"

--- a/utilities/package.json
+++ b/utilities/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {},
   "dependencies": {
-    "chalk": "^5.4.1",
+    "chalk": "^5.6.2",
     "fs-extra": "^11.3.0",
     "ioredis": "^5.6.1",
     "mongodb": "^6.17.0",


### PR DESCRIPTION
## Summary
- bump the chalk dependency to 5.6.2 for the portal and utilities packages
- refresh the utilities lockfile to capture the new chalk release

## Testing
- npm --prefix services/portal test

------
https://chatgpt.com/codex/tasks/task_e_68e078e5d13c8331ac9211127acc2b15