### PR TITLE
Preserve portal Discord state during service refresh

### DIFF
--- a/services/moon/src/pages/__tests__/Setup.spec.js
+++ b/services/moon/src/pages/__tests__/Setup.spec.js
@@ -102,4 +102,162 @@ describe('Setup installer logs', () => {
       'fifth log entry',
     ]);
   });
+
+  it('keeps the Discord connection intact while refreshing services during portal install', async () => {
+    vi.useFakeTimers();
+
+    const createServiceEntry = (overrides = {}) => ({
+      name: 'noona-portal',
+      installed: false,
+      required: true,
+      envConfig: [
+        { key: 'DISCORD_BOT_TOKEN', defaultValue: '' },
+        { key: 'DISCORD_GUILD_ID', defaultValue: '' },
+      ],
+      ...overrides,
+    });
+
+    const baseServices = [
+      createServiceEntry(),
+      { name: 'noona-vault', installed: false, required: true },
+      { name: 'noona-redis', installed: true, required: true },
+      { name: 'noona-mongo', installed: true, required: true },
+    ];
+
+    const installedServices = [
+      createServiceEntry({ installed: true }),
+      { name: 'noona-vault', installed: true, required: true },
+      { name: 'noona-redis', installed: true, required: true },
+      { name: 'noona-mongo', installed: true, required: true },
+    ];
+
+    const serviceResponses = [
+      { services: baseServices },
+      { services: installedServices },
+      { services: installedServices },
+    ];
+
+    global.fetch = vi.fn(async (input, init = {}) => {
+      const url = typeof input === 'string' ? input : input?.url || '';
+      const method = init?.method || (typeof input === 'object' ? input?.method : undefined);
+
+      if (url.includes('/install/progress')) {
+        return {
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              status: 'complete',
+              percent: 100,
+              items: [],
+            }),
+        };
+      }
+
+      if (url.includes('/installation/logs')) {
+        return {
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ entries: [] }),
+        };
+      }
+
+      if (url.includes('/noona-portal/test')) {
+        return {
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ success: true }),
+        };
+      }
+
+      if (url.includes('/setup/install') && method === 'POST') {
+        return {
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              results: [
+                { name: 'noona-portal', status: 'installed' },
+                { name: 'noona-vault', status: 'installed' },
+              ],
+            }),
+        };
+      }
+
+      if (url.includes('/api/setup/services')) {
+        const response = serviceResponses.shift() || serviceResponses[serviceResponses.length - 1];
+        return {
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(response),
+        };
+      }
+
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({}),
+      };
+    });
+
+    const wrapper = mount(Setup, {
+      global: {
+        stubs: {
+          Header: {
+            template: '<div><slot /></div>',
+          },
+        },
+        config: {
+          compilerOptions: {
+            isCustomElement: (tag) => tag.startsWith('v-'),
+          },
+        },
+      },
+    });
+
+    try {
+      await flushPromises();
+      await nextTick();
+
+      wrapper.vm.activeStepIndex = 1;
+      await nextTick();
+
+      const portalEnv = wrapper.vm.portalEnvForm;
+      portalEnv.DISCORD_BOT_TOKEN = 'token-value';
+      portalEnv.DISCORD_GUILD_ID = 'guild-value';
+
+      const state = wrapper.vm.portalDiscordState;
+      state.verified = true;
+      state.guild = { id: 'guild-value', name: 'Guild Name' };
+      state.roles = [{ id: 'role-id', name: 'Role Name' }];
+      state.channels = [{ id: 'channel-id', name: 'Channel Name' }];
+      state.lastVerifiedToken = 'token-value';
+      state.lastVerifiedGuildId = 'guild-value';
+
+      const resetSpy = vi.spyOn(wrapper.vm, 'resetPortalDiscordState');
+      resetSpy.mockClear();
+
+      await wrapper.vm.installCurrentStep();
+      await flushPromises();
+      await nextTick();
+      vi.runAllTimers();
+      await flushPromises();
+      await nextTick();
+
+      expect(wrapper.vm.portalDiscordState.verified).toBe(true);
+      expect(wrapper.vm.portalDiscordState.guild).toEqual({
+        id: 'guild-value',
+        name: 'Guild Name',
+      });
+      expect(wrapper.vm.portalDiscordState.roles).toEqual([
+        { id: 'role-id', name: 'Role Name' },
+      ]);
+      expect(wrapper.vm.portalDiscordState.channels).toEqual([
+        { id: 'channel-id', name: 'Channel Name' },
+      ]);
+      expect(resetSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- allow `refreshServices` to keep the current UI state and optionally skip resetting the portal Discord data
- reuse the non-resetting refresh path during the portal installation flow and fix the retry button click handler
- add a setup page test that confirms the Discord connection remains verified while the portal step refreshes services

## Testing
- npm run test -- Setup

------
https://chatgpt.com/codex/tasks/task_e_68e2bab32a108331bd50565bd5f60012

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves Discord portal connection during service refreshes in setup, preventing unintended disconnects while installing steps.
  * Improves loading state handling for smoother, more predictable UI feedback during refresh operations.
  * Ensures the Retry button reliably triggers a refresh action.

* **Tests**
  * Added coverage to verify the Discord portal connection remains intact during portal install refresh, including roles, channels, and guild details, and that a reset is not triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->