### PR TITLE
Add default Vault URL configuration for Raven descriptor

### DIFF
--- a/services/warden/docker/noonaDockers.mjs
+++ b/services/warden/docker/noonaDockers.mjs
@@ -10,6 +10,7 @@ const DOCKER_WARDEN_URL =
 const DEFAULT_VAULT_MONGO_URI = process.env.MONGO_URI || 'mongodb://noona-mongo:27017';
 const DEFAULT_VAULT_REDIS_HOST = process.env.REDIS_HOST || 'noona-redis';
 const DEFAULT_VAULT_REDIS_PORT = process.env.REDIS_PORT || '6379';
+const DEFAULT_RAVEN_VAULT_URL = process.env.VAULT_URL || 'http://noona-vault:3005';
 
 const rawList = [
     'noona-sage',
@@ -86,6 +87,17 @@ const serviceDefs = rawList.map(name => {
             createEnvField('WARDEN_BASE_URL', DOCKER_WARDEN_URL, {
                 label: 'Warden Base URL',
                 warning: 'Adjust only if Warden is reachable at a custom URL within the Docker network.',
+            }),
+        );
+    }
+
+    if (name === 'noona-raven') {
+        env.push(`VAULT_URL=${DEFAULT_RAVEN_VAULT_URL}`);
+        envConfig.push(
+            createEnvField('VAULT_URL', DEFAULT_RAVEN_VAULT_URL, {
+                label: 'Vault URL',
+                description: 'Base URL Raven uses when communicating with the Vault service.',
+                warning: 'Update only when Vault is exposed on a non-default host or port within your deployment.',
             }),
         );
     }

--- a/services/warden/readme.md
+++ b/services/warden/readme.md
@@ -53,6 +53,7 @@ DEBUG=super node initWarden.mjs
 | -------- | --------------------------------------------------------------------------- | ------- |
 | `DEBUG`  | Controls launch mode and enables log streaming when set to `true` or `super`. | `false` |
 | `HOST_SERVICE_URL` | Base URL used when logging host-facing service endpoints (e.g. `http://localhost`). | `http://localhost` |
+| `VAULT_URL` | Default Vault service URL injected into the Raven descriptor for Docker setups. | `http://noona-vault:3005` |
 | `*_VAULT_TOKEN` | Optional per-service override (e.g. `NOONA_SAGE_VAULT_TOKEN`) for Vault API tokens. | Built-in dev token |
 
 ---

--- a/services/warden/tests/vaultTokens.test.mjs
+++ b/services/warden/tests/vaultTokens.test.mjs
@@ -138,6 +138,28 @@ test('noona-portal descriptor exposes Redis and HTTP defaults', async () => {
     }
 });
 
+test('noona-raven descriptor includes default Vault URL configuration', async () => {
+    const module = await import('../docker/noonaDockers.mjs?test=raven-env');
+    const { default: noonaDockers } = module;
+
+    const raven = noonaDockers['noona-raven'];
+    assert.ok(raven, 'Raven service descriptor should be defined.');
+
+    const expectedEntry = 'VAULT_URL=http://noona-vault:3005';
+    assert.ok(
+        raven.env.includes(expectedEntry),
+        'Raven env array should expose the default Vault URL.',
+    );
+
+    const vaultUrlField = raven.envConfig.find((entry) => entry.key === 'VAULT_URL');
+    assert.ok(vaultUrlField, 'Raven envConfig should describe the Vault URL field.');
+    assert.equal(
+        vaultUrlField.defaultValue,
+        'http://noona-vault:3005',
+        'Raven Vault URL default should match the Docker network address.',
+    );
+});
+
 test('noona-vault descriptor exposes storage connection environment fields', async () => {
     const module = await import('../docker/noonaDockers.mjs?test=storage-env');
     const { default: noonaDockers } = module;


### PR DESCRIPTION
## Summary
- add a default VAULT_URL entry to the Raven service descriptor along with setup guidance
- cover the new VAULT_URL field in the Warden test suite
- document the new configuration option in the Warden README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e125fb74308331a21b4d40d1fda397