### PR TITLE
Enforce Discord permissions for Portal slash commands

### DIFF
--- a/services/portal/shared/roleManager.mjs
+++ b/services/portal/shared/roleManager.mjs
@@ -1,0 +1,171 @@
+// services/portal/shared/roleManager.mjs
+
+const normalizeString = (value) => {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+};
+
+const normalizeCommandName = (commandName) => {
+    if (typeof commandName !== 'string') {
+        return '';
+    }
+
+    return commandName
+        .trim()
+        .toUpperCase()
+        .replace(/[^A-Z0-9]/g, '_');
+};
+
+const resolveGuildId = (interaction) =>
+    interaction?.guildId
+    ?? interaction?.guild?.id
+    ?? interaction?.member?.guild?.id
+    ?? null;
+
+const hasRoleInCollection = (collection, roleId) => {
+    if (!collection) {
+        return false;
+    }
+
+    if (typeof collection.has === 'function') {
+        try {
+            return collection.has(roleId);
+        } catch (error) {
+            return false;
+        }
+    }
+
+    if (typeof collection.get === 'function') {
+        try {
+            return collection.get(roleId) != null;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    if (Array.isArray(collection)) {
+        return collection.includes(roleId);
+    }
+
+    if (collection instanceof Set) {
+        return collection.has(roleId);
+    }
+
+    if (collection instanceof Map) {
+        return collection.has(roleId);
+    }
+
+    if (collection && typeof collection === 'object') {
+        return Object.prototype.hasOwnProperty.call(collection, roleId);
+    }
+
+    return false;
+};
+
+const memberHasRole = (member, roleId) => {
+    if (!roleId) {
+        return true;
+    }
+
+    if (!member) {
+        return false;
+    }
+
+    const sources = [];
+
+    if (member.roles) {
+        sources.push(member.roles);
+
+        if (member.roles.cache) {
+            sources.push(member.roles.cache);
+        }
+
+        if (Array.isArray(member.roles)) {
+            sources.push(member.roles);
+        }
+    }
+
+    if (Array.isArray(member._roles)) {
+        sources.push(member._roles);
+    }
+
+    sources.push(member);
+
+    return sources.some(source => hasRoleInCollection(source, roleId));
+};
+
+const resolveDeniedMessage = ({ reason }) => {
+    switch (reason) {
+    case 'guild':
+        return 'This command can only be used inside the configured Discord server.';
+    case 'role':
+        return 'You do not have permission to use this command.';
+    default:
+        return 'You do not have permission to use this command.';
+    }
+};
+
+export const createRoleManager = ({ env = process.env } = {}) => {
+    const requiredGuildId = normalizeString(env.REQUIRED_GUILD_ID);
+
+    const getRequiredRoleKey = (commandName) => {
+        const normalized = normalizeCommandName(commandName);
+        if (!normalized) {
+            return null;
+        }
+
+        return `REQUIRED_ROLE_${normalized}`;
+    };
+
+    const getRequiredRoleId = (commandName) => {
+        const key = getRequiredRoleKey(commandName);
+        if (!key) {
+            return null;
+        }
+
+        return normalizeString(env[key]);
+    };
+
+    const checkAccess = (interaction, commandName) => {
+        if (requiredGuildId) {
+            const interactionGuildId = resolveGuildId(interaction);
+            if (interactionGuildId !== requiredGuildId) {
+                return {
+                    allowed: false,
+                    reason: 'guild',
+                    message: resolveDeniedMessage({ reason: 'guild' }),
+                    requiredGuildId,
+                };
+            }
+        }
+
+        const requiredRoleId = getRequiredRoleId(commandName);
+        if (requiredRoleId && !memberHasRole(interaction?.member, requiredRoleId)) {
+            return {
+                allowed: false,
+                reason: 'role',
+                message: resolveDeniedMessage({ reason: 'role' }),
+                requiredRoleId,
+            };
+        }
+
+        return {
+            allowed: true,
+            requiredGuildId,
+            requiredRoleId,
+        };
+    };
+
+    return Object.freeze({
+        checkAccess,
+        getRequiredRoleId,
+        getRequiredRoleKey,
+        requiredGuildId,
+    });
+};
+
+export default createRoleManager;

--- a/services/warden/docker/noonaDockers.mjs
+++ b/services/warden/docker/noonaDockers.mjs
@@ -138,6 +138,18 @@ const serviceDefs = rawList.map(name => {
                 description: 'Identifier of the Discord server that the portal should connect to.',
             },
             {
+                key: 'DISCORD_GUILD_ROLE_ID',
+                label: 'Discord Guild Role ID',
+                description: 'Role identifier assigned to new members after onboarding.',
+                required: false,
+            },
+            {
+                key: 'DISCORD_DEFAULT_ROLE_ID',
+                label: 'Discord Default Role ID',
+                description: 'Fallback role identifier to grant onboarded members when a guild role is not specified.',
+                required: false,
+            },
+            {
                 key: 'KAVITA_BASE_URL',
                 label: 'Kavita Base URL',
                 description: 'Base URL of the Kavita instance providing library content.',
@@ -177,6 +189,36 @@ const serviceDefs = rawList.map(name => {
                 label: 'Portal HTTP Timeout',
                 description: 'HTTP client timeout in milliseconds for outbound portal requests.',
                 defaultValue: '10000',
+                required: false,
+            },
+            {
+                key: 'REQUIRED_GUILD_ID',
+                label: 'Required Discord Guild ID',
+                description: 'Restricts slash command usage to interactions originating from this guild ID.',
+                required: false,
+            },
+            {
+                key: 'REQUIRED_ROLE_DING',
+                label: 'Required Role for /ding',
+                description: 'Discord role ID required to execute the /ding command.',
+                required: false,
+            },
+            {
+                key: 'REQUIRED_ROLE_JOIN',
+                label: 'Required Role for /join',
+                description: 'Discord role ID required to execute the /join command.',
+                required: false,
+            },
+            {
+                key: 'REQUIRED_ROLE_SCAN',
+                label: 'Required Role for /scan',
+                description: 'Discord role ID required to execute the /scan command.',
+                required: false,
+            },
+            {
+                key: 'REQUIRED_ROLE_SEARCH',
+                label: 'Required Role for /search',
+                description: 'Discord role ID required to execute the /search command.',
                 required: false,
             },
         ];

--- a/services/warden/tests/vaultTokens.test.mjs
+++ b/services/warden/tests/vaultTokens.test.mjs
@@ -129,6 +129,16 @@ test('noona-portal descriptor exposes Redis and HTTP defaults', async () => {
         ['VAULT_BASE_URL', 'http://noona-vault:3005'],
     ];
 
+    const optionalDiscordExpectations = [
+        'DISCORD_GUILD_ROLE_ID',
+        'DISCORD_DEFAULT_ROLE_ID',
+        'REQUIRED_GUILD_ID',
+        'REQUIRED_ROLE_DING',
+        'REQUIRED_ROLE_JOIN',
+        'REQUIRED_ROLE_SCAN',
+        'REQUIRED_ROLE_SEARCH',
+    ];
+
     for (const [key, value] of requiredExpectations) {
         assert.ok(portal.env.includes(`${key}=${value}`), `${key} should be exported with default ${value}.`);
 
@@ -147,6 +157,17 @@ test('noona-portal descriptor exposes Redis and HTTP defaults', async () => {
         const field = portal.envConfig.find((entry) => entry.key === key);
         assert.ok(field, `Portal envConfig should include ${key}.`);
         assert.equal(field.defaultValue, value, `${key} default should match implicit behavior.`);
+        assert.equal(field.required, false, `${key} should be optional in setup UI.`);
+    }
+
+    for (const key of optionalDiscordExpectations) {
+        assert.ok(
+            portal.env.includes(`${key}=`),
+            `${key} should be exported so the setup wizard can collect it.`,
+        );
+
+        const field = portal.envConfig.find((entry) => entry.key === key);
+        assert.ok(field, `Portal envConfig should include ${key}.`);
         assert.equal(field.required, false, `${key} should be optional in setup UI.`);
     }
 });


### PR DESCRIPTION
## Summary
- add a shared role manager to gate Portal slash commands using REQUIRED_GUILD_ID and REQUIRED_ROLE_* environment variables
- check permissions in the Discord client before executing handlers and reply ephemerally when access is denied
- expose the additional Portal Discord environment fields to the setup wizard descriptor and cover them with tests

## Testing
- node --test services/portal/tests/discordClient.test.mjs
- node --test services/warden/tests/vaultTokens.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e1d386d5cc8331af218c627d2f179e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced role-based access control for Discord commands with clear permission-denied messaging.
  - Added configurable environment options for guild restriction and per-command role requirements (e.g., join, scan, search).
- Tests
  - Added coverage to ensure commands are blocked when guild or role requirements aren’t met, verifying user-facing denial responses.
- Chores
  - Expanded environment configuration to include optional Discord role and access-control fields, enabling easier setup and customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->