### PR TITLE
Update portal Dockerfile healthcheck route

### DIFF
--- a/deployment/portal.Dockerfile
+++ b/deployment/portal.Dockerfile
@@ -26,6 +26,6 @@ COPY services/portal ./
 RUN npm install
 EXPOSE 3003
 HEALTHCHECK --interval=5s --timeout=3s --start-period=5s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:3003/', res => res.statusCode === 200 ? process.exit(0) : process.exit(1)).on('error', () => process.exit(1))"
+  CMD node -e "require('http').get('http://localhost:3003/health', res => res.statusCode === 200 ? process.exit(0) : process.exit(1)).on('error', () => process.exit(1))"
 USER noona
 CMD ["node", "initPortal.mjs"]


### PR DESCRIPTION
## Summary
- update the Portal image healthcheck to query the /health endpoint instead of the root path

## Testing
- `docker build -f deployment/portal.Dockerfile -t portal-test .` *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e09bd1a0288331b0178771cdbd8a0b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container health check to target the dedicated /health endpoint, improving accuracy of service status detection.
  * Ensures healthier rollout behavior by distinguishing app readiness from generic root responses.
  * Maintains existing success/failure conditions for consistent monitoring and automated restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->