### PR TITLE
Allow portal Vault token to fall back to API token

### DIFF
--- a/services/portal/shared/config.mjs
+++ b/services/portal/shared/config.mjs
@@ -55,7 +55,18 @@ const resolveEnv = (overrides = {}) => ({
 const collectMissing = (env) => {
     const missing = [];
 
+    const hasVaultToken =
+        normalizeString(env.VAULT_ACCESS_TOKEN) ||
+        normalizeString(env.VAULT_API_TOKEN);
+
     for (const key of REQUIRED_STRINGS) {
+        if (key === 'VAULT_ACCESS_TOKEN') {
+            if (!hasVaultToken) {
+                missing.push(key);
+            }
+            continue;
+        }
+
         if (!normalizeString(env[key])) {
             missing.push(key);
         }
@@ -96,7 +107,9 @@ export const loadPortalConfig = (overrides = {}) => {
         },
         vault: {
             baseUrl: normalizeUrl(env.VAULT_BASE_URL),
-            token: env.VAULT_ACCESS_TOKEN,
+            token:
+                normalizeString(env.VAULT_ACCESS_TOKEN) ||
+                normalizeString(env.VAULT_API_TOKEN),
         },
         redis: {
             namespace: normalizeString(env.PORTAL_REDIS_NAMESPACE) || 'portal:onboarding',

--- a/services/portal/tests/config.test.mjs
+++ b/services/portal/tests/config.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { safeLoadPortalConfig } from '../shared/config.mjs';
+
+const REQUIRED_ENV = {
+    DISCORD_BOT_TOKEN: 'bot-token',
+    DISCORD_CLIENT_ID: 'client-id',
+    DISCORD_GUILD_ID: 'guild-id',
+    KAVITA_BASE_URL: 'https://kavita.example',
+    KAVITA_API_KEY: 'kavita-api-key',
+    VAULT_BASE_URL: 'https://vault.example',
+};
+
+test('safeLoadPortalConfig uses VAULT_API_TOKEN when override is provided', () => {
+    const config = safeLoadPortalConfig({
+        ...REQUIRED_ENV,
+        VAULT_ACCESS_TOKEN: undefined,
+        VAULT_API_TOKEN: 'api-token-override',
+    });
+
+    assert.equal(config.vault.token, 'api-token-override');
+});
+
+test('safeLoadPortalConfig throws when no vault tokens are provided', () => {
+    assert.throws(
+        () =>
+            safeLoadPortalConfig({
+                ...REQUIRED_ENV,
+                VAULT_ACCESS_TOKEN: undefined,
+                VAULT_API_TOKEN: undefined,
+            }),
+        /Missing required environment variables: VAULT_ACCESS_TOKEN/,
+    );
+});


### PR DESCRIPTION
## Summary
- allow the portal config loader to accept VAULT_ACCESS_TOKEN or VAULT_API_TOKEN and fall back to the latter
- cover the fallback and missing-token failure cases with new configuration tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2b1b071d48331a58a91643030e2af

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for VAULT_API_TOKEN as an alternative to VAULT_ACCESS_TOKEN; when both are set, VAULT_API_TOKEN takes precedence.
- Bug Fixes
  - Improved configuration validation with clearer errors when no vault token is provided.
- Tests
  - Added unit tests covering token precedence and error handling when neither token is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->