### PR TITLE
Hide setup UI when service setup complete

### DIFF
--- a/services/moon/src/components/__tests__/Header.test.ts
+++ b/services/moon/src/components/__tests__/Header.test.ts
@@ -90,4 +90,62 @@ describe('Header navigation', () => {
     await ravenItem!.trigger('click');
     expect(push).toHaveBeenCalledWith('/raven');
   });
+
+  it('shows Setup navigation while installations are pending', async () => {
+    (global as any).fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        services: [
+          { name: 'noona-warden', installed: false },
+        ],
+      }),
+    });
+
+    const store = useServiceInstallationStore();
+    await store.refresh();
+
+    const wrapper = mount(Header, {
+      global: {
+        stubs,
+      },
+    });
+
+    const setupItem = wrapper
+      .findAll('.v-list-item')
+      .find((item) => item.text().includes('Setup'));
+
+    expect(setupItem).toBeDefined();
+  });
+
+  it('hides Setup navigation once all installations are complete', async () => {
+    (global as any).fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        services: [
+          { name: 'noona-warden', installed: true },
+          { name: 'noona-vault', installed: true },
+          { name: 'noona-portal', installed: true },
+          { name: 'noona-sage', installed: true },
+          { name: 'noona-moon', installed: true },
+          { name: 'noona-raven', installed: true },
+          { name: 'noona-oracle', installed: true },
+        ],
+      }),
+    });
+
+    const store = useServiceInstallationStore();
+    await store.refresh();
+
+    const wrapper = mount(Header, {
+      global: {
+        stubs,
+      },
+    });
+
+    const setupItem = wrapper
+      .findAll('.v-list-item')
+      .find((item) => item.text().includes('Setup'));
+
+    expect(setupItem).toBeUndefined();
+  });
 });

--- a/services/moon/src/pages/Home.vue
+++ b/services/moon/src/pages/Home.vue
@@ -61,6 +61,8 @@ onMounted(() => {
   store.ensureLoaded();
 });
 
+const showSetupButton = computed(() => store.hasPendingSetup.value);
+
 const serviceCards = computed(() =>
   servicePages.map((service) => {
     const requiredService = getRequiredServiceForPath(service.path);
@@ -97,7 +99,13 @@ const serviceCards = computed(() =>
             <v-card-subtitle class="mb-6">
               Explore the control surfaces for every service or jump straight into the setup wizard.
             </v-card-subtitle>
-            <v-btn color="primary" size="large" @click="$router.push('/setup')">
+            <v-btn
+                v-if="showSetupButton"
+                color="primary"
+                size="large"
+                data-test="launch-setup"
+                @click="$router.push('/setup')"
+            >
               Launch Setup Wizard
             </v-btn>
           </v-card>

--- a/services/moon/src/pages/__tests__/Home.test.ts
+++ b/services/moon/src/pages/__tests__/Home.test.ts
@@ -57,6 +57,8 @@ describe('Home page service cards', () => {
     await flushAsync();
     await wrapper.vm.$nextTick();
 
+    expect(wrapper.find('[data-test="launch-setup"]').exists()).toBe(true);
+
     const wardenButton = wrapper.get('[data-test="service-link-/warden"]');
     expect(wardenButton.attributes('disabled')).toBeDefined();
     expect(wardenButton.attributes('title')).toContain('pending');
@@ -87,6 +89,8 @@ describe('Home page service cards', () => {
 
     await flushAsync();
     await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-test="launch-setup"]').exists()).toBe(false);
 
     const wardenButton = wrapper.get('[data-test="service-link-/warden"]');
     expect(wardenButton.attributes('disabled')).toBeUndefined();

--- a/services/moon/src/utils/serviceInstallationStore.js
+++ b/services/moon/src/utils/serviceInstallationStore.js
@@ -86,8 +86,19 @@ const installedServiceNames = computed(() => {
     return installed;
 });
 
+const hasPendingSetup = computed(() =>
+    SERVICE_NAVIGATION_CONFIG.some(
+        (item) =>
+            !!item.requiredService &&
+            !installedServiceNames.value.has(item.requiredService),
+    ),
+);
+
 const navigationItems = computed(() =>
     SERVICE_NAVIGATION_CONFIG.filter((item) => {
+        if (item.path === '/setup') {
+            return hasPendingSetup.value;
+        }
         if (!item.requiredService) {
             return true;
         }
@@ -184,6 +195,7 @@ export function useServiceInstallationStore() {
         loading: computed(() => state.loading),
         error: computed(() => state.error),
         navigationItems,
+        hasPendingSetup,
         ensureLoaded,
         refresh,
         isServiceInstalled,


### PR DESCRIPTION
## Summary
- add a hasPendingSetup flag to the installation store and drop Setup from navigation once requirements are met
- hide the Home page setup CTA when all services are installed
- expand Header and Home tests to assert Setup visibility during and after installation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1dc7cc8948331a290a1da4a0bddd8