### PR TITLE
Fix Raven Vault chapter scraping initialization

### DIFF
--- a/services/raven/src/main/java/com/paxkun/raven/service/DownloadService.java
+++ b/services/raven/src/main/java/com/paxkun/raven/service/DownloadService.java
@@ -233,8 +233,8 @@ public class DownloadService {
         }
     }
 
-    public static List<Map<String, String>> parseChapters(String url) {
-        return new TitleScraper().getChapters(url);
+    public List<Map<String, String>> fetchChapters(String titleUrl) {
+        return fetchAllChaptersWithRetry(titleUrl);
     }
 
     public void downloadSingleChapter(NewTitle title, String chapterNumber) {

--- a/services/raven/src/main/java/com/paxkun/raven/service/VaultService.java
+++ b/services/raven/src/main/java/com/paxkun/raven/service/VaultService.java
@@ -2,6 +2,7 @@ package com.paxkun.raven.service;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -19,10 +20,12 @@ import java.util.Map;
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class VaultService {
 
     private final WebClient webClient = WebClient.builder().build();
     private final Gson gson = new Gson();
+    private final DownloadService downloadService;
 
     @Value("${vault.url:http://noona-vault:3005}")
     private String vaultUrl;
@@ -156,7 +159,7 @@ public class VaultService {
      */
     public String fetchLatestChapterFromSource(String sourceUrl) {
         try {
-            List<Map<String, String>> chapters = DownloadService.parseChapters(sourceUrl);
+            List<Map<String, String>> chapters = downloadService.fetchChapters(sourceUrl);
             if (chapters == null || chapters.isEmpty()) return "0";
 
             return chapters.get(0).get("chapter_title").replaceAll("[^\\d.]", "");


### PR DESCRIPTION
## Summary
- add an instance-level `fetchChapters` helper in `DownloadService` that reuses the existing retry logic
- inject `DownloadService` into `VaultService` so chapter scraping uses the managed bean instead of a manually created scraper
- annotate `VaultService` with `@RequiredArgsConstructor` to wire the new dependency safely

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68e07c05da248331a3626ee6fa03ac9b