### PR TITLE
Add portal env defaults to warden descriptors

### DIFF
--- a/services/warden/docker/noonaDockers.mjs
+++ b/services/warden/docker/noonaDockers.mjs
@@ -127,15 +127,37 @@ const serviceDefs = rawList.map(name => {
                 label: 'Vault Access Token',
                 description: 'Authentication token that allows the portal to access Vault.',
             },
+            {
+                key: 'PORTAL_REDIS_NAMESPACE',
+                label: 'Portal Redis Namespace',
+                description: 'Namespace prefix used for onboarding state stored in Redis.',
+                defaultValue: 'portal:onboarding',
+                required: false,
+            },
+            {
+                key: 'PORTAL_TOKEN_TTL',
+                label: 'Portal Token TTL',
+                description: 'Time-to-live in seconds for onboarding tokens cached in Redis.',
+                defaultValue: '900',
+                required: false,
+            },
+            {
+                key: 'PORTAL_HTTP_TIMEOUT',
+                label: 'Portal HTTP Timeout',
+                description: 'HTTP client timeout in milliseconds for outbound portal requests.',
+                defaultValue: '10000',
+                required: false,
+            },
         ];
 
         portalEnvFields.forEach(field => {
-            env.push(`${field.key}=`);
+            const defaultValue = field.defaultValue ?? '';
+            env.push(`${field.key}=${defaultValue}`);
             envConfig.push(
-                createEnvField(field.key, '', {
+                createEnvField(field.key, defaultValue, {
                     label: field.label,
                     description: field.description,
-                    required: true,
+                    required: field.required !== false,
                 }),
             );
         });

--- a/services/warden/tests/vaultTokens.test.mjs
+++ b/services/warden/tests/vaultTokens.test.mjs
@@ -112,6 +112,32 @@ test('setup wizard uses generated Vault tokens in VAULT_API_TOKEN fields', async
     }
 });
 
+test('noona-portal descriptor exposes Redis and HTTP defaults', async () => {
+    const module = await import('../docker/noonaDockers.mjs?test=portal-env');
+    const { default: noonaDockers } = module;
+
+    const portal = noonaDockers['noona-portal'];
+    assert.ok(portal, 'Portal service descriptor should be defined.');
+
+    const expectations = [
+        ['PORTAL_REDIS_NAMESPACE', 'portal:onboarding'],
+        ['PORTAL_TOKEN_TTL', '900'],
+        ['PORTAL_HTTP_TIMEOUT', '10000'],
+    ];
+
+    for (const [key, value] of expectations) {
+        assert.ok(
+            portal.env.includes(`${key}=${value}`),
+            `${key} should be exported with its default of ${value}.`,
+        );
+
+        const field = portal.envConfig.find((entry) => entry.key === key);
+        assert.ok(field, `Portal envConfig should include ${key}.`);
+        assert.equal(field.defaultValue, value, `${key} default should match implicit behavior.`);
+        assert.equal(field.required, false, `${key} should be optional in setup UI.`);
+    }
+});
+
 test('noona-vault descriptor exposes storage connection environment fields', async () => {
     const module = await import('../docker/noonaDockers.mjs?test=storage-env');
     const { default: noonaDockers } = module;


### PR DESCRIPTION
## Summary
- expose the portal Redis namespace, token TTL, and HTTP timeout variables in the warden docker env configuration
- ensure the setup metadata treats the new portal fields as optional with documented defaults
- add a regression test covering the exported portal defaults

## Testing
- node --test services/warden/tests/*.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e0a38b5fc48331ae56b35eb1eaee88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added three optional configuration settings for the portal service: Redis namespace, token TTL, and HTTP timeout, each with sensible defaults.
  - Environment generation now consistently applies defined default values (or empty when unspecified), ensuring predictable behavior across portal settings.
- Tests
  - Added tests to verify the portal descriptor exposes the new settings, with correct default values and optional status.
  - Expanded coverage ensures environment configuration aligns with expected defaults and optionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->