### PR TITLE
feat(raven): add download progress tracking and status API

### DIFF
--- a/services/raven/readme.md
+++ b/services/raven/readme.md
@@ -35,20 +35,23 @@ It powers automatic searching, scraping, and downloading of manga chapters into 
        ```
        Chapter {Number} [Pages {Count} {Source} - Noona].cbz
        ```
+     - Updates Raven's library with the latest `lastDownloaded` chapter
    - Adds the title & chapter to the local library
 
 ---
 
 ## 🔗 **API Endpoints**
 
-| Method | Endpoint                                             | Description                                                                       |
-| ------ | ---------------------------------------------------- | --------------------------------------------------------------------------------- |
-| GET    | `/v1/download/health`                                | Health check for the download module.                                             |
+| Method | Endpoint                                             | Description |
+| ------ | ---------------------------------------------------- | ----------- |
+| GET    | `/v1/download/health`                                | Health check for the download module. |
 | GET    | `/v1/download/search/{titleName}`                    | Search WeebCentral for a manga title. Returns options and a generated `searchId`. |
-| GET    | `/v1/download/select/{searchId}/{optionIndex}`       | Download all chapters from a previously searched title.                           |
-| GET    | `/v1/library/health`                                 | Health check for the library module.                                              |
-| GET    | `/v1/library/getall`                                 | Get all titles currently in the library.                                          |
-| GET    | `/v1/library/get/{titleName}`                        | Get details of a specific title by name.                                          |
+| GET    | `/v1/download/select/{searchId}/{optionIndex}`       | Download all chapters from a previously searched title. |
+| GET    | `/v1/download/status`                                | View active downloads plus recent history, including progress metadata. |
+| DELETE | `/v1/download/status/{title}`                        | Clear a progress entry (useful for pruning stale history). |
+| GET    | `/v1/library/health`                                 | Health check for the library module. |
+| GET    | `/v1/library/getall`                                 | Get all titles currently in the library. |
+| GET    | `/v1/library/get/{titleName}`                        | Get details of a specific title by name. |
 
 ---
 
@@ -145,6 +148,7 @@ docker run -p 8080:8080 `
 Visit:
 
 * [http://localhost:8080/v1/download/health](http://localhost:8080/v1/download/health)
+* [http://localhost:8080/v1/download/status](http://localhost:8080/v1/download/status)
 * [http://localhost:8080/v1/library/health](http://localhost:8080/v1/library/health)
 
 You should see:

--- a/services/raven/src/main/java/com/paxkun/raven/controller/DownloadController.java
+++ b/services/raven/src/main/java/com/paxkun/raven/controller/DownloadController.java
@@ -2,10 +2,13 @@ package com.paxkun.raven.controller;
 
 import com.paxkun.raven.service.DownloadService;
 import com.paxkun.raven.service.LoggerService;
+import com.paxkun.raven.service.download.DownloadProgress;
 import com.paxkun.raven.service.download.SearchTitle;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * DownloadController handles endpoints for searching and downloading manga titles and chapters.
@@ -74,6 +77,35 @@ public class DownloadController {
                         " | optionIndex=" + optionIndex +
                         " | message=" + sanitizeForLog(result));
         return ResponseEntity.ok(result);
+    }
+
+    /**
+     * Retrieves the current download queue and recently completed jobs.
+     *
+     * @return List of {@link DownloadProgress} entries.
+     */
+    @GetMapping("/status")
+    public ResponseEntity<List<DownloadProgress>> getStatus() {
+        logger.debug("DOWNLOAD_CONTROLLER", "Status request received");
+        List<DownloadProgress> status = downloadService.getDownloadStatuses();
+        logger.debug(
+                "DOWNLOAD_CONTROLLER",
+                "Returning " + status.size() + " progress entries");
+        return ResponseEntity.ok(status);
+    }
+
+    /**
+     * Clears an existing progress entry, allowing stale history to be removed.
+     *
+     * @param titleName Title whose progress entry should be cleared.
+     * @return Empty response with 204 status.
+     */
+    @DeleteMapping("/status/{titleName}")
+    public ResponseEntity<Void> clearStatus(@PathVariable String titleName) {
+        String sanitizedTitle = sanitizeForLog(titleName);
+        logger.debug("DOWNLOAD_CONTROLLER", "Clearing status for title=" + sanitizedTitle);
+        downloadService.clearDownloadStatus(titleName);
+        return ResponseEntity.noContent().build();
     }
 
     private String sanitizeForLog(String value) {

--- a/services/raven/src/main/java/com/paxkun/raven/service/download/DownloadProgress.java
+++ b/services/raven/src/main/java/com/paxkun/raven/service/download/DownloadProgress.java
@@ -1,0 +1,148 @@
+package com.paxkun.raven.service.download;
+
+/**
+ * Thread-safe download progress DTO that captures the current state of an
+ * ongoing or recently completed download job.
+ */
+public class DownloadProgress {
+
+    private final String title;
+    private final long queuedAt;
+
+    private int totalChapters;
+    private int completedChapters;
+    private String currentChapter;
+    private String status;
+    private Long startedAt;
+    private Long completedAt;
+    private String errorMessage;
+    private long lastUpdated;
+
+    /**
+     * Creates a new progress tracker for the provided title, defaulting the
+     * status to {@code queued}.
+     */
+    public DownloadProgress(String title) {
+        long now = System.currentTimeMillis();
+        this.title = title;
+        this.status = "queued";
+        this.queuedAt = now;
+        this.lastUpdated = now;
+    }
+
+    private DownloadProgress(
+            String title,
+            long queuedAt,
+            int totalChapters,
+            int completedChapters,
+            String currentChapter,
+            String status,
+            Long startedAt,
+            Long completedAt,
+            String errorMessage,
+            long lastUpdated) {
+        this.title = title;
+        this.queuedAt = queuedAt;
+        this.totalChapters = totalChapters;
+        this.completedChapters = completedChapters;
+        this.currentChapter = currentChapter;
+        this.status = status;
+        this.startedAt = startedAt;
+        this.completedAt = completedAt;
+        this.errorMessage = errorMessage;
+        this.lastUpdated = lastUpdated;
+    }
+
+    private long now() {
+        return System.currentTimeMillis();
+    }
+
+    public synchronized void markStarted(int totalChapters) {
+        this.totalChapters = totalChapters;
+        this.startedAt = now();
+        this.status = "downloading";
+        this.lastUpdated = this.startedAt;
+    }
+
+    public synchronized void chapterStarted(String chapterTitle) {
+        this.currentChapter = chapterTitle;
+        this.status = "downloading";
+        this.lastUpdated = now();
+    }
+
+    public synchronized void chapterCompleted() {
+        this.completedChapters++;
+        this.lastUpdated = now();
+    }
+
+    public synchronized void markCompleted() {
+        long now = now();
+        this.status = "completed";
+        this.currentChapter = null;
+        this.completedAt = now;
+        this.lastUpdated = now;
+    }
+
+    public synchronized void markFailed(String message) {
+        long now = now();
+        this.status = "failed";
+        this.errorMessage = message;
+        this.currentChapter = null;
+        this.completedAt = now;
+        this.lastUpdated = now;
+    }
+
+    public synchronized DownloadProgress copy() {
+        return new DownloadProgress(
+                title,
+                queuedAt,
+                totalChapters,
+                completedChapters,
+                currentChapter,
+                status,
+                startedAt,
+                completedAt,
+                errorMessage,
+                lastUpdated);
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public long getQueuedAt() {
+        return queuedAt;
+    }
+
+    public synchronized int getTotalChapters() {
+        return totalChapters;
+    }
+
+    public synchronized int getCompletedChapters() {
+        return completedChapters;
+    }
+
+    public synchronized String getCurrentChapter() {
+        return currentChapter;
+    }
+
+    public synchronized String getStatus() {
+        return status;
+    }
+
+    public synchronized Long getStartedAt() {
+        return startedAt;
+    }
+
+    public synchronized Long getCompletedAt() {
+        return completedAt;
+    }
+
+    public synchronized String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public synchronized long getLastUpdated() {
+        return lastUpdated;
+    }
+}

--- a/services/raven/src/test/java/com/paxkun/raven/controller/DownloadControllerTest.java
+++ b/services/raven/src/test/java/com/paxkun/raven/controller/DownloadControllerTest.java
@@ -1,0 +1,64 @@
+package com.paxkun.raven.controller;
+
+import com.paxkun.raven.service.DownloadService;
+import com.paxkun.raven.service.LoggerService;
+import com.paxkun.raven.service.download.DownloadProgress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class DownloadControllerTest {
+
+    @Mock
+    private DownloadService downloadService;
+
+    @Mock
+    private LoggerService loggerService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new DownloadController(downloadService, loggerService)).build();
+    }
+
+    @Test
+    void statusEndpointReturnsProgress() throws Exception {
+        DownloadProgress progress = new DownloadProgress("Solo Leveling");
+        progress.markStarted(2);
+        progress.chapterStarted("Chapter 1");
+        progress.chapterCompleted();
+        progress.markCompleted();
+        when(downloadService.getDownloadStatuses()).thenReturn(List.of(progress));
+
+        mockMvc.perform(get("/v1/download/status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].title").value("Solo Leveling"))
+                .andExpect(jsonPath("$[0].status").value("completed"))
+                .andExpect(jsonPath("$[0].totalChapters").value(2));
+
+        verify(downloadService).getDownloadStatuses();
+    }
+
+    @Test
+    void deleteEndpointClearsEntry() throws Exception {
+        mockMvc.perform(delete("/v1/download/status/{title}", "Solo Leveling"))
+                .andExpect(status().isNoContent());
+
+        verify(downloadService).clearDownloadStatus("Solo Leveling");
+    }
+}

--- a/services/raven/src/test/java/com/paxkun/raven/service/DownloadServiceTest.java
+++ b/services/raven/src/test/java/com/paxkun/raven/service/DownloadServiceTest.java
@@ -1,25 +1,38 @@
 package com.paxkun.raven.service;
 
+import com.paxkun.raven.service.download.DownloadProgress;
 import com.paxkun.raven.service.download.SearchTitle;
 import com.paxkun.raven.service.download.SourceFinder;
 import com.paxkun.raven.service.download.TitleScraper;
+import com.paxkun.raven.service.library.NewChapter;
+import com.paxkun.raven.service.library.NewTitle;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
+import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class DownloadServiceTest {
 
     @Mock
@@ -31,8 +44,11 @@ class DownloadServiceTest {
     @Mock
     private LoggerService loggerService;
 
+    @Mock
+    private LibraryService libraryService;
+
     @InjectMocks
-    private DownloadService downloadService;
+    private TestableDownloadService downloadService;
 
     @TempDir
     Path downloadsRoot;
@@ -56,6 +72,8 @@ class DownloadServiceTest {
         when(titleScraper.getChapters("http://example.com/solo"))
                 .thenReturn(List.of(Map.of("chapter_title", "Chapter 1", "href", "http://example.com/solo/1")));
         when(sourceFinder.findSource(anyString())).thenReturn(Collections.emptyList());
+        lenient().when(libraryService.resolveOrCreateTitle(eq("Solo Leveling"), eq("http://example.com/solo")))
+                .thenReturn(new NewTitle("Solo Leveling", "uuid", "http://example.com/solo", "0"));
 
         SearchTitle searchTitle = downloadService.searchTitle("solo");
         String searchId = searchTitle.getSearchId();
@@ -87,5 +105,93 @@ class DownloadServiceTest {
         String response = downloadService.queueDownloadAllChapters(searchId, 1);
 
         assertThat(response).isEqualTo("⚠️ Search session expired or not found. Please search again.");
+    }
+
+    @Test
+    void downloadProgressIsTrackedAndLibraryUpdated() throws Exception {
+        Map<String, String> title = new HashMap<>();
+        title.put("title", "Solo Leveling");
+        title.put("href", "http://example.com/solo");
+
+        when(titleScraper.searchManga("solo"))
+                .thenReturn(new ArrayList<>(List.of(title)));
+        when(loggerService.getDownloadsRoot()).thenReturn(downloadsRoot);
+        List<Map<String, String>> chapters = List.of(
+                Map.of("chapter_title", "Chapter 1", "href", "http://example.com/solo/1"),
+                Map.of("chapter_title", "Chapter 2", "href", "http://example.com/solo/2")
+        );
+        when(titleScraper.getChapters("http://example.com/solo")).thenReturn(chapters);
+        when(sourceFinder.findSource(anyString())).thenReturn(List.of("http://example.com/solo/page1.jpg"));
+        NewTitle resolvedTitle = new NewTitle("Solo Leveling", "uuid", "http://example.com/solo", "0");
+        when(libraryService.resolveOrCreateTitle("Solo Leveling", "http://example.com/solo"))
+                .thenReturn(resolvedTitle);
+
+        SearchTitle searchTitle = downloadService.searchTitle("solo");
+        downloadService.queueDownloadAllChapters(searchTitle.getSearchId(), 1);
+
+        waitForStatus("Solo Leveling", "completed");
+
+        List<DownloadProgress> statuses = downloadService.getDownloadStatuses();
+        assertThat(statuses)
+                .anySatisfy(progress -> {
+                    assertThat(progress.getTitle()).isEqualTo("Solo Leveling");
+                    assertThat(progress.getTotalChapters()).isEqualTo(2);
+                    assertThat(progress.getCompletedChapters()).isEqualTo(2);
+                    assertThat(progress.getStatus()).isEqualTo("completed");
+                });
+
+        ArgumentCaptor<NewTitle> titleCaptor = ArgumentCaptor.forClass(NewTitle.class);
+        ArgumentCaptor<NewChapter> chapterCaptor = ArgumentCaptor.forClass(NewChapter.class);
+        verify(libraryService, timeout(2000).times(2))
+                .addOrUpdateTitle(titleCaptor.capture(), chapterCaptor.capture());
+        assertThat(chapterCaptor.getAllValues())
+                .extracting(NewChapter::getChapter)
+                .containsExactlyInAnyOrder("1", "2");
+        assertThat(titleCaptor.getAllValues())
+                .allSatisfy(capturedTitle -> assertThat(capturedTitle.getTitleName()).isEqualTo("Solo Leveling"));
+        assertThat(resolvedTitle.getLastDownloaded()).isEqualTo("2");
+    }
+
+    private void waitForStatus(String titleName, String expectedStatus) throws InterruptedException {
+        for (int attempt = 0; attempt < 50; attempt++) {
+            List<DownloadProgress> statuses = downloadService.getDownloadStatuses();
+            boolean match = statuses.stream()
+                    .anyMatch(progress -> titleName.equals(progress.getTitle())
+                            && expectedStatus.equals(progress.getStatus()));
+            if (match) {
+                return;
+            }
+            Thread.sleep(100);
+        }
+        throw new AssertionError("Timed out waiting for status=" + expectedStatus + " for title=" + titleName);
+    }
+
+    static class TestableDownloadService extends DownloadService {
+        @Override
+        protected int saveImagesToFolder(List<String> urls, Path folder) {
+            try {
+                Files.createDirectories(folder);
+            } catch (IOException ignored) {
+            }
+            return urls.size();
+        }
+
+        @Override
+        protected void zipFolderAsCbz(Path folder, Path cbzPath) {
+            try {
+                Path parent = cbzPath.getParent();
+                if (parent != null) {
+                    Files.createDirectories(parent);
+                }
+                Files.deleteIfExists(cbzPath);
+                Files.createFile(cbzPath);
+            } catch (IOException ignored) {
+            }
+        }
+
+        @Override
+        protected void deleteFolder(Path folderPath) {
+            // Skip deletion to simplify testing
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a thread-safe DownloadProgress model and update DownloadService to track active/history status while updating the library after each chapter
- ensure LibraryService resolves or creates titles before downloads and expose status/cleanup endpoints via DownloadController
- document the new status endpoint and extend automated tests for download progress, library behavior, and controller responses

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68e25d5ed3288331bc6620796a57b211