### PR TITLE
Add Discord setup flow for Portal configuration

### DIFF
--- a/services/moon/src/pages/__tests__/Setup.test.ts
+++ b/services/moon/src/pages/__tests__/Setup.test.ts
@@ -38,10 +38,16 @@ const stubs = {
   },
   'v-expand-transition': { template: '<div><slot /></div>' },
   'v-text-field': {
-    template: '<input data-test="text-field" />',
+    props: ['modelValue', 'disabled', 'readonly', 'dataTest'],
+    emits: ['update:modelValue'],
+    template:
+      '<input :value="modelValue" :disabled="disabled" :readonly="readonly" :data-test="dataTest || `text-field`" @input="$emit(\'update:modelValue\', $event.target.value)" />',
   },
   'v-select': {
-    template: '<select data-test="boolean-select"><slot /></select>',
+    props: ['modelValue', 'disabled', 'dataTest'],
+    emits: ['update:modelValue'],
+    template:
+      '<select :value="modelValue" :disabled="disabled" :data-test="dataTest || `boolean-select`" @change="$emit(\'update:modelValue\', $event.target.value)"><slot /></select>',
   },
   'v-checkbox': {
     props: ['modelValue', 'disabled'],
@@ -73,7 +79,16 @@ const servicesPayload = {
     {
       name: 'noona-portal',
       installed: false,
-      envConfig: [],
+      envConfig: [
+        { key: 'DISCORD_BOT_TOKEN', label: 'Discord Bot Token' },
+        { key: 'DISCORD_GUILD_ID', label: 'Discord Guild ID' },
+        { key: 'DISCORD_GUILD_ROLE_ID', label: 'Default Role' },
+        {
+          key: 'DISCORD_ONBOARDING_CHANNEL_ID',
+          label: 'Onboarding Channel',
+        },
+        { key: 'PORTAL_HTTP_TIMEOUT', label: 'Portal HTTP Timeout' },
+      ],
     },
     {
       name: 'noona-vault',
@@ -87,6 +102,9 @@ const servicesPayload = {
     },
   ],
 };
+
+const PORTAL_TOKEN_KEY = 'DISCORD_BOT_TOKEN';
+const PORTAL_GUILD_KEY = 'DISCORD_GUILD_ID';
 
 describe('Setup page', () => {
   afterEach(() => {
@@ -127,6 +145,154 @@ describe('Setup page', () => {
 
     const selects = wrapper.findAll('select[data-test="boolean-select"]');
     expect(selects.length).toBeGreaterThan(0);
+  });
+
+  it('requires Discord validation before unlocking portal resources', async () => {
+    const discordPayload = {
+      guild: { id: '123', name: 'Noona Guild' },
+      roles: [{ id: '456', name: 'Reader', position: 1 }],
+      channels: [{ id: '789', name: 'general', type: 'GUILD_TEXT' }],
+    };
+
+    const fetchMock = vi.fn<(url: RequestInfo | URL) => Promise<Response>>((url) => {
+      const target = typeof url === 'string' ? url : url instanceof URL ? url.toString() : '';
+      if (target.includes('/discord/validate')) {
+        return Promise.resolve(mockResponse(discordPayload));
+      }
+      return Promise.resolve(mockResponse(servicesPayload));
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fetchMock);
+
+    const wrapper = mount(SetupPage, {
+      global: { stubs },
+    });
+
+    await flushAsync();
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as {
+      $: {
+        setupState: {
+          activeStepIndex: number;
+          expandedCards: string[];
+          envForms: Record<string, Record<string, string>>;
+          portalDiscordState: { verified: boolean };
+          connectPortalDiscord: () => Promise<void>;
+        };
+      };
+    };
+
+    vm.$.setupState.activeStepIndex = 1;
+    vm.$.setupState.expandedCards = ['noona-portal'];
+    await wrapper.vm.$nextTick();
+
+    const timeoutFieldBefore = wrapper.find('input[data-test="portal-field-PORTAL_HTTP_TIMEOUT"]');
+    expect(timeoutFieldBefore.attributes('disabled')).toBeDefined();
+
+    const roleSelectBefore = wrapper.find(
+      'select[data-test="portal-resource-DISCORD_GUILD_ROLE_ID"]',
+    );
+    expect(roleSelectBefore.attributes('disabled')).toBeDefined();
+
+    const envForms = vm.$.setupState.envForms;
+    envForms['noona-portal'][PORTAL_TOKEN_KEY] = 'token-value';
+    envForms['noona-portal'][PORTAL_GUILD_KEY] = 'guild-value';
+    await wrapper.vm.$nextTick();
+
+    await vm.$.setupState.connectPortalDiscord();
+    await flushAsync();
+    await wrapper.vm.$nextTick();
+
+    expect(vm.$.setupState.portalDiscordState.verified).toBe(true);
+
+    const roleSelectAfter = wrapper.find(
+      'select[data-test="portal-resource-DISCORD_GUILD_ROLE_ID"]',
+    );
+    expect(roleSelectAfter.attributes('disabled')).toBeUndefined();
+
+    const timeoutFieldAfter = wrapper.find('input[data-test="portal-field-PORTAL_HTTP_TIMEOUT"]');
+    expect(timeoutFieldAfter.attributes('disabled')).toBeUndefined();
+
+    const successAlert = wrapper.find('[data-test="portal-success"]');
+    expect(successAlert.exists()).toBe(true);
+  });
+
+  it('persists new Discord resources created from the setup flow', async () => {
+    const discordPayload = {
+      guild: { id: '123', name: 'Noona Guild' },
+      roles: [{ id: '456', name: 'Reader', position: 1 }],
+      channels: [{ id: '789', name: 'general', type: 'GUILD_TEXT' }],
+    };
+
+    const fetchMock = vi.fn<(url: RequestInfo | URL) => Promise<Response>>((url) => {
+      const target = typeof url === 'string' ? url : url instanceof URL ? url.toString() : '';
+      if (target.includes('/discord/roles')) {
+        return Promise.resolve(
+          mockResponse({ role: { id: 'role-2', name: 'Curator', position: 2 } }),
+        );
+      }
+      if (target.includes('/discord/channels')) {
+        return Promise.resolve(
+          mockResponse({ channel: { id: 'channel-2', name: 'welcome', type: 'GUILD_TEXT' } }),
+        );
+      }
+      if (target.includes('/discord/validate')) {
+        return Promise.resolve(mockResponse(discordPayload));
+      }
+      return Promise.resolve(mockResponse(servicesPayload));
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fetchMock);
+
+    const wrapper = mount(SetupPage, {
+      global: { stubs },
+    });
+
+    await flushAsync();
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as {
+      $: {
+        setupState: {
+          activeStepIndex: number;
+          expandedCards: string[];
+          envForms: Record<string, Record<string, string>>;
+          portalDiscordState: {
+            verified: boolean;
+            createRole: { name: string };
+            createChannel: { name: string };
+          };
+          connectPortalDiscord: () => Promise<void>;
+          handleCreatePortalRole: (fieldKey: string) => Promise<void>;
+          handleCreatePortalChannel: (fieldKey: string) => Promise<void>;
+        };
+      };
+    };
+
+    vm.$.setupState.activeStepIndex = 1;
+    vm.$.setupState.expandedCards = ['noona-portal'];
+    const envForms = vm.$.setupState.envForms;
+    envForms['noona-portal'][PORTAL_TOKEN_KEY] = 'token-value';
+    envForms['noona-portal'][PORTAL_GUILD_KEY] = 'guild-value';
+
+    await vm.$.setupState.connectPortalDiscord();
+    await flushAsync();
+    await wrapper.vm.$nextTick();
+
+    vm.$.setupState.portalDiscordState.createRole.name = 'Curator';
+    await vm.$.setupState.handleCreatePortalRole('DISCORD_GUILD_ROLE_ID');
+    await flushAsync();
+    await wrapper.vm.$nextTick();
+
+    expect(envForms['noona-portal'].DISCORD_GUILD_ROLE_ID).toBe('role-2');
+
+    vm.$.setupState.portalDiscordState.createChannel.name = 'welcome';
+    await vm.$.setupState.handleCreatePortalChannel('DISCORD_ONBOARDING_CHANNEL_ID');
+    await flushAsync();
+    await wrapper.vm.$nextTick();
+
+    expect(envForms['noona-portal'].DISCORD_ONBOARDING_CHANNEL_ID).toBe('channel-2');
   });
 
   it('shows the success message after completing the Raven install', async () => {

--- a/services/moon/src/utils/portalDiscordSetup.js
+++ b/services/moon/src/utils/portalDiscordSetup.js
@@ -1,0 +1,71 @@
+const PORTAL_DISCORD_VALIDATE_ENDPOINT =
+  '/api/setup/services/noona-portal/discord/validate';
+const PORTAL_DISCORD_ROLES_ENDPOINT =
+  '/api/setup/services/noona-portal/discord/roles';
+const PORTAL_DISCORD_CHANNELS_ENDPOINT =
+  '/api/setup/services/noona-portal/discord/channels';
+
+const parseResponse = async (response, fallbackError) => {
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const message =
+      typeof payload?.error === 'string' && payload.error.trim()
+        ? payload.error.trim()
+        : fallbackError;
+    throw new Error(message);
+  }
+
+  return payload;
+};
+
+export const validatePortalDiscordConfig = async ({ token, guildId }) => {
+  const response = await fetch(PORTAL_DISCORD_VALIDATE_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token, guildId }),
+  });
+
+  return await parseResponse(
+    response,
+    'Unable to verify the provided Discord credentials.',
+  );
+};
+
+export const createPortalDiscordRole = async ({ token, guildId, name }) => {
+  const response = await fetch(PORTAL_DISCORD_ROLES_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token, guildId, name }),
+  });
+
+  const payload = await parseResponse(
+    response,
+    'Unable to create a new Discord role.',
+  );
+  return payload?.role ?? null;
+};
+
+export const createPortalDiscordChannel = async ({
+  token,
+  guildId,
+  name,
+  type,
+}) => {
+  const response = await fetch(PORTAL_DISCORD_CHANNELS_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token, guildId, name, type }),
+  });
+
+  const payload = await parseResponse(
+    response,
+    'Unable to create a new Discord channel.',
+  );
+  return payload?.channel ?? null;
+};
+
+export default {
+  validatePortalDiscordConfig,
+  createPortalDiscordRole,
+  createPortalDiscordChannel,
+};

--- a/services/sage/shared/discordSetupClient.mjs
+++ b/services/sage/shared/discordSetupClient.mjs
@@ -1,0 +1,213 @@
+// services/sage/shared/discordSetupClient.mjs
+
+import createDiscordClient from '../../portal/shared/discordClient.mjs'
+import { SetupValidationError } from './errors.mjs'
+
+const normalizeString = (value) => {
+    if (typeof value !== 'string') {
+        return ''
+    }
+
+    const trimmed = value.trim()
+    return trimmed
+}
+
+const ensureNonEmpty = (value, label) => {
+    const normalized = normalizeString(value)
+    if (!normalized) {
+        throw new SetupValidationError(`${label} is required.`)
+    }
+
+    return normalized
+}
+
+const toArray = (collection) => {
+    if (!collection) {
+        return []
+    }
+
+    if (Array.isArray(collection)) {
+        return collection
+    }
+
+    if (typeof collection.values === 'function') {
+        return Array.from(collection.values())
+    }
+
+    if (collection.cache) {
+        return toArray(collection.cache)
+    }
+
+    if (typeof collection.forEach === 'function') {
+        const items = []
+        collection.forEach((value) => {
+            items.push(value)
+        })
+        return items
+    }
+
+    return []
+}
+
+const mapRole = (role) => ({
+    id: role?.id ?? null,
+    name: role?.name ?? null,
+    color: role?.hexColor ?? null,
+    position: typeof role?.position === 'number' ? role.position : null,
+    managed: Boolean(role?.managed),
+})
+
+const sortRoles = (a, b) => {
+    const posA = typeof a.position === 'number' ? a.position : 0
+    const posB = typeof b.position === 'number' ? b.position : 0
+    if (posA === posB) {
+        return (a.name ?? '').localeCompare(b.name ?? '')
+    }
+
+    return posB - posA
+}
+
+const mapChannel = (channel) => ({
+    id: channel?.id ?? null,
+    name: channel?.name ?? null,
+    type: channel?.type ?? null,
+})
+
+const isUsableRole = (role) => role?.id && !role.managed
+
+const isUsableChannel = (channel) => Boolean(channel?.id && (channel?.name ?? '').trim())
+
+const withDiscordClient = async ({ token, guildId, logger, serviceName }, handler) => {
+    const discordClient = createDiscordClient({
+        token,
+        guildId,
+        commands: new Map(),
+    })
+
+    try {
+        await discordClient.login()
+        return await handler(discordClient)
+    } finally {
+        try {
+            discordClient.destroy?.()
+        } catch (error) {
+            logger?.error?.(
+                `[${serviceName}] ⚠️ Failed to clean up Discord client: ${error instanceof Error ? error.message : error}`,
+            )
+        }
+    }
+}
+
+export const createDiscordSetupClient = ({ logger, serviceName = 'noona-sage' } = {}) => {
+    const resolveCredentials = (credentials = {}) => ({
+        token: ensureNonEmpty(credentials.token, 'Discord bot token'),
+        guildId: ensureNonEmpty(credentials.guildId, 'Discord guild id'),
+    })
+
+    return {
+        async fetchResources(credentials = {}) {
+            const { token, guildId } = resolveCredentials(credentials)
+
+            return await withDiscordClient({ token, guildId, logger, serviceName }, async (client) => {
+                const guild = await client.fetchGuild()
+                if (!guild) {
+                    throw new Error('Discord guild could not be retrieved.')
+                }
+
+                let roles = []
+                try {
+                    const fetchedRoles = guild.roles?.fetch ? await guild.roles.fetch() : guild.roles
+                    roles = toArray(fetchedRoles).map(mapRole).filter(isUsableRole).sort(sortRoles)
+                } catch (error) {
+                    logger?.error?.(
+                        `[${serviceName}] ⚠️ Failed to load Discord roles: ${error instanceof Error ? error.message : error}`,
+                    )
+                    roles = []
+                }
+
+                let channels = []
+                try {
+                    const fetchedChannels = guild.channels?.fetch ? await guild.channels.fetch() : guild.channels
+                    channels = toArray(fetchedChannels).map(mapChannel).filter(isUsableChannel)
+                } catch (error) {
+                    logger?.error?.(
+                        `[${serviceName}] ⚠️ Failed to load Discord channels: ${error instanceof Error ? error.message : error}`,
+                    )
+                    channels = []
+                }
+
+                const summary = {
+                    id: guild.id ?? guildId,
+                    name: guild.name ?? null,
+                    description: guild.description ?? null,
+                    icon: guild.icon ?? null,
+                }
+
+                const resourceSummary =
+                    `[${serviceName}] 🤖 Verified Discord guild ${summary.name || summary.id} with ${roles.length} roles and ${channels.length} channels`
+                logger?.info?.(resourceSummary)
+
+                return { guild: summary, roles, channels }
+            })
+        },
+
+        async createRole(credentials = {}) {
+            const { token, guildId } = resolveCredentials(credentials)
+            const name = ensureNonEmpty(credentials.name, 'Role name')
+
+            return await withDiscordClient({ token, guildId, logger, serviceName }, async (client) => {
+                const guild = await client.fetchGuild()
+                if (!guild) {
+                    throw new Error('Discord guild could not be retrieved.')
+                }
+
+                const role = await guild.roles?.create?.({
+                    name,
+                    reason: 'Requested during Noona setup',
+                })
+
+                if (!role) {
+                    throw new Error('Discord did not return a newly created role.')
+                }
+
+                const mapped = mapRole(role)
+                logger?.info?.(
+                    `[${serviceName}] 🎨 Created Discord role ${mapped.name || mapped.id} for guild ${guildId}`,
+                )
+                return mapped
+            })
+        },
+
+        async createChannel(credentials = {}) {
+            const { token, guildId } = resolveCredentials(credentials)
+            const name = ensureNonEmpty(credentials.name, 'Channel name')
+            const type = normalizeString(credentials.type) || null
+
+            return await withDiscordClient({ token, guildId, logger, serviceName }, async (client) => {
+                const guild = await client.fetchGuild()
+                if (!guild) {
+                    throw new Error('Discord guild could not be retrieved.')
+                }
+
+                const createOptions = { name, reason: 'Requested during Noona setup' }
+                if (type) {
+                    createOptions.type = type
+                }
+
+                const channel = await guild.channels?.create?.(createOptions)
+
+                if (!channel) {
+                    throw new Error('Discord did not return a newly created channel.')
+                }
+
+                const mapped = mapChannel(channel)
+                logger?.info?.(
+                    `[${serviceName}] 📢 Created Discord channel ${mapped.name || mapped.id} for guild ${guildId}`,
+                )
+                return mapped
+            })
+        },
+    }
+}
+
+export default createDiscordSetupClient

--- a/services/sage/shared/errors.mjs
+++ b/services/sage/shared/errors.mjs
@@ -1,0 +1,10 @@
+// services/sage/shared/errors.mjs
+
+export class SetupValidationError extends Error {
+    constructor(message) {
+        super(message)
+        this.name = 'SetupValidationError'
+    }
+}
+
+export default SetupValidationError


### PR DESCRIPTION
## Summary
- gate Portal environment fields on Discord token and guild verification with inline creation actions for roles and channels
- add frontend utilities and backend helpers to validate Discord credentials and manage guild resources during setup
- expand the setup test suite to cover the new interactive Portal configuration flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1cff0d7c88331a4c12cd374ffc516