### PR TITLE
Fix raven build task shadowJar dependency

### DIFF
--- a/services/raven/build.gradle
+++ b/services/raven/build.gradle
@@ -84,5 +84,5 @@ tasks.named('shadowJar') {
 }
 
 tasks.named('build') {
-    dependsOn tasks.named('shadowJar')4
+    dependsOn tasks.named('shadowJar')
 }


### PR DESCRIPTION
## Summary
- remove an extraneous character from the raven build.gradle so the build task depends on shadowJar correctly

## Testing
- ./gradlew build (from services/raven)


------
https://chatgpt.com/codex/tasks/task_e_68e0819ee9808331a89b8d17fd700456