### PR TITLE
Configure Raven Docker image download directory

### DIFF
--- a/deployment/raven.Dockerfile
+++ b/deployment/raven.Dockerfile
@@ -37,6 +37,11 @@ RUN apt-get update && \
 # Set working directory
 WORKDIR /app
 
+# Configure application data directory for downloads and ensure it exists
+ENV APPDATA=/app/downloads
+RUN mkdir -p "$APPDATA"
+VOLUME ["${APPDATA}"]
+
 # Copy built jar from builder stage
 COPY --from=builder /app/build/libs/*-all.jar app.jar
 


### PR DESCRIPTION
## Summary
- define APPDATA in the Raven runtime image and create the downloads directory
- declare the download directory as a volume so bind mounts inherit correct permissions

## Testing
- not run (docker not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e19d52f5548331a4ed8b4c741611c4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Downloads now persist across container restarts and updates via a dedicated, writable application data directory.
  - The downloads directory is automatically created at startup to ensure a ready-to-use path.
  - Easier mounting of external storage for downloads, improving reliability and durability of files.

- Chores
  - Runtime image declares a volume for application data to support persistence and simplify container deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->