### PR TITLE
Add bulk Mongo find support for Raven library lookups

### DIFF
--- a/services/raven/src/test/java/com/paxkun/raven/service/VaultServiceTest.java
+++ b/services/raven/src/test/java/com/paxkun/raven/service/VaultServiceTest.java
@@ -1,0 +1,91 @@
+package com.paxkun.raven.service;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Type;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class VaultServiceTest {
+
+    private static final Gson GSON = new Gson();
+
+    private HttpServer server;
+    private int port;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        port = server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void findAllRequestsFindManyAndReturnsDocuments() {
+        DownloadService downloadService = Mockito.mock(DownloadService.class);
+        VaultService vaultService = new VaultService(downloadService);
+
+        AtomicReference<String> capturedBody = new AtomicReference<>();
+        AtomicReference<String> capturedAuth = new AtomicReference<>();
+
+        List<Map<String, Object>> mockDocs = List.of(
+                Map.of("title", "Solo Leveling"),
+                Map.of("title", "Omniscient Reader")
+        );
+
+        server.createContext("/v1/vault/handle", exchange -> {
+            capturedAuth.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            capturedBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+
+            byte[] responseBytes = GSON.toJson(Map.of(
+                    "status", "ok",
+                    "data", mockDocs
+            )).getBytes(StandardCharsets.UTF_8);
+
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, responseBytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(responseBytes);
+            }
+        });
+        server.start();
+
+        ReflectionTestUtils.setField(vaultService, "vaultUrl", "http://127.0.0.1:" + port);
+        ReflectionTestUtils.setField(vaultService, "vaultApiToken", "test-token");
+
+        List<Map<String, Object>> documents = vaultService.findAll("manga_library");
+
+        assertThat(documents).containsExactlyElementsOf(mockDocs);
+        assertEquals("Bearer test-token", capturedAuth.get());
+
+        String body = capturedBody.get();
+        assertNotNull(body);
+        Type type = new TypeToken<Map<String, Object>>() {}.getType();
+        Map<String, Object> request = GSON.fromJson(body, type);
+
+        assertEquals("mongo", request.get("storageType"));
+        assertEquals("findMany", request.get("operation"));
+    }
+}

--- a/utilities/database/packetParser.mjs
+++ b/utilities/database/packetParser.mjs
@@ -9,7 +9,7 @@ import redis from './redis/redisClient.mjs';
 import { log, warn, errMSG } from '../etc/logger.mjs';
 
 const allowedOps = {
-    mongo: ['insert', 'find', 'update'],
+    mongo: ['insert', 'find', 'findMany', 'update'],
     redis: ['set', 'get', 'del'],
 };
 
@@ -52,6 +52,13 @@ export async function handlePacket(packet) {
                     const result = await col.findOne(query);
                     log(`[Vault] 🔍 Queried "${collection}"`);
                     return result ? { status: 'ok', data: result } : { error: 'No document found' };
+                }
+
+                case 'findMany': {
+                    const cursor = col.find(query);
+                    const results = await cursor.toArray();
+                    log(`[Vault] 📚 Queried many from "${collection}" (count=${results.length})`);
+                    return { status: 'ok', data: results };
                 }
 
                 case 'update': {


### PR DESCRIPTION
## Summary
- add a Mongo `findMany` operation to the packet parser and allow-list so Vault can return multiple documents
- update Raven's `VaultService.findAll` to call the new operation and deserialize the list directly
- add Vault and Raven tests that cover array responses and verify the new bulk path

## Testing
- `npm test` (from `services/vault`)
- `./gradlew test` (from `services/raven`)
- Manually booted Raven against a stub Vault and `curl`'d `/v1/library/getall`

------
https://chatgpt.com/codex/tasks/task_e_68e081a2b9648331ae18ce5da88e718f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for fetching multiple records in one request, enabling richer result sets.
  - Updated data retrieval to use the new multi-record operation across services for consistent behavior.
- Bug Fixes
  - Improved robustness of responses: safely handles missing or malformed data and returns empty results when appropriate.
- Tests
  - Added integration and unit tests validating multi-record retrieval, authorization headers, request payloads, and response shapes.
  - Ensured server startup/shutdown and handler invocation are verified for reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->