### PR TITLE
feat: add Moon service informational pages

### DIFF
--- a/services/moon/src/components/Header.vue
+++ b/services/moon/src/components/Header.vue
@@ -1,4 +1,4 @@
-﻿<script setup>
+<script setup>
 import {onMounted, ref, watch} from 'vue';
 import {useRoute, useRouter} from 'vue-router';
 import {useTheme} from 'vuetify';
@@ -7,6 +7,18 @@ const drawer = ref(true); // Sidebar open/closed
 const theme = useTheme();
 const router = useRouter();
 const route = useRoute();
+
+const navigationItems = [
+  {title: 'Home', icon: 'mdi-home', path: '/', description: 'Overview of the Moon control center.'},
+  {title: 'Setup', icon: 'mdi-cog-play', path: '/setup', description: 'Guide for configuring your deployment.'},
+  {title: 'Warden', icon: 'mdi-shield-crown', path: '/warden', description: 'Orchestrator for the entire stack.'},
+  {title: 'Vault', icon: 'mdi-safe-square', path: '/vault', description: 'Authentication and data access gateway.'},
+  {title: 'Portal', icon: 'mdi-transit-connection-variant', path: '/portal', description: 'External integrations hub.'},
+  {title: 'Sage', icon: 'mdi-chart-box-outline', path: '/sage', description: 'Monitoring and logging backbone.'},
+  {title: 'Moon Service', icon: 'mdi-moon-waning-crescent', path: '/moon-service', description: 'Web-based control center features.'},
+  {title: 'Raven', icon: 'mdi-crow', path: '/raven', description: 'Custom Java-based scraper/downloader.'},
+  {title: 'Oracle', icon: 'mdi-crystal-ball', path: '/oracle', description: 'AI assistant layer for insights.'},
+];
 
 // Collapse sidebar after navigation (especially for mobile)
 const navigate = (path) => {
@@ -52,11 +64,18 @@ watch(drawer, (val) => {
         <v-list-item prepend-icon="mdi-theme-light-dark" @click="toggleDark">
           <v-list-item-title>Toggle Dark Mode</v-list-item-title>
         </v-list-item>
-        <v-list-item prepend-icon="mdi-cog" @click="navigate('/setup')">
-          <v-list-item-title>Go to Setup</v-list-item-title>
-        </v-list-item>
-        <v-list-item prepend-icon="mdi-crow" @click="navigate('/raven')">
-          <v-list-item-title>Go to Raven</v-list-item-title>
+        <v-divider class="my-4"/>
+        <v-list-subheader>Explore Services</v-list-subheader>
+        <v-list-item
+            v-for="item in navigationItems"
+            :key="item.path"
+            :prepend-icon="item.icon"
+            :active="route.path === item.path"
+            rounded
+            @click="navigate(item.path)"
+        >
+          <v-list-item-title>{{ item.title }}</v-list-item-title>
+          <v-list-item-subtitle>{{ item.description }}</v-list-item-subtitle>
         </v-list-item>
       </v-list>
     </v-navigation-drawer>

--- a/services/moon/src/components/__tests__/Header.test.ts
+++ b/services/moon/src/components/__tests__/Header.test.ts
@@ -5,7 +5,7 @@ const push = vi.fn();
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push }),
-  useRoute: () => ({ name: 'Test Route' }),
+  useRoute: () => ({ name: 'Test Route', path: '/raven' }),
 }));
 
 vi.mock('vuetify', () => ({
@@ -23,6 +23,7 @@ const stubs = {
   'v-app': { template: '<div><slot /></div>' },
   'v-navigation-drawer': { template: '<aside><slot /></aside>' },
   'v-list': { template: '<div><slot /></div>' },
+  'v-list-subheader': { template: '<div><slot /></div>' },
   'v-list-item': {
     props: ['prependIcon'],
     emits: ['click'],
@@ -30,6 +31,7 @@ const stubs = {
       '<button class="v-list-item" type="button" @click="$emit(\'click\')"><slot /></button>',
   },
   'v-list-item-title': { template: '<span><slot /></span>' },
+  'v-list-item-subtitle': { template: '<small><slot /></small>' },
   'v-divider': { template: '<hr />' },
   'v-app-bar': { template: '<header><slot /></header>' },
   'v-app-bar-nav-icon': {
@@ -66,7 +68,7 @@ describe('Header navigation', () => {
 
     const ravenItem = wrapper
       .findAll('.v-list-item')
-      .find((item) => item.text().includes('Go to Raven'));
+      .find((item) => item.text().includes('Raven'));
 
     expect(ravenItem).toBeDefined();
     await ravenItem!.trigger('click');

--- a/services/moon/src/pages/Home.vue
+++ b/services/moon/src/pages/Home.vue
@@ -1,16 +1,100 @@
-﻿<script setup>
+<script setup>
 import Header from '../components/Header.vue';
+
+const servicePages = [
+  {
+    title: 'Warden',
+    summary:
+      'Orchestrator for the entire stack. Builds Docker images, provisions containers, enforces boot order, performs health checks, and manages rolling updates across master and node deployments.',
+    path: '/warden',
+    icon: 'mdi-shield-crown',
+  },
+  {
+    title: 'Vault',
+    summary:
+      'Authentication and data access gateway. Issues JWTs to services, brokers reads/writes to MongoDB and Redis, and secures internal APIs.',
+    path: '/vault',
+    icon: 'mdi-safe-square',
+  },
+  {
+    title: 'Portal',
+    summary:
+      "External integrations hub. Handles Discord command logic, listens for guild events, and bridges to Kavita's APIs.",
+    path: '/portal',
+    icon: 'mdi-transit-connection-variant',
+  },
+  {
+    title: 'Sage',
+    summary:
+      'Monitoring and logging backbone using Prometheus for metrics collection and Grafana for visualization.',
+    path: '/sage',
+    icon: 'mdi-chart-box-outline',
+  },
+  {
+    title: 'Moon Service',
+    summary:
+      'Web-based control center built with React. Provides dashboards for admins and readers, Discord authentication, AI chat, request management, and service status.',
+    path: '/moon-service',
+    icon: 'mdi-moon-waning-crescent',
+  },
+  {
+    title: 'Raven',
+    summary:
+      'Custom Java-based scraper/downloader. Automates content acquisition, metadata enrichment, and CBZ packaging.',
+    path: '/raven',
+    icon: 'mdi-crow',
+  },
+  {
+    title: 'Oracle',
+    summary:
+      'AI assistant layer powered by LangChain, LocalAI/AnythingLLM for conversational insights and recommendations.',
+    path: '/oracle',
+    icon: 'mdi-crystal-ball',
+  },
+];
 </script>
 
 <template>
   <Header>
-    <v-container class="fill-height d-flex align-center justify-center">
-      <v-card class="pa-10 text-center" elevation="12" width="500">
-        <v-img class="mx-auto mb-6" max-width="100" src="/logo.svg"/>
-        <v-card-title class="text-h4 mb-2">Welcome to Noona</v-card-title>
-        <v-card-subtitle>Let’s get started by exploring the setup wizard.</v-card-subtitle>
-        <v-btn class="mt-6" color="primary" @click="$router.push('/setup')">Go to Setup</v-btn>
-      </v-card>
+    <v-container class="py-12">
+      <v-row justify="center" class="mb-12">
+        <v-col cols="12" md="8" lg="6">
+          <v-card class="pa-10 text-center" elevation="12">
+            <v-img class="mx-auto mb-6" max-width="100" src="/logo.svg"/>
+            <v-card-title class="text-h4 mb-2">Welcome to Noona</v-card-title>
+            <v-card-subtitle class="mb-6">
+              Explore the control surfaces for every service or jump straight into the setup wizard.
+            </v-card-subtitle>
+            <v-btn color="primary" size="large" @click="$router.push('/setup')">
+              Launch Setup Wizard
+            </v-btn>
+          </v-card>
+        </v-col>
+      </v-row>
+
+      <v-row class="service-grid" dense>
+        <v-col
+            v-for="service in servicePages"
+            :key="service.path"
+            cols="12"
+            md="6"
+            lg="4"
+        >
+          <v-card class="h-100 d-flex flex-column justify-space-between" elevation="4">
+            <div class="pa-6">
+              <v-icon :icon="service.icon" size="40" class="mb-4 text-primary"/>
+              <h2 class="text-h5 mb-3">{{ service.title }}</h2>
+              <p class="text-body-2 mb-6">{{ service.summary }}</p>
+            </div>
+            <v-divider/>
+            <v-card-actions>
+              <v-btn block color="secondary" variant="text" @click="$router.push(service.path)">
+                View {{ service.title }}
+              </v-btn>
+            </v-card-actions>
+          </v-card>
+        </v-col>
+      </v-row>
     </v-container>
   </Header>
 </template>

--- a/services/moon/src/pages/MoonService.vue
+++ b/services/moon/src/pages/MoonService.vue
@@ -1,0 +1,56 @@
+<script setup>
+import Header from '../components/Header.vue';
+
+const service = {
+  title: 'Moon',
+  summary:
+    'Web-based control center built with React. Provides dashboards for admins and readers, Discord authentication, AI chat, request management, and service status.',
+  points: [
+    'Deliver dashboards tailored to admins and readers.',
+    'Support Discord authentication to unify access control.',
+    'Offer AI chat, request management, and live service status in one place.',
+  ],
+};
+</script>
+
+<template>
+  <Header>
+    <section class="service-page">
+      <h1 class="service-title">{{ service.title }}</h1>
+      <p class="service-summary">{{ service.summary }}</p>
+      <ul class="service-points">
+        <li v-for="point in service.points" :key="point">
+          {{ point }}
+        </li>
+      </ul>
+    </section>
+  </Header>
+</template>
+
+<style scoped>
+.service-page {
+  display: grid;
+  gap: 1.5rem;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 3rem 1rem 4rem;
+  text-align: center;
+}
+
+.service-title {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 700;
+}
+
+.service-summary {
+  font-size: 1.125rem;
+  line-height: 1.7;
+}
+
+.service-points {
+  display: grid;
+  gap: 0.75rem;
+  padding-left: 1.25rem;
+  text-align: left;
+}
+</style>

--- a/services/moon/src/pages/Oracle.vue
+++ b/services/moon/src/pages/Oracle.vue
@@ -1,0 +1,56 @@
+<script setup>
+import Header from '../components/Header.vue';
+
+const service = {
+  title: 'Oracle',
+  summary:
+    'AI assistant layer powered by LangChain, LocalAI/AnythingLLM for conversational insights and recommendations.',
+  points: [
+    'Leverage LangChain orchestration for contextual conversations.',
+    'Run on LocalAI or AnythingLLM to stay fully self-hosted.',
+    'Provide actionable insights and recommendations to every service.',
+  ],
+};
+</script>
+
+<template>
+  <Header>
+    <section class="service-page">
+      <h1 class="service-title">{{ service.title }}</h1>
+      <p class="service-summary">{{ service.summary }}</p>
+      <ul class="service-points">
+        <li v-for="point in service.points" :key="point">
+          {{ point }}
+        </li>
+      </ul>
+    </section>
+  </Header>
+</template>
+
+<style scoped>
+.service-page {
+  display: grid;
+  gap: 1.5rem;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 3rem 1rem 4rem;
+  text-align: center;
+}
+
+.service-title {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 700;
+}
+
+.service-summary {
+  font-size: 1.125rem;
+  line-height: 1.7;
+}
+
+.service-points {
+  display: grid;
+  gap: 0.75rem;
+  padding-left: 1.25rem;
+  text-align: left;
+}
+</style>

--- a/services/moon/src/pages/Portal.vue
+++ b/services/moon/src/pages/Portal.vue
@@ -1,0 +1,56 @@
+<script setup>
+import Header from '../components/Header.vue';
+
+const service = {
+  title: 'Portal',
+  summary:
+    "External integrations hub. Handles Discord command logic, listens for guild events, and bridges to Kavita's APIs.",
+  points: [
+    'Handle Discord command logic for server automation.',
+    'Listen for guild events to keep the community in sync.',
+    "Bridge to Kavita's APIs so libraries stay connected.",
+  ],
+};
+</script>
+
+<template>
+  <Header>
+    <section class="service-page">
+      <h1 class="service-title">{{ service.title }}</h1>
+      <p class="service-summary">{{ service.summary }}</p>
+      <ul class="service-points">
+        <li v-for="point in service.points" :key="point">
+          {{ point }}
+        </li>
+      </ul>
+    </section>
+  </Header>
+</template>
+
+<style scoped>
+.service-page {
+  display: grid;
+  gap: 1.5rem;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 3rem 1rem 4rem;
+  text-align: center;
+}
+
+.service-title {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 700;
+}
+
+.service-summary {
+  font-size: 1.125rem;
+  line-height: 1.7;
+}
+
+.service-points {
+  display: grid;
+  gap: 0.75rem;
+  padding-left: 1.25rem;
+  text-align: left;
+}
+</style>

--- a/services/moon/src/pages/Sage.vue
+++ b/services/moon/src/pages/Sage.vue
@@ -1,0 +1,56 @@
+<script setup>
+import Header from '../components/Header.vue';
+
+const service = {
+  title: 'Sage',
+  summary:
+    'Monitoring and logging backbone using Prometheus for metrics collection and Grafana for visualization.',
+  points: [
+    'Collect detailed metrics with Prometheus scraping.',
+    'Visualize service health and performance in Grafana dashboards.',
+    'Centralize logs to keep operational insights close at hand.',
+  ],
+};
+</script>
+
+<template>
+  <Header>
+    <section class="service-page">
+      <h1 class="service-title">{{ service.title }}</h1>
+      <p class="service-summary">{{ service.summary }}</p>
+      <ul class="service-points">
+        <li v-for="point in service.points" :key="point">
+          {{ point }}
+        </li>
+      </ul>
+    </section>
+  </Header>
+</template>
+
+<style scoped>
+.service-page {
+  display: grid;
+  gap: 1.5rem;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 3rem 1rem 4rem;
+  text-align: center;
+}
+
+.service-title {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 700;
+}
+
+.service-summary {
+  font-size: 1.125rem;
+  line-height: 1.7;
+}
+
+.service-points {
+  display: grid;
+  gap: 0.75rem;
+  padding-left: 1.25rem;
+  text-align: left;
+}
+</style>

--- a/services/moon/src/pages/Vault.vue
+++ b/services/moon/src/pages/Vault.vue
@@ -1,0 +1,56 @@
+<script setup>
+import Header from '../components/Header.vue';
+
+const service = {
+  title: 'Vault',
+  summary:
+    'Authentication and data access gateway. Issues JWTs to services, brokers reads/writes to MongoDB and Redis, and secures internal APIs.',
+  points: [
+    'Issue JWTs so services can authenticate every request.',
+    'Broker reads and writes across MongoDB and Redis backends.',
+    'Secure internal APIs that the rest of the stack depends on.',
+  ],
+};
+</script>
+
+<template>
+  <Header>
+    <section class="service-page">
+      <h1 class="service-title">{{ service.title }}</h1>
+      <p class="service-summary">{{ service.summary }}</p>
+      <ul class="service-points">
+        <li v-for="point in service.points" :key="point">
+          {{ point }}
+        </li>
+      </ul>
+    </section>
+  </Header>
+</template>
+
+<style scoped>
+.service-page {
+  display: grid;
+  gap: 1.5rem;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 3rem 1rem 4rem;
+  text-align: center;
+}
+
+.service-title {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 700;
+}
+
+.service-summary {
+  font-size: 1.125rem;
+  line-height: 1.7;
+}
+
+.service-points {
+  display: grid;
+  gap: 0.75rem;
+  padding-left: 1.25rem;
+  text-align: left;
+}
+</style>

--- a/services/moon/src/pages/Warden.vue
+++ b/services/moon/src/pages/Warden.vue
@@ -1,0 +1,56 @@
+<script setup>
+import Header from '../components/Header.vue';
+
+const service = {
+  title: 'Warden',
+  summary:
+    'Orchestrator for the entire stack. Builds Docker images, provisions containers, enforces boot order, performs health checks, and manages rolling updates across master and node deployments.',
+  points: [
+    'Build Docker images to keep every service reproducible.',
+    'Provision containers with an enforced boot order for reliable startups.',
+    'Perform health checks and rolling updates across master and node deployments.',
+  ],
+};
+</script>
+
+<template>
+  <Header>
+    <section class="service-page">
+      <h1 class="service-title">{{ service.title }}</h1>
+      <p class="service-summary">{{ service.summary }}</p>
+      <ul class="service-points">
+        <li v-for="point in service.points" :key="point">
+          {{ point }}
+        </li>
+      </ul>
+    </section>
+  </Header>
+</template>
+
+<style scoped>
+.service-page {
+  display: grid;
+  gap: 1.5rem;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 3rem 1rem 4rem;
+  text-align: center;
+}
+
+.service-title {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 700;
+}
+
+.service-summary {
+  font-size: 1.125rem;
+  line-height: 1.7;
+}
+
+.service-points {
+  display: grid;
+  gap: 0.75rem;
+  padding-left: 1.25rem;
+  text-align: left;
+}
+</style>

--- a/services/moon/src/pages/__tests__/Services.test.ts
+++ b/services/moon/src/pages/__tests__/Services.test.ts
@@ -1,0 +1,63 @@
+import {describe, expect, it} from 'vitest';
+import {mount} from '@vue/test-utils';
+import Warden from '../Warden.vue';
+import Vault from '../Vault.vue';
+import Portal from '../Portal.vue';
+import Sage from '../Sage.vue';
+import MoonService from '../MoonService.vue';
+import Oracle from '../Oracle.vue';
+
+const mountWithLayout = (component: any) =>
+  mount(component, {
+    global: {
+      stubs: {
+        Header: {
+          template: '<div><slot /></div>',
+        },
+      },
+    },
+  });
+
+describe('Service summary pages', () => {
+  it('renders Warden summary', () => {
+    const wrapper = mountWithLayout(Warden);
+    expect(wrapper.text()).toContain(
+      'Orchestrator for the entire stack. Builds Docker images, provisions containers, enforces boot order, performs health checks, and manages rolling updates across master and node deployments.',
+    );
+  });
+
+  it('renders Vault summary', () => {
+    const wrapper = mountWithLayout(Vault);
+    expect(wrapper.text()).toContain(
+      'Authentication and data access gateway. Issues JWTs to services, brokers reads/writes to MongoDB and Redis, and secures internal APIs.',
+    );
+  });
+
+  it('renders Portal summary', () => {
+    const wrapper = mountWithLayout(Portal);
+    expect(wrapper.text()).toContain(
+      "External integrations hub. Handles Discord command logic, listens for guild events, and bridges to Kavita's APIs.",
+    );
+  });
+
+  it('renders Sage summary', () => {
+    const wrapper = mountWithLayout(Sage);
+    expect(wrapper.text()).toContain(
+      'Monitoring and logging backbone using Prometheus for metrics collection and Grafana for visualization.',
+    );
+  });
+
+  it('renders Moon service summary', () => {
+    const wrapper = mountWithLayout(MoonService);
+    expect(wrapper.text()).toContain(
+      'Web-based control center built with React. Provides dashboards for admins and readers, Discord authentication, AI chat, request management, and service status.',
+    );
+  });
+
+  it('renders Oracle summary', () => {
+    const wrapper = mountWithLayout(Oracle);
+    expect(wrapper.text()).toContain(
+      'AI assistant layer powered by LangChain, LocalAI/AnythingLLM for conversational insights and recommendations.',
+    );
+  });
+});

--- a/services/moon/src/router/index.js
+++ b/services/moon/src/router/index.js
@@ -1,4 +1,4 @@
-﻿import {createRouter, createWebHistory} from 'vue-router';
+import {createRouter, createWebHistory} from 'vue-router';
 
 const routes = [
     {
@@ -12,9 +12,39 @@ const routes = [
         component: () => import('../pages/Setup.vue'), // lazy-loaded
     },
     {
+        path: '/warden',
+        name: 'Warden',
+        component: () => import('../pages/Warden.vue'),
+    },
+    {
+        path: '/vault',
+        name: 'Vault',
+        component: () => import('../pages/Vault.vue'),
+    },
+    {
+        path: '/portal',
+        name: 'Portal',
+        component: () => import('../pages/Portal.vue'),
+    },
+    {
+        path: '/sage',
+        name: 'Sage',
+        component: () => import('../pages/Sage.vue'),
+    },
+    {
+        path: '/moon-service',
+        name: 'Moon Service',
+        component: () => import('../pages/MoonService.vue'),
+    },
+    {
         path: '/raven',
         name: 'Raven',
         component: () => import('../pages/Raven.vue'),
+    },
+    {
+        path: '/oracle',
+        name: 'Oracle',
+        component: () => import('../pages/Oracle.vue'),
     },
 ];
 


### PR DESCRIPTION
## Summary
- add informational pages for Warden, Vault, Portal, Sage, Moon, and Oracle that surface the README service summaries
- register the new routes, expand the header navigation, and highlight the links from the refreshed home page
- cover the new content with lightweight component tests alongside the existing header test adjustments

## Testing
- npm test --prefix services/moon

------
https://chatgpt.com/codex/tasks/task_e_68e1cc718cc48331817d81797ca3024e