### PR TITLE
Fix portal health check endpoint

### DIFF
--- a/services/warden/docker/noonaDockers.mjs
+++ b/services/warden/docker/noonaDockers.mjs
@@ -248,6 +248,10 @@ const serviceDefs = rawList.map(name => {
             return 'http://noona-raven:8080/v1/library/health';
         }
 
+        if (name === 'noona-portal') {
+            return 'http://noona-portal:3003/health';
+        }
+
         return `http://${name}:${portMap[name]}/`;
     })();
 

--- a/services/warden/tests/vaultTokens.test.mjs
+++ b/services/warden/tests/vaultTokens.test.mjs
@@ -151,6 +151,20 @@ test('noona-portal descriptor exposes Redis and HTTP defaults', async () => {
     }
 });
 
+test('noona-portal health check points to /health endpoint', async () => {
+    const module = await import('../docker/noonaDockers.mjs?test=portal-health');
+    const { default: noonaDockers } = module;
+
+    const portal = noonaDockers['noona-portal'];
+    assert.ok(portal, 'Portal service descriptor should be defined.');
+
+    assert.equal(
+        portal.health,
+        'http://noona-portal:3003/health',
+        'Portal health check should target the /health endpoint.',
+    );
+});
+
 test('noona-raven descriptor provides default Vault URL configuration', async () => {
     const module = await import('../docker/noonaDockers.mjs?test=raven-env');
     const { default: noonaDockers } = module;


### PR DESCRIPTION
## Summary
- update the portal Docker descriptor to use the /health endpoint for its health check
- add a regression test ensuring the portal descriptor exports the /health health URL

## Testing
- npm test (from services/warden)


------
https://chatgpt.com/codex/tasks/task_e_68e1ba8fe9b48331904f55c1441b8d28