### PR TITLE
Add Raven placeholder page and navigation

### DIFF
--- a/services/moon/src/components/Header.vue
+++ b/services/moon/src/components/Header.vue
@@ -55,6 +55,9 @@ watch(drawer, (val) => {
         <v-list-item prepend-icon="mdi-cog" @click="navigate('/setup')">
           <v-list-item-title>Go to Setup</v-list-item-title>
         </v-list-item>
+        <v-list-item prepend-icon="mdi-crow" @click="navigate('/raven')">
+          <v-list-item-title>Go to Raven</v-list-item-title>
+        </v-list-item>
       </v-list>
     </v-navigation-drawer>
 

--- a/services/moon/src/components/__tests__/Header.test.ts
+++ b/services/moon/src/components/__tests__/Header.test.ts
@@ -1,0 +1,75 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const push = vi.fn();
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+  useRoute: () => ({ name: 'Test Route' }),
+}));
+
+vi.mock('vuetify', () => ({
+  useTheme: () => ({
+    global: {
+      current: { value: { dark: false } },
+      name: { value: 'light' },
+    },
+  }),
+}));
+
+const Header = (await import('../Header.vue')).default;
+
+const stubs = {
+  'v-app': { template: '<div><slot /></div>' },
+  'v-navigation-drawer': { template: '<aside><slot /></aside>' },
+  'v-list': { template: '<div><slot /></div>' },
+  'v-list-item': {
+    props: ['prependIcon'],
+    emits: ['click'],
+    template:
+      '<button class="v-list-item" type="button" @click="$emit(\'click\')"><slot /></button>',
+  },
+  'v-list-item-title': { template: '<span><slot /></span>' },
+  'v-divider': { template: '<hr />' },
+  'v-app-bar': { template: '<header><slot /></header>' },
+  'v-app-bar-nav-icon': {
+    emits: ['click'],
+    template: '<button class="nav-icon" type="button" @click="$emit(\'click\')"></button>',
+  },
+  'v-img': { template: '<img />' },
+  'v-toolbar-title': { template: '<div><slot /></div>' },
+  'v-main': { template: '<main><slot /></main>' },
+};
+
+describe('Header navigation', () => {
+  beforeEach(() => {
+    push.mockClear();
+    const storage = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    };
+    vi.stubGlobal('localStorage', storage);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('renders a Raven navigation item that navigates when clicked', async () => {
+    const wrapper = mount(Header, {
+      global: {
+        stubs,
+      },
+    });
+
+    const ravenItem = wrapper
+      .findAll('.v-list-item')
+      .find((item) => item.text().includes('Go to Raven'));
+
+    expect(ravenItem).toBeDefined();
+    await ravenItem!.trigger('click');
+    expect(push).toHaveBeenCalledWith('/raven');
+  });
+});

--- a/services/moon/src/pages/Raven.vue
+++ b/services/moon/src/pages/Raven.vue
@@ -1,0 +1,22 @@
+<script setup>
+import Header from '../components/Header.vue';
+</script>
+
+<template>
+  <Header>
+    <v-container class="py-12">
+      <v-row class="justify-center">
+        <v-col cols="12" md="8" lg="6">
+          <v-card class="pa-8 text-center" elevation="10">
+            <v-icon class="mb-4" color="primary" size="48">mdi-crow</v-icon>
+            <v-card-title class="text-h4 mb-2">Raven Operations</v-card-title>
+            <v-card-subtitle class="mb-4">Monitoring and insights for your Noona services.</v-card-subtitle>
+            <v-card-text>
+              The Raven console is under construction. Check back soon for dashboards, alerts, and telemetry to keep your deployment healthy.
+            </v-card-text>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+  </Header>
+</template>

--- a/services/moon/src/router/index.js
+++ b/services/moon/src/router/index.js
@@ -11,6 +11,11 @@ const routes = [
         name: 'Setup',
         component: () => import('../pages/Setup.vue'), // lazy-loaded
     },
+    {
+        path: '/raven',
+        name: 'Raven',
+        component: () => import('../pages/Raven.vue'),
+    },
 ];
 
 const router = createRouter({


### PR DESCRIPTION
## Summary
- add a Raven placeholder page that reuses the shared Header layout
- register a lazy-loaded /raven route and expose it through the sidebar navigation
- cover the new navigation entry with a lightweight Header component test

## Testing
- npm --prefix services/moon test

------
https://chatgpt.com/codex/tasks/task_e_68e1ba97678c83318844aad9ceba3a2d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “Go to Raven” item in the header navigation that takes you to a new Raven page at /raven.
  - Introduced the Raven page with a centered card showcasing “Raven Operations,” indicating the console is under construction and focused on monitoring and insights.

- Tests
  - Added unit tests to verify that selecting the Raven navigation item routes correctly to /raven.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->