### PR TITLE
Use linear progress indicator for Setup wizard loading

### DIFF
--- a/services/moon/src/pages/Setup.vue
+++ b/services/moon/src/pages/Setup.vue
@@ -386,8 +386,13 @@ onMounted(() => {
             </v-card-subtitle>
 
             <v-card-text>
-              <div v-if="state.loading" class="d-flex justify-center py-10">
-                <v-progress-circular color="primary" size="64" indeterminate />
+              <div v-if="state.loading" class="setup-loading py-10">
+                <v-progress-linear
+                  color="primary"
+                  height="6"
+                  indeterminate
+                  aria-label="Downloading services"
+                />
               </div>
 
               <v-alert
@@ -622,6 +627,10 @@ onMounted(() => {
 
 .setup-list__divider {
   margin: 4px 0;
+}
+
+.setup-loading {
+  width: 100%;
 }
 
 @media (max-width: 600px) {

--- a/services/moon/src/pages/__tests__/Setup.test.ts
+++ b/services/moon/src/pages/__tests__/Setup.test.ts
@@ -1,0 +1,47 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import SetupPage from '../Setup.vue';
+
+const stubs = {
+  Header: { template: '<div><slot /></div>' },
+  'v-container': { template: '<div><slot /></div>' },
+  'v-row': { template: '<div><slot /></div>' },
+  'v-col': { template: '<div><slot /></div>' },
+  'v-card': { template: '<div><slot /></div>' },
+  'v-card-title': { template: '<div><slot /></div>' },
+  'v-card-subtitle': { template: '<div><slot /></div>' },
+  'v-card-text': { template: '<div><slot /></div>' },
+  'v-card-actions': { template: '<div><slot /></div>' },
+  'v-alert': { template: '<div><slot /><slot name="append" /></div>' },
+  'v-btn': { template: '<button><slot /></button>' },
+  'v-chip': { template: '<div><slot /></div>' },
+  'v-list': { template: '<div><slot /></div>' },
+  'v-divider': { template: '<hr />' },
+  'v-progress-linear': { template: '<div role="progressbar" v-bind="$attrs"></div>' },
+  'v-progress-circular': { template: '<div role="progressbar" v-bind="$attrs"></div>' },
+  'v-expand-transition': { template: '<div><slot /></div>' },
+  'v-text-field': { template: '<input />' },
+  'v-icon': { template: '<i><slot /></i>' },
+  SetupListItem: { template: '<div />' },
+};
+
+describe('Setup page', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows a download progress bar while services are loading', () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () => new Promise(() => {}) as unknown as Promise<Response>,
+    );
+
+    const wrapper = mount(SetupPage, {
+      global: {
+        stubs,
+      },
+    });
+
+    const progressBar = wrapper.find('[aria-label="Downloading services"]');
+    expect(progressBar.exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- replace the Setup wizard loading spinner with a full-width linear progress bar and accessible label
- add scoped styling for the loading container to align with the card layout
- add a Setup page test that asserts the progress bar appears while services are loading

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e192fee03c8331b567f9f6ae72acb6