### PR TITLE
Build Raven runtime from Spring Boot jar

### DIFF
--- a/services/raven/build.gradle
+++ b/services/raven/build.gradle
@@ -5,7 +5,6 @@ plugins {
     id 'org.springframework.boot' version '3.5.3'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.graalvm.buildtools.native' version '0.10.6'
-    id 'com.gradleup.shadow' version '8.3.6'
 }
 
 group = 'com.paxkun'
@@ -22,7 +21,7 @@ springBoot {
 }
 
 bootJar {
-    enabled = false
+    enabled = true
 }
 
 jar {
@@ -75,14 +74,6 @@ tasks.withType(Test).configureEach {
     useJUnitPlatform()
 }
 
-tasks.named('shadowJar') {
-    archiveClassifier.set('all')
-    mergeServiceFiles()
-    manifest {
-        attributes('Main-Class': springBoot.mainClass)
-    }
-}
-
 tasks.named('build') {
-    dependsOn tasks.named('shadowJar')
+    dependsOn tasks.named('bootJar')
 }


### PR DESCRIPTION
## Summary
- remove the Shadow plugin from the Raven service and re-enable the Spring Boot executable jar
- update the Raven Dockerfile to build via `bootJar` and package the Boot jar as the runtime artifact

## Testing
- ./gradlew clean bootJar (services/raven)


------
https://chatgpt.com/codex/tasks/task_e_68e1a4d475708331b4a380346e4d3aba