### PR TITLE
Ensure portal Discord setup uses discovered Sage host

### DIFF
--- a/services/moon/src/utils/portalDiscordSetup.js
+++ b/services/moon/src/utils/portalDiscordSetup.js
@@ -1,9 +1,23 @@
-const PORTAL_DISCORD_VALIDATE_ENDPOINT =
-  '/api/setup/services/noona-portal/discord/validate';
-const PORTAL_DISCORD_ROLES_ENDPOINT =
-  '/api/setup/services/noona-portal/discord/roles';
-const PORTAL_DISCORD_CHANNELS_ENDPOINT =
-  '/api/setup/services/noona-portal/discord/channels';
+const DEFAULT_PORTAL_DISCORD_BASE = '/api/setup/services/noona-portal/discord';
+
+const sanitizeBaseUrl = (baseUrl) => {
+  if (typeof baseUrl !== 'string') {
+    return DEFAULT_PORTAL_DISCORD_BASE;
+  }
+
+  const trimmed = baseUrl.trim();
+  if (!trimmed) {
+    return DEFAULT_PORTAL_DISCORD_BASE;
+  }
+
+  return trimmed.replace(/\/+$/, '');
+};
+
+const buildPortalDiscordEndpoint = (segment, baseUrl) => {
+  const base = sanitizeBaseUrl(baseUrl);
+  const normalizedSegment = segment.startsWith('/') ? segment : `/${segment}`;
+  return `${base}${normalizedSegment}`;
+};
 
 const parseResponse = async (response, fallbackError) => {
   const payload = await response.json().catch(() => ({}));
@@ -18,12 +32,18 @@ const parseResponse = async (response, fallbackError) => {
   return payload;
 };
 
-export const validatePortalDiscordConfig = async ({ token, guildId }) => {
-  const response = await fetch(PORTAL_DISCORD_VALIDATE_ENDPOINT, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ token, guildId }),
-  });
+export const validatePortalDiscordConfig = async (
+  { token, guildId },
+  baseUrl,
+) => {
+  const response = await fetch(
+    buildPortalDiscordEndpoint('/validate', baseUrl),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, guildId }),
+    },
+  );
 
   return await parseResponse(
     response,
@@ -31,12 +51,18 @@ export const validatePortalDiscordConfig = async ({ token, guildId }) => {
   );
 };
 
-export const createPortalDiscordRole = async ({ token, guildId, name }) => {
-  const response = await fetch(PORTAL_DISCORD_ROLES_ENDPOINT, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ token, guildId, name }),
-  });
+export const createPortalDiscordRole = async (
+  { token, guildId, name },
+  baseUrl,
+) => {
+  const response = await fetch(
+    buildPortalDiscordEndpoint('/roles', baseUrl),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, guildId, name }),
+    },
+  );
 
   const payload = await parseResponse(
     response,
@@ -45,17 +71,18 @@ export const createPortalDiscordRole = async ({ token, guildId, name }) => {
   return payload?.role ?? null;
 };
 
-export const createPortalDiscordChannel = async ({
-  token,
-  guildId,
-  name,
-  type,
-}) => {
-  const response = await fetch(PORTAL_DISCORD_CHANNELS_ENDPOINT, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ token, guildId, name, type }),
-  });
+export const createPortalDiscordChannel = async (
+  { token, guildId, name, type },
+  baseUrl,
+) => {
+  const response = await fetch(
+    buildPortalDiscordEndpoint('/channels', baseUrl),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, guildId, name, type }),
+    },
+  );
 
   const payload = await parseResponse(
     response,


### PR DESCRIPTION
## Summary
- allow the portal Discord setup utilities to accept an optional base URL before building their endpoints
- derive the Discord endpoint base in the setup wizard from the active services endpoint when available and pass it to helper calls
- extend the setup page tests to cover host detection for the Discord API requests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e278a40a248331a9c32c828978e514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Discord setup now auto-detects and uses the correct API endpoint from the active service, with a safe default fallback. Improves reliability for validating configuration and creating roles/channels across environments. No UI changes or user action required.
- Tests
  - Added tests to verify endpoint derivation and correct requests during Discord configuration and resource creation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->