### PR TITLE
Install utilities dependencies during portal image build

### DIFF
--- a/deployment/portal.Dockerfile
+++ b/deployment/portal.Dockerfile
@@ -13,6 +13,9 @@ COPY package*.json ./
 RUN npm install
 
 COPY utilities ./utilities
+WORKDIR /noona/utilities
+RUN npm install --production
+WORKDIR /noona
 USER noona
 
 


### PR DESCRIPTION
## Summary
- install production dependencies for utilities during the portal image build before dropping privileges

## Testing
- not run (docker unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_68e085a5b2088331bc03c72963509eda