### PR TITLE
Add debug tracing to Raven download flow

### DIFF
--- a/services/raven/src/main/java/com/paxkun/raven/controller/DownloadController.java
+++ b/services/raven/src/main/java/com/paxkun/raven/controller/DownloadController.java
@@ -1,6 +1,7 @@
 package com.paxkun.raven.controller;
 
 import com.paxkun.raven.service.DownloadService;
+import com.paxkun.raven.service.LoggerService;
 import com.paxkun.raven.service.download.SearchTitle;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class DownloadController {
 
     private final DownloadService downloadService;
+    private final LoggerService logger;
 
     /**
      * Health check endpoint for Raven's download module.
@@ -36,7 +38,16 @@ public class DownloadController {
      */
     @GetMapping("/search/{titleName}")
     public ResponseEntity<SearchTitle> searchTitle(@PathVariable String titleName) {
+        String sanitizedTitle = sanitizeForLog(titleName);
+        logger.debug("DOWNLOAD_CONTROLLER", "Request received to search title: " + sanitizedTitle);
         SearchTitle result = downloadService.searchTitle(titleName);
+        String sanitizedSearchId = result != null ? sanitizeForLog(result.getSearchId()) : "";
+        int optionCount = result != null && result.getOptions() != null ? result.getOptions().size() : 0;
+        logger.debug(
+                "DOWNLOAD_CONTROLLER",
+                "Search completed for query: " + sanitizedTitle +
+                        " | searchId=" + sanitizedSearchId +
+                        " | options=" + optionCount);
         return ResponseEntity.ok(result);
     }
 
@@ -52,8 +63,23 @@ public class DownloadController {
     public ResponseEntity<String> queueDownload(
             @PathVariable String searchId,
             @PathVariable int optionIndex) {
-
+        String sanitizedSearchId = sanitizeForLog(searchId);
+        logger.debug(
+                "DOWNLOAD_CONTROLLER",
+                "Queue request received | searchId=" + sanitizedSearchId + " | optionIndex=" + optionIndex);
         String result = downloadService.queueDownloadAllChapters(searchId, optionIndex);
+        logger.debug(
+                "DOWNLOAD_CONTROLLER",
+                "Queue response | searchId=" + sanitizedSearchId +
+                        " | optionIndex=" + optionIndex +
+                        " | message=" + sanitizeForLog(result));
         return ResponseEntity.ok(result);
+    }
+
+    private String sanitizeForLog(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replaceAll("[\\r\\n]", "").replaceAll("[^\\p{Alnum}\\s_-]", "").trim();
     }
 }


### PR DESCRIPTION
## Summary
- add controller-level debug logging for search and queue endpoints using LoggerService
- expand DownloadService debug instrumentation across search, queuing, download execution, and helper routines with sanitized metadata

## Testing
- services/raven/gradlew -p services/raven test

------
https://chatgpt.com/codex/tasks/task_e_68e18aea7b6083318a64acba21ccdd14