### PR TITLE
Add log buffering and setup API proxies for Moon wizard

### DIFF
--- a/services/moon/src/pages/__tests__/Setup.test.ts
+++ b/services/moon/src/pages/__tests__/Setup.test.ts
@@ -162,7 +162,7 @@ describe('Setup page', () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(mockResponse(initialServices))
-      .mockResolvedValueOnce(mockResponse({ items: [], status: 'Installing' }))
+      .mockResolvedValueOnce(mockResponse({ status: 'installing', percent: 0, items: [] }))
       .mockResolvedValueOnce(postResponse)
       .mockResolvedValueOnce(mockResponse(refreshedServices));
 


### PR DESCRIPTION
## Summary
- buffer Docker pull progress and container logs per service for Warden APIs and expose history/progress/test/detect endpoints
- proxy the new Warden setup routes through Sage and surface them in the Moon setup wizard UI
- extend unit tests across Warden, Sage, and Moon to cover the new API flows and UI interactions

## Testing
- npm --prefix services/warden test
- npm --prefix services/sage test
- npm --prefix services/moon test

------
https://chatgpt.com/codex/tasks/task_e_68e1c7965ce8833198e085e596ba8514