### PR TITLE
Fix title deserialization and add library coverage

### DIFF
--- a/services/raven/src/main/java/com/paxkun/raven/service/library/NewTitle.java
+++ b/services/raven/src/main/java/com/paxkun/raven/service/library/NewTitle.java
@@ -1,5 +1,6 @@
 package com.paxkun.raven.service.library;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,6 +17,7 @@ import lombok.NoArgsConstructor;
 public class NewTitle {
 
     /** The human-readable name of the manga title. */
+    @SerializedName("title")
     private String titleName;
 
     /** Unique UUID assigned when the title is first added. */


### PR DESCRIPTION
## Summary
- map NewTitle.titleName to the Vault `title` field for Gson deserialization
- add unit coverage ensuring library titles preserve their names during checks and downloads

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68e1af1040c08331a26f5c9828302fb7