### PR TITLE
Set default Vault base URL for portal container

### DIFF
--- a/services/warden/docker/noonaDockers.mjs
+++ b/services/warden/docker/noonaDockers.mjs
@@ -10,6 +10,8 @@ const DOCKER_WARDEN_URL =
 const DEFAULT_VAULT_MONGO_URI = process.env.MONGO_URI || 'mongodb://noona-mongo:27017';
 const DEFAULT_VAULT_REDIS_HOST = process.env.REDIS_HOST || 'noona-redis';
 const DEFAULT_VAULT_REDIS_PORT = process.env.REDIS_PORT || '6379';
+const DEFAULT_PORTAL_VAULT_BASE_URL =
+    process.env.PORTAL_VAULT_BASE_URL || 'http://noona-vault:3005';
 
 const rawList = [
     'noona-sage',
@@ -121,6 +123,7 @@ const serviceDefs = rawList.map(name => {
                 key: 'VAULT_BASE_URL',
                 label: 'Vault Base URL',
                 description: 'URL where the Vault service is exposed for the portal.',
+                defaultValue: DEFAULT_PORTAL_VAULT_BASE_URL,
             },
             {
                 key: 'VAULT_ACCESS_TOKEN',

--- a/services/warden/tests/vaultTokens.test.mjs
+++ b/services/warden/tests/vaultTokens.test.mjs
@@ -125,6 +125,19 @@ test('noona-portal descriptor exposes Redis and HTTP defaults', async () => {
         ['PORTAL_HTTP_TIMEOUT', '10000'],
     ];
 
+    const requiredExpectations = [
+        ['VAULT_BASE_URL', 'http://noona-vault:3005'],
+    ];
+
+    for (const [key, value] of requiredExpectations) {
+        assert.ok(portal.env.includes(`${key}=${value}`), `${key} should be exported with default ${value}.`);
+
+        const field = portal.envConfig.find((entry) => entry.key === key);
+        assert.ok(field, `Portal envConfig should include ${key}.`);
+        assert.equal(field.defaultValue, value, `${key} default should match container default.`);
+        assert.equal(field.required, true, `${key} should remain required in setup UI.`);
+    }
+
     for (const [key, value] of expectations) {
         assert.ok(
             portal.env.includes(`${key}=${value}`),


### PR DESCRIPTION
## Summary
- default the portal VAULT_BASE_URL to http://noona-vault:3005 so the generated env vars and setup wizard match
- extend the portal descriptor test to cover the new Vault base URL default alongside existing optional fields

## Testing
- npm test (from services/warden)


------
https://chatgpt.com/codex/tasks/task_e_68e125f3921c8331a3e169781ac5089a