### PR TITLE
Implement Raven library management UI

### DIFF
--- a/services/moon/src/components/raven/RavenLibraryCard.vue
+++ b/services/moon/src/components/raven/RavenLibraryCard.vue
@@ -1,0 +1,109 @@
+<script setup>
+import {computed} from 'vue';
+
+const props = defineProps({
+  item: {
+    type: Object,
+    required: true,
+  },
+  status: {
+    type: Object,
+    default: null,
+  },
+});
+
+const hasCover = computed(() => Boolean(props.item?.coverImage));
+
+const statusState = computed(() => props.status?.state ?? null);
+
+const isInProgress = computed(() => {
+  const state = statusState.value;
+  return state === 'pending' || state === 'downloading' || state === 'queued';
+});
+
+const isFailed = computed(() => statusState.value === 'failed');
+
+const isCompleted = computed(() => statusState.value === 'completed');
+
+const progressValue = computed(() => {
+  const value = props.status?.progress;
+  return typeof value === 'number' ? Math.min(100, Math.max(0, value)) : null;
+});
+
+const statusMessage = computed(() => {
+  if (!props.status) return '';
+  if (props.status.message) return props.status.message;
+  if (isCompleted.value) return 'Download completed';
+  if (isFailed.value) return 'Download failed';
+  if (isInProgress.value) return 'Downloading';
+  if (statusState.value === 'queued') return 'Queued';
+  return '';
+});
+
+const subtitle = computed(() => props.item?.subtitle ?? props.item?.author ?? props.item?.series);
+</script>
+
+<template>
+  <v-card data-test="raven-library-card" class="h-100 d-flex flex-column" elevation="6">
+    <v-img
+        v-if="hasCover"
+        :src="item.coverImage"
+        height="160"
+        cover
+        class="rounded-t"
+    />
+    <v-card-title class="text-h6">{{ item.title ?? 'Untitled series' }}</v-card-title>
+    <v-card-subtitle v-if="subtitle">{{ subtitle }}</v-card-subtitle>
+    <v-card-text class="flex-grow-1">
+      <p v-if="item.description" class="mb-4 text-body-2">{{ item.description }}</p>
+      <div v-if="statusState" class="mb-2">
+        <v-chip
+            v-if="isCompleted"
+            color="success"
+            size="small"
+            variant="tonal"
+            class="mr-2"
+        >
+          Ready
+        </v-chip>
+        <v-chip
+            v-else-if="isFailed"
+            color="error"
+            size="small"
+            variant="tonal"
+            class="mr-2"
+        >
+          Failed
+        </v-chip>
+        <v-chip
+            v-else
+            color="primary"
+            size="small"
+            variant="tonal"
+            class="mr-2"
+        >
+          {{ isInProgress ? 'Downloading' : statusState }}
+        </v-chip>
+      </div>
+      <v-progress-linear
+          v-if="progressValue !== null"
+          :model-value="progressValue"
+          height="6"
+          color="primary"
+          rounded
+          data-test="download-progress"
+      />
+      <div
+          v-if="statusMessage"
+          class="mt-2 text-body-2"
+          :class="{'text-error': isFailed}"
+      >
+        {{ statusMessage }}
+      </div>
+    </v-card-text>
+    <v-divider v-if="item.downloadedAt" />
+    <v-card-text v-if="item.downloadedAt" class="text-caption text-medium-emphasis">
+      Downloaded {{ new Date(item.downloadedAt).toLocaleString?.() ?? item.downloadedAt }}
+    </v-card-text>
+  </v-card>
+</template>

--- a/services/moon/src/components/raven/RavenLibraryGrid.vue
+++ b/services/moon/src/components/raven/RavenLibraryGrid.vue
@@ -1,0 +1,86 @@
+<script setup>
+import {computed} from 'vue';
+import RavenLibraryCard from './RavenLibraryCard.vue';
+
+const props = defineProps({
+  items: {
+    type: Array,
+    default: () => [],
+  },
+  statuses: {
+    type: Array,
+    default: () => [],
+  },
+});
+
+const itemKey = (item, index) => {
+  const candidate = item?.id ?? item?.slug ?? item?.seriesId ?? item?.title;
+  return candidate != null ? String(candidate) : `item-${index}`;
+};
+
+const statusKey = (status) => {
+  if (!status) return null;
+  const key =
+    status.libraryId ??
+    status.id ??
+    status.searchId ??
+    status.seriesId ??
+    status.title ??
+    null;
+  return key != null ? String(key) : null;
+};
+
+const statusMap = computed(() => {
+  const map = new Map();
+  props.statuses?.forEach((status) => {
+    const key = statusKey(status);
+    if (key !== null) {
+      map.set(key, status);
+    }
+  });
+  return map;
+});
+
+const combinedEntries = computed(() => {
+  const seen = new Set();
+  const entries = [];
+
+  props.items?.forEach((item, index) => {
+    const key = itemKey(item, index);
+    const normalizedKey = key != null ? String(key) : `item-${index}`;
+    const status = statusMap.value.get(normalizedKey) ?? null;
+    entries.push({key: normalizedKey, item, status});
+    seen.add(normalizedKey);
+  });
+
+  statusMap.value.forEach((status, key) => {
+    if (seen.has(key)) return;
+    entries.push({
+      key,
+      item: {
+        id: key,
+        title: status.title ?? 'Processing download',
+        description: status.message ?? 'This title is being prepared.',
+      },
+      status,
+    });
+  });
+
+  return entries;
+});
+</script>
+
+<template>
+  <v-row dense>
+    <v-col
+        v-for="entry in combinedEntries"
+        :key="entry.key"
+        cols="12"
+        sm="6"
+        md="4"
+        class="d-flex"
+    >
+      <RavenLibraryCard :item="entry.item" :status="entry.status" class="flex-grow-1" />
+    </v-col>
+  </v-row>
+</template>

--- a/services/moon/src/pages/Raven.vue
+++ b/services/moon/src/pages/Raven.vue
@@ -1,22 +1,392 @@
 <script setup>
+import {computed, onBeforeUnmount, onMounted, ref} from 'vue';
 import Header from '../components/Header.vue';
+import RavenLibraryGrid from '../components/raven/RavenLibraryGrid.vue';
+import {
+  fetchDownloadStatuses,
+  fetchLibrary,
+  searchTitles,
+  startDownload,
+} from '../utils/ravenClient.js';
+
+const library = ref([]);
+const libraryLoading = ref(false);
+const libraryError = ref('');
+
+const downloads = ref([]);
+const downloadsError = ref('');
+
+const isDialogOpen = ref(false);
+const searchQuery = ref('');
+const searchResults = ref([]);
+const searchLoading = ref(false);
+const searchError = ref('');
+const downloadError = ref('');
+const downloadLoading = ref(false);
+const selectedOption = ref(null);
+
+const POLL_INTERVAL = 5000;
+let pollHandle = null;
+
+const completedDownloads = new Set();
+
+const resetDialogState = () => {
+  searchQuery.value = '';
+  searchResults.value = [];
+  searchError.value = '';
+  downloadError.value = '';
+  selectedOption.value = null;
+  downloadLoading.value = false;
+};
+
+const openAddDialog = () => {
+  resetDialogState();
+  isDialogOpen.value = true;
+};
+
+const closeAddDialog = () => {
+  isDialogOpen.value = false;
+  resetDialogState();
+};
+
+const parseLibraryResponse = (payload) => {
+  if (!payload) return [];
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload.library)) return payload.library;
+  if (Array.isArray(payload.series)) return payload.series;
+  if (Array.isArray(payload.items)) return payload.items;
+  return [];
+};
+
+const parseDownloadsResponse = (payload) => {
+  if (!payload) return [];
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload.downloads)) return payload.downloads;
+  if (Array.isArray(payload.statuses)) return payload.statuses;
+  return [];
+};
+
+const statusKey = (status) => {
+  if (!status) return null;
+  return (
+    status.libraryId ??
+    status.id ??
+    status.searchId ??
+    status.seriesId ??
+    status.title ??
+    null
+  );
+};
+
+const loadLibrary = async () => {
+  libraryLoading.value = true;
+  libraryError.value = '';
+  try {
+    const payload = await fetchLibrary();
+    library.value = parseLibraryResponse(payload);
+  } catch (error) {
+    libraryError.value = error instanceof Error ? error.message : 'Failed to load library.';
+  } finally {
+    libraryLoading.value = false;
+  }
+};
+
+const refreshDownloads = async () => {
+  try {
+    downloadsError.value = '';
+    const payload = await fetchDownloadStatuses();
+    const list = parseDownloadsResponse(payload);
+    downloads.value = list;
+
+    let shouldRefreshLibrary = false;
+    list.forEach((status) => {
+      const key = statusKey(status);
+      if (status?.state === 'completed' && key && !completedDownloads.has(key)) {
+        completedDownloads.add(key);
+        shouldRefreshLibrary = true;
+      }
+    });
+
+    if (shouldRefreshLibrary) {
+      await loadLibrary();
+    }
+  } catch (error) {
+    downloadsError.value =
+      error instanceof Error ? error.message : 'Failed to load download status.';
+  }
+};
+
+const activeDownloads = computed(() => downloads.value ?? []);
+
+const performSearch = async () => {
+  const query = searchQuery.value.trim();
+  if (!query) {
+    searchError.value = 'Please enter a search term.';
+    return;
+  }
+
+  searchLoading.value = true;
+  searchError.value = '';
+  downloadError.value = '';
+  searchResults.value = [];
+  selectedOption.value = null;
+
+  try {
+    const payload = await searchTitles(query);
+    const results = payload?.results ?? payload?.options ?? payload;
+    searchResults.value = Array.isArray(results) ? results : [];
+    if (!searchResults.value.length) {
+      searchError.value = 'No matches found.';
+    }
+  } catch (error) {
+    searchError.value = error instanceof Error ? error.message : 'Failed to search titles.';
+    searchResults.value = [];
+  } finally {
+    searchLoading.value = false;
+  }
+};
+
+const selectOption = (searchId, optionIndex) => {
+  selectedOption.value = {searchId, optionIndex};
+  downloadError.value = '';
+};
+
+const isSelected = (result, optionIndex) => {
+  const id = result?.id ?? result?.searchId;
+  return (
+    selectedOption.value?.searchId === id &&
+    selectedOption.value?.optionIndex === optionIndex
+  );
+};
+
+const canConfirmDownload = computed(
+  () => Boolean(selectedOption.value) && !downloadLoading.value,
+);
+
+const startDownloadFlow = async () => {
+  if (!selectedOption.value) return;
+
+  downloadLoading.value = true;
+  downloadError.value = '';
+
+  try {
+    await startDownload({
+      searchId: selectedOption.value.searchId,
+      optionIndex: selectedOption.value.optionIndex,
+    });
+    closeAddDialog();
+    await refreshDownloads();
+  } catch (error) {
+    downloadError.value =
+      error instanceof Error ? error.message : 'Failed to start download.';
+  } finally {
+    downloadLoading.value = false;
+  }
+};
+
+const activeSearchSelectionLabel = computed(() => {
+  if (!selectedOption.value) return '';
+  const {searchId, optionIndex} = selectedOption.value;
+  const result = searchResults.value.find(
+    (entry) => (entry?.id ?? entry?.searchId) === searchId,
+  );
+  if (!result) return '';
+  const option = result.options?.[optionIndex];
+  const optionLabel = option?.label ?? option?.name ?? `Option ${optionIndex + 1}`;
+  const title = result.title ?? result.name ?? 'Selected title';
+  return `${title} – ${optionLabel}`;
+});
+
+onMounted(() => {
+  loadLibrary();
+  refreshDownloads();
+  pollHandle = setInterval(() => {
+    refreshDownloads();
+  }, POLL_INTERVAL);
+});
+
+onBeforeUnmount(() => {
+  if (pollHandle) {
+    clearInterval(pollHandle);
+    pollHandle = null;
+  }
+});
 </script>
 
 <template>
   <Header>
     <v-container class="py-12">
-      <v-row class="justify-center">
-        <v-col cols="12" md="8" lg="6">
-          <v-card class="pa-8 text-center" elevation="10">
-            <v-icon class="mb-4" color="primary" size="48">mdi-crow</v-icon>
-            <v-card-title class="text-h4 mb-2">Raven Operations</v-card-title>
-            <v-card-subtitle class="mb-4">Monitoring and insights for your Noona services.</v-card-subtitle>
-            <v-card-text>
-              The Raven console is under construction. Check back soon for dashboards, alerts, and telemetry to keep your deployment healthy.
-            </v-card-text>
-          </v-card>
+      <v-row class="align-center mb-6">
+        <v-col cols="12" md="8" class="d-flex justify-space-between flex-column flex-md-row">
+          <div class="mb-4 mb-md-0">
+            <h1 class="text-h4 font-weight-medium mb-1">Raven Library</h1>
+            <p class="text-body-1 text-medium-emphasis mb-0">
+              Monitor downloads and manage your telemetry series.
+            </p>
+          </div>
+          <v-btn
+              color="primary"
+              prepend-icon="mdi-plus"
+              class="align-self-md-end"
+              data-test="open-add-dialog"
+              @click="openAddDialog"
+          >
+            Add new title
+          </v-btn>
         </v-col>
       </v-row>
+
+      <v-row v-if="libraryError" class="mb-4">
+        <v-col cols="12">
+          <v-alert
+              type="error"
+              variant="tonal"
+              data-test="library-error"
+          >
+            {{ libraryError }}
+          </v-alert>
+        </v-col>
+      </v-row>
+
+      <v-row v-if="downloadsError" class="mb-4">
+        <v-col cols="12">
+          <v-alert
+              type="warning"
+              variant="tonal"
+              data-test="downloads-error"
+          >
+            {{ downloadsError }}
+          </v-alert>
+        </v-col>
+      </v-row>
+
+      <v-row v-if="libraryLoading" class="mb-6">
+        <v-col cols="12">
+          <v-progress-linear indeterminate color="primary" />
+        </v-col>
+      </v-row>
+
+      <div
+          v-if="!libraryLoading && !library.length"
+          class="text-center py-16 text-medium-emphasis"
+          data-test="library-empty"
+      >
+        <v-icon color="primary" size="64" class="mb-4">mdi-crow</v-icon>
+        <div class="text-h5 mb-2">Your Raven library is empty.</div>
+        <div class="text-body-1">
+          Start a search to download your first telemetry series.
+        </div>
+      </div>
+
+      <RavenLibraryGrid
+          v-else
+          :items="library"
+          :statuses="activeDownloads"
+      />
     </v-container>
+
+    <v-dialog v-model="isDialogOpen" max-width="640">
+      <v-card data-test="add-dialog">
+        <v-card-title class="text-h5">Add a new title</v-card-title>
+        <v-card-text>
+          <v-form data-test="search-form" @submit.prevent="performSearch">
+            <v-text-field
+                v-model="searchQuery"
+                label="Search the Raven index"
+                prepend-inner-icon="mdi-magnify"
+                clearable
+                data-test="search-query"
+            />
+            <v-btn
+                type="submit"
+                color="primary"
+                class="mt-2"
+                block
+                :loading="searchLoading"
+                :disabled="searchLoading"
+                data-test="submit-search"
+            >
+              Search
+            </v-btn>
+          </v-form>
+
+          <v-progress-linear
+              v-if="searchLoading"
+              class="my-4"
+              indeterminate
+              color="primary"
+          />
+
+          <v-alert
+              v-if="searchError"
+              type="error"
+              variant="tonal"
+              class="mt-4"
+              data-test="search-error"
+          >
+            {{ searchError }}
+          </v-alert>
+
+          <div v-if="searchResults.length" class="mt-4" data-test="search-results">
+            <div
+                v-for="result in searchResults"
+                :key="result.id ?? result.searchId"
+                class="mb-4"
+                data-test="search-result"
+            >
+              <div class="text-subtitle-1 font-weight-medium">
+                {{ result.title ?? result.name }}
+              </div>
+              <div v-if="result.description" class="text-body-2 text-medium-emphasis mb-2">
+                {{ result.description }}
+              </div>
+              <div class="d-flex flex-wrap gap-2">
+                <v-btn
+                    v-for="(option, optionIndex) in result.options ?? []"
+                    :key="optionIndex"
+                    variant="outlined"
+                    :color="isSelected(result, optionIndex) ? 'primary' : undefined"
+                    data-test="search-option"
+                    @click="selectOption(result.id ?? result.searchId, optionIndex)"
+                >
+                  {{ option?.label ?? option?.name ?? `Option ${optionIndex + 1}` }}
+                </v-btn>
+              </div>
+            </div>
+          </div>
+
+          <v-alert
+              v-if="downloadError"
+              type="error"
+              variant="tonal"
+              data-test="download-error"
+          >
+            {{ downloadError }}
+          </v-alert>
+
+          <v-alert
+              v-if="activeSearchSelectionLabel"
+              type="info"
+              variant="tonal"
+              class="mt-4"
+              data-test="selected-option"
+          >
+            {{ activeSearchSelectionLabel }}
+          </v-alert>
+        </v-card-text>
+        <v-card-actions class="justify-end">
+          <v-btn variant="text" @click="closeAddDialog">Cancel</v-btn>
+          <v-btn
+              color="primary"
+              :disabled="!canConfirmDownload"
+              :loading="downloadLoading"
+              data-test="confirm-download"
+              @click="startDownloadFlow"
+          >
+            Confirm download
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </Header>
 </template>

--- a/services/moon/src/pages/__tests__/Raven.test.ts
+++ b/services/moon/src/pages/__tests__/Raven.test.ts
@@ -1,0 +1,261 @@
+import {mount, VueWrapper} from '@vue/test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+vi.mock('../../utils/ravenClient.js', () => {
+  return {
+    fetchLibrary: vi.fn(),
+    fetchDownloadStatuses: vi.fn(),
+    searchTitles: vi.fn(),
+    startDownload: vi.fn(),
+  };
+});
+
+import RavenPage from '../Raven.vue';
+import {
+  fetchLibrary,
+  fetchDownloadStatuses,
+  searchTitles,
+  startDownload,
+} from '../../utils/ravenClient.js';
+
+type MockedFn = ReturnType<typeof vi.fn>;
+
+const fetchLibraryMock = fetchLibrary as unknown as MockedFn;
+const fetchDownloadStatusesMock = fetchDownloadStatuses as unknown as MockedFn;
+const searchTitlesMock = searchTitles as unknown as MockedFn;
+const startDownloadMock = startDownload as unknown as MockedFn;
+
+const flushAsync = async () => {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+const stubs = {
+  Header: {template: '<div><slot /></div>'},
+  'v-container': {template: '<div><slot /></div>'},
+  'v-row': {template: '<div><slot /></div>'},
+  'v-col': {template: '<div><slot /></div>'},
+  'v-card': {template: '<div><slot /></div>'},
+  'v-card-title': {template: '<div><slot /></div>'},
+  'v-card-subtitle': {template: '<div><slot /></div>'},
+  'v-card-text': {template: '<div><slot /></div>'},
+  'v-card-actions': {template: '<div><slot /></div>'},
+  'v-btn': {
+    props: ['disabled'],
+    emits: ['click'],
+    template:
+      '<button v-bind="$attrs" :disabled="disabled" @click="$emit(\'click\', $event)"><slot /></button>',
+  },
+  'v-icon': {template: '<i><slot /></i>'},
+  'v-alert': {template: '<div><slot /></div>'},
+  'v-progress-linear': {
+    props: ['modelValue'],
+    template: '<progress v-bind="$attrs" :value="modelValue" max="100"><slot /></progress>',
+  },
+  'v-dialog': {
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template: '<div v-if="modelValue" v-bind="$attrs"><slot /><slot name="actions" /></div>',
+  },
+  'v-text-field': {
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template:
+      '<input v-bind="$attrs" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  },
+  'v-form': {
+    emits: ['submit'],
+    template: '<form v-bind="$attrs" @submit.prevent="$emit(\'submit\', $event)"><slot /></form>',
+  },
+  'v-img': {template: '<img />'},
+  'v-chip': {template: '<span><slot /></slot></span>'},
+  'v-divider': {template: '<hr />'},
+};
+
+const mountPage = async () => {
+  const wrapper = mount(RavenPage, {
+    global: {stubs},
+  });
+
+  await flushAsync();
+  await wrapper.vm.$nextTick();
+  return wrapper;
+};
+
+describe('Raven library page', () => {
+  let wrapper: VueWrapper | null = null;
+
+  beforeEach(() => {
+    fetchLibraryMock.mockReset();
+    fetchDownloadStatusesMock.mockReset();
+    searchTitlesMock.mockReset();
+    startDownloadMock.mockReset();
+    fetchLibraryMock.mockResolvedValue({library: []});
+    fetchDownloadStatusesMock.mockResolvedValue({downloads: []});
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+  });
+
+  it('renders downloaded series cards', async () => {
+    fetchLibraryMock.mockResolvedValue({
+      library: [
+        {id: 'series-1', title: 'Series One', description: 'A telemetry story'},
+      ],
+    });
+
+    wrapper = await mountPage();
+    await flushAsync();
+
+    expect(wrapper.findAll('[data-test="raven-library-card"]').length).toBe(1);
+    expect(wrapper.text()).toContain('Series One');
+  });
+
+  it('shows an empty state when the library has no entries', async () => {
+    fetchLibraryMock.mockResolvedValue({library: []});
+
+    wrapper = await mountPage();
+    await flushAsync();
+
+    expect(wrapper.find('[data-test="library-empty"]').exists()).toBe(true);
+  });
+
+  it('handles dialog search and download confirmation', async () => {
+    searchTitlesMock.mockResolvedValue({
+      results: [
+        {
+          id: 'search-1',
+          title: 'Raven Saga',
+          options: [
+            {label: 'Complete series'},
+            {label: 'Volume 1'},
+          ],
+        },
+      ],
+    });
+
+    startDownloadMock.mockResolvedValue({status: 'queued'});
+
+    wrapper = await mountPage();
+    await flushAsync();
+
+    await wrapper.get('[data-test="open-add-dialog"]').trigger('click');
+    const input = wrapper.get('input[data-test="search-query"]');
+    await input.setValue('raven');
+    await wrapper.get('[data-test="search-form"]').trigger('submit');
+    await flushAsync();
+
+    expect(searchTitles).toHaveBeenCalledWith('raven');
+
+    const options = wrapper.findAll('[data-test="search-option"]');
+    expect(options.length).toBe(2);
+
+    await options[1].trigger('click');
+    const confirm = wrapper.get('[data-test="confirm-download"]');
+    expect(confirm.attributes('disabled')).toBeUndefined();
+
+    await confirm.trigger('click');
+    await flushAsync();
+
+    expect(startDownload).toHaveBeenCalledWith({searchId: 'search-1', optionIndex: 1});
+    expect(wrapper.find('[data-test="add-dialog"]').exists()).toBe(false);
+  });
+
+  it('shows an error when the library request fails', async () => {
+    fetchLibraryMock.mockRejectedValue(new Error('server down'));
+
+    wrapper = await mountPage();
+    await flushAsync();
+
+    expect(wrapper.find('[data-test="library-error"]').text()).toContain('server down');
+  });
+
+  it('renders download progress from status polling', async () => {
+    fetchLibraryMock.mockResolvedValue({
+      library: [{id: 'series-1', title: 'Series One'}],
+    });
+
+    fetchDownloadStatusesMock.mockResolvedValue({
+      downloads: [
+        {
+          id: 'download-1',
+          libraryId: 'series-1',
+          title: 'Series One',
+          state: 'downloading',
+          progress: 40,
+          message: 'Downloading',
+        },
+      ],
+    });
+
+    wrapper = await mountPage();
+    await flushAsync();
+
+    expect(wrapper.find('[data-test="download-progress"]').exists()).toBe(true);
+  });
+
+  it('shows a search error when the search endpoint fails', async () => {
+    searchTitlesMock.mockRejectedValue(new Error('search failed'));
+
+    wrapper = await mountPage();
+    await flushAsync();
+
+    await wrapper.get('[data-test="open-add-dialog"]').trigger('click');
+    const input = wrapper.get('input[data-test="search-query"]');
+    await input.setValue('issue');
+    await wrapper.get('[data-test="search-form"]').trigger('submit');
+    await flushAsync();
+
+    expect(wrapper.find('[data-test="search-error"]').text()).toContain('search failed');
+  });
+
+  it('shows a download error when starting the download fails', async () => {
+    searchTitlesMock.mockResolvedValue({
+      results: [
+        {
+          id: 'search-2',
+          title: 'Dark Flight',
+          options: [{label: 'Complete'}],
+        },
+      ],
+    });
+
+    startDownloadMock.mockRejectedValue(new Error('download failed'));
+
+    wrapper = await mountPage();
+    await flushAsync();
+
+    await wrapper.get('[data-test="open-add-dialog"]').trigger('click');
+    const input = wrapper.get('input[data-test="search-query"]');
+    await input.setValue('dark');
+    await wrapper.get('[data-test="search-form"]').trigger('submit');
+    await flushAsync();
+
+    await wrapper.get('[data-test="search-option"]').trigger('click');
+    await wrapper.get('[data-test="confirm-download"]').trigger('click');
+    await flushAsync();
+
+    expect(wrapper.find('[data-test="download-error"]').text()).toContain('download failed');
+  });
+
+  it('refreshes the library when downloads complete', async () => {
+    fetchLibraryMock
+      .mockResolvedValueOnce({library: []})
+      .mockResolvedValueOnce({library: [{id: 'series-2', title: 'Completed'}]})
+      .mockResolvedValue({library: [{id: 'series-2', title: 'Completed'}]});
+
+    fetchDownloadStatusesMock.mockResolvedValue({
+      downloads: [
+        {id: 'download-2', libraryId: 'series-2', title: 'Completed', state: 'completed'},
+      ],
+    });
+
+    wrapper = await mountPage();
+    await flushAsync();
+
+    expect(fetchLibrary).toHaveBeenCalledTimes(2);
+    expect(wrapper.findAll('[data-test="raven-library-card"]').length).toBe(1);
+  });
+});

--- a/services/moon/src/utils/ravenClient.js
+++ b/services/moon/src/utils/ravenClient.js
@@ -1,0 +1,66 @@
+const DEFAULT_HEADERS = {'Content-Type': 'application/json'};
+
+const buildOptions = (options = {}) => {
+  const headers = {...DEFAULT_HEADERS, ...(options.headers ?? {})};
+  const init = {...options, headers};
+
+  if (options.body && typeof options.body === 'object' && !(options.body instanceof FormData)) {
+    init.body = JSON.stringify(options.body);
+  }
+
+  return init;
+};
+
+const request = async (path, options = {}) => {
+  const response = await fetch(path, buildOptions(options));
+
+  if (!response.ok) {
+    let message = `Request failed with status ${response.status}`;
+
+    try {
+      const text = await response.text();
+      if (text) {
+        try {
+          const parsed = JSON.parse(text);
+          message = parsed?.message ?? parsed?.error ?? text;
+        } catch (_) {
+          message = text;
+        }
+      }
+    } catch (_) {
+      // Ignore secondary failures while extracting the error message
+    }
+
+    throw new Error(message);
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+
+  if (contentType.includes('application/json')) {
+    return await response.json();
+  }
+
+  return await response.text();
+};
+
+export const fetchLibrary = () => request('/api/raven/library');
+
+export const searchTitles = (query) =>
+  request('/api/raven/search', {
+    method: 'POST',
+    body: {query},
+  });
+
+export const startDownload = ({searchId, optionIndex}) =>
+  request('/api/raven/download', {
+    method: 'POST',
+    body: {searchId, optionIndex},
+  });
+
+export const fetchDownloadStatuses = () => request('/api/raven/downloads/status');
+
+export {request as __ravenRequest};


### PR DESCRIPTION
## Summary
- replace the Raven placeholder with a fully interactive library view that loads series, opens a download dialog, and polls download status
- add reusable Raven library grid/card components and a REST client helper for the new endpoints
- cover the new flows with Vitest specs that exercise library rendering, dialog search, and error cases

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e1f4f796448331980b85278371570b