### PR TITLE
Add Raven Vault URL configuration option

### DIFF
--- a/services/warden/docker/noonaDockers.mjs
+++ b/services/warden/docker/noonaDockers.mjs
@@ -12,6 +12,7 @@ const DEFAULT_VAULT_REDIS_HOST = process.env.REDIS_HOST || 'noona-redis';
 const DEFAULT_VAULT_REDIS_PORT = process.env.REDIS_PORT || '6379';
 const DEFAULT_PORTAL_VAULT_BASE_URL =
     process.env.PORTAL_VAULT_BASE_URL || 'http://noona-vault:3005';
+const DEFAULT_RAVEN_VAULT_URL = process.env.RAVEN_VAULT_URL || 'http://noona-vault:3005';
 
 const rawList = [
     'noona-sage',
@@ -93,6 +94,7 @@ const serviceDefs = rawList.map(name => {
     }
 
     if (name === 'noona-raven') {
+        env.push(`VAULT_URL=${DEFAULT_RAVEN_VAULT_URL}`);
         envConfig.push(
             createEnvField('APPDATA', '', {
                 label: 'Raven Downloads Root',
@@ -109,6 +111,11 @@ const serviceDefs = rawList.map(name => {
                 warning:
                     'Supply this when Warden cannot discover your Kavita container automatically.',
                 required: false,
+            }),
+            createEnvField('VAULT_URL', DEFAULT_RAVEN_VAULT_URL, {
+                label: 'Vault Service URL',
+                warning:
+                    'Change only if Vault is reachable for Raven at a non-default address inside the Docker network.',
             }),
         );
     }

--- a/services/warden/readme.md
+++ b/services/warden/readme.md
@@ -49,10 +49,11 @@ DEBUG=super node initWarden.mjs
 
 ## 📝 Environment Variables
 
-| Variable | Description                                                                 | Default |
-| -------- | --------------------------------------------------------------------------- | ------- |
-| `DEBUG`  | Controls launch mode and enables log streaming when set to `true` or `super`. | `false` |
+| Variable | Description | Default |
+| -------- | ----------- | ------- |
+| `DEBUG` | Controls launch mode and enables log streaming when set to `true` or `super`. | `false` |
 | `HOST_SERVICE_URL` | Base URL used when logging host-facing service endpoints (e.g. `http://localhost`). | `http://localhost` |
+| `RAVEN_VAULT_URL` | Overrides the default Vault endpoint provided to Raven containers. | `http://noona-vault:3005` |
 | `*_VAULT_TOKEN` | Optional per-service override (e.g. `NOONA_SAGE_VAULT_TOKEN`) for Vault API tokens. | Built-in dev token |
 
 ---

--- a/services/warden/tests/vaultTokens.test.mjs
+++ b/services/warden/tests/vaultTokens.test.mjs
@@ -151,6 +151,29 @@ test('noona-portal descriptor exposes Redis and HTTP defaults', async () => {
     }
 });
 
+test('noona-raven descriptor provides default Vault URL configuration', async () => {
+    const module = await import('../docker/noonaDockers.mjs?test=raven-env');
+    const { default: noonaDockers } = module;
+
+    const raven = noonaDockers['noona-raven'];
+    assert.ok(raven, 'Raven service descriptor should be defined.');
+
+    const expectedDefault = 'http://noona-vault:3005';
+    assert.ok(
+        raven.env.includes(`VAULT_URL=${expectedDefault}`),
+        'Raven env should include VAULT_URL with the default Vault endpoint.',
+    );
+
+    const field = raven.envConfig.find((entry) => entry.key === 'VAULT_URL');
+    assert.ok(field, 'Raven envConfig should include VAULT_URL field.');
+    assert.equal(field.defaultValue, expectedDefault, 'VAULT_URL default should match the container env.');
+    assert.equal(
+        field.warning,
+        'Change only if Vault is reachable for Raven at a non-default address inside the Docker network.',
+        'VAULT_URL envConfig should explain when to adjust the value.',
+    );
+});
+
 test('noona-vault descriptor exposes storage connection environment fields', async () => {
     const module = await import('../docker/noonaDockers.mjs?test=storage-env');
     const { default: noonaDockers } = module;


### PR DESCRIPTION
## Summary
- add a default `VAULT_URL` environment value to the Raven descriptor along with setup metadata
- extend the Warden unit tests to cover the Raven Vault URL defaults
- document the new `RAVEN_VAULT_URL` override in the Warden README

## Testing
- `cd services/warden && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e176827fd4833182e072b2f1b089b0