### PR TITLE
Limit installer log output to last three entries

### DIFF
--- a/services/moon/src/pages/Setup.vue
+++ b/services/moon/src/pages/Setup.vue
@@ -13,7 +13,8 @@ const DEFAULT_SERVICES_ENDPOINT = '/api/setup/services';
 const DEFAULT_INSTALL_ENDPOINT = '/api/setup/install';
 const DEFAULT_INSTALL_PROGRESS_ENDPOINT = '/api/setup/services/install/progress';
 const DEFAULT_INSTALL_LOGS_ENDPOINT = '/api/setup/services/installation/logs';
-const DEFAULT_INSTALL_LOG_LIMIT = 200;
+const INSTALL_LOG_DISPLAY_COUNT = 3;
+const DEFAULT_INSTALL_LOG_LIMIT = INSTALL_LOG_DISPLAY_COUNT;
 const PORTAL_TEST_ENDPOINT = '/api/setup/services/noona-portal/test';
 const RAVEN_DETECT_ENDPOINT = '/api/setup/services/noona-raven/detect';
 const ABSOLUTE_URL_REGEX = /^https?:\/\//i;
@@ -1159,7 +1160,8 @@ const fetchInstallLogs = async (options = {}) => {
     const formatted = entries
       .map(formatLogEntry)
       .filter((line) => typeof line === 'string' && line.length > 0);
-    installLogs.value = formatted.join('\n');
+    const latestEntries = formatted.slice(-INSTALL_LOG_DISPLAY_COUNT);
+    installLogs.value = latestEntries.join('\n');
     state.progress.logError = '';
   } catch (error) {
     state.progress.logError = error instanceof Error ? error.message : String(error);
@@ -1180,7 +1182,7 @@ const fetchInstallLogs = async (options = {}) => {
 const refreshInstallLogs = () => fetchInstallLogs();
 
 const showMoreInstallLogs = () => {
-  installLogLimit.value += DEFAULT_INSTALL_LOG_LIMIT;
+  installLogLimit.value = INSTALL_LOG_DISPLAY_COUNT;
   void fetchInstallLogs();
 };
 

--- a/services/moon/src/pages/__tests__/Setup.spec.js
+++ b/services/moon/src/pages/__tests__/Setup.spec.js
@@ -1,0 +1,105 @@
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import Setup from '../Setup.vue';
+
+const createFetchMock = (logEntries, requests) =>
+  vi.fn(async (input) => {
+    const url = typeof input === 'string' ? input : input?.url || '';
+
+    if (url.includes('/installation/logs')) {
+      requests.push(url);
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ entries: logEntries }),
+      };
+    }
+
+    if (url.includes('/api/setup/services')) {
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ services: [] }),
+      };
+    }
+
+    return {
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    };
+  });
+
+describe('Setup installer logs', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      delete global.fetch;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('limits rendered log lines to the display count after showing more logs', async () => {
+    const logEntries = [
+      { message: 'first log entry' },
+      { message: 'second log entry' },
+      { message: 'third log entry' },
+      { message: 'fourth log entry' },
+      { message: 'fifth log entry' },
+    ];
+    const requests = [];
+
+    global.fetch = createFetchMock(logEntries, requests);
+
+    const wrapper = mount(Setup, {
+      global: {
+        stubs: {
+          Header: {
+            template: '<div><slot /></div>',
+          },
+        },
+        config: {
+          compilerOptions: {
+            isCustomElement: (tag) => tag.startsWith('v-'),
+          },
+        },
+      },
+    });
+
+    await flushPromises();
+
+    wrapper.vm.showProgressDetails = true;
+    await nextTick();
+
+    await wrapper.vm.fetchInstallLogs();
+    await flushPromises();
+    await nextTick();
+
+    const showMoreButton = wrapper.find('[data-test="show-more-logs"]');
+    expect(showMoreButton.exists()).toBe(true);
+
+    await showMoreButton.trigger('click');
+    await flushPromises();
+    await nextTick();
+
+    const logRequests = requests.filter((url) => url.includes('/installation/logs'));
+    expect(logRequests.at(-1)).toContain('limit=3');
+
+    const renderedLogs = wrapper
+      .find('.progress-logs__body')
+      .text()
+      .split('\n')
+      .filter((line) => line.trim().length > 0);
+
+    expect(renderedLogs.length).toBeLessThanOrEqual(3);
+    expect(renderedLogs).toEqual([
+      'third log entry',
+      'fourth log entry',
+      'fifth log entry',
+    ]);
+  });
+});

--- a/services/moon/src/pages/__tests__/Setup.test.ts
+++ b/services/moon/src/pages/__tests__/Setup.test.ts
@@ -602,10 +602,11 @@ describe('Setup page', () => {
         return Promise.resolve(
           mockResponse({
             entries: [
-              {
-                timestamp: '2024-01-01T00:00:00Z',
-                message: 'Installer ready',
-              },
+              { message: 'Installer started' },
+              { message: 'Preparing dependencies' },
+              { message: 'Downloading assets' },
+              { message: 'Configuring services' },
+              { message: 'Installer ready' },
             ],
           }),
         );
@@ -640,7 +641,19 @@ describe('Setup page', () => {
       .map(([arg]) => (typeof arg === 'string' ? arg : arg instanceof URL ? arg.toString() : ''))
       .filter((call) => call.includes('/installation/logs'));
 
-    expect(logRequestsAfterOpen).toContain('/api/setup/services/installation/logs?limit=200');
+    expect(logRequestsAfterOpen).toContain('/api/setup/services/installation/logs?limit=3');
+
+    const initialLogs = wrapper
+      .find('.progress-logs__body')
+      .text()
+      .split('\n')
+      .filter((line) => line.trim().length > 0);
+
+    expect(initialLogs).toEqual([
+      'Downloading assets',
+      'Configuring services',
+      'Installer ready',
+    ]);
 
     const showMoreButton = wrapper.find('[data-test="show-more-logs"]');
     expect(showMoreButton.exists()).toBe(true);
@@ -654,7 +667,20 @@ describe('Setup page', () => {
       .map(([arg]) => (typeof arg === 'string' ? arg : arg instanceof URL ? arg.toString() : ''))
       .filter((call) => call.includes('/installation/logs'));
 
-    expect(logRequests).toContain('/api/setup/services/installation/logs?limit=400');
+    const lastLogRequest = logRequests[logRequests.length - 1];
+    expect(lastLogRequest).toBe('/api/setup/services/installation/logs?limit=3');
+
+    const updatedLogs = wrapper
+      .find('.progress-logs__body')
+      .text()
+      .split('\n')
+      .filter((line) => line.trim().length > 0);
+
+    expect(updatedLogs).toEqual([
+      'Downloading assets',
+      'Configuring services',
+      'Installer ready',
+    ]);
   });
 
   it('uses the fallback services endpoints for progress and logs when setup services fail', async () => {
@@ -683,10 +709,11 @@ describe('Setup page', () => {
         return Promise.resolve(
           mockResponse({
             entries: [
-              {
-                timestamp: '2024-01-01T00:00:00Z',
-                message: 'Installer ready',
-              },
+              { message: 'Installer started' },
+              { message: 'Preparing dependencies' },
+              { message: 'Downloading assets' },
+              { message: 'Configuring services' },
+              { message: 'Installer ready' },
             ],
           }),
         );
@@ -730,7 +757,19 @@ describe('Setup page', () => {
       .map(([arg]) => (typeof arg === 'string' ? arg : arg instanceof URL ? arg.toString() : ''))
       .filter((call) => call.includes('/installation/logs'));
 
-    expect(logRequests).toContain('/api/services/installation/logs?limit=200');
+    expect(logRequests).toContain('/api/services/installation/logs?limit=3');
+
+    const initialLogs = wrapper
+      .find('.progress-logs__body')
+      .text()
+      .split('\n')
+      .filter((line) => line.trim().length > 0);
+
+    expect(initialLogs).toEqual([
+      'Downloading assets',
+      'Configuring services',
+      'Installer ready',
+    ]);
 
     const showMoreButton = wrapper.find('[data-test="show-more-logs"]');
     expect(showMoreButton.exists()).toBe(true);
@@ -744,7 +783,20 @@ describe('Setup page', () => {
       .map(([arg]) => (typeof arg === 'string' ? arg : arg instanceof URL ? arg.toString() : ''))
       .filter((call) => call.includes('/installation/logs'));
 
-    expect(updatedLogRequests).toContain('/api/services/installation/logs?limit=400');
+    const lastFallbackLogRequest = updatedLogRequests[updatedLogRequests.length - 1];
+    expect(lastFallbackLogRequest).toBe('/api/services/installation/logs?limit=3');
+
+    const updatedLogs = wrapper
+      .find('.progress-logs__body')
+      .text()
+      .split('\n')
+      .filter((line) => line.trim().length > 0);
+
+    expect(updatedLogs).toEqual([
+      'Downloading assets',
+      'Configuring services',
+      'Installer ready',
+    ]);
   });
 
   it('shows the success message after completing the Raven install', async () => {


### PR DESCRIPTION
## Summary
- limit Moon setup installer logs to the last three entries and update log fetching to use the smaller limit
- add targeted tests covering the three-line log display for both default and fallback endpoints
- introduce a focused spec validating the rendered log truncation when using the show more control

## Testing
- npm test (from services/moon)

------
https://chatgpt.com/codex/tasks/task_e_68e2a261fda48331b128b7ecc2ec51af