### PR TITLE
Fix Raven setup button disabled by string install status

### DIFF
--- a/services/moon/src/utils/__tests__/serviceInstallationStore.test.ts
+++ b/services/moon/src/utils/__tests__/serviceInstallationStore.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __resetServiceInstallationStore,
+  useServiceInstallationStore,
+} from '../../utils/serviceInstallationStore.js';
+
+const mockResponse = (body: unknown) => ({
+  ok: true,
+  json: async () => body,
+});
+
+describe('serviceInstallationStore', () => {
+  beforeEach(() => {
+    __resetServiceInstallationStore();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('normalises string installation statuses as installed', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        mockResponse({
+          services: [
+            { name: 'noona-raven', installed: 'installed' },
+            { name: 'noona-portal', status: 'ready' },
+            { name: 'noona-mongo', installed: false },
+          ],
+        }),
+      );
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fetchMock as typeof fetch);
+
+    const store = useServiceInstallationStore();
+    const services = await store.ensureLoaded();
+
+    const raven = services.find((service) => service.name === 'noona-raven');
+    expect(raven?.installed).toBe(true);
+
+    const portal = services.find((service) => service.name === 'noona-portal');
+    expect(portal?.installed).toBe(true);
+
+    const mongo = services.find((service) => service.name === 'noona-mongo');
+    expect(mongo?.installed).toBe(false);
+  });
+});

--- a/services/moon/src/utils/serviceInstallationStore.js
+++ b/services/moon/src/utils/serviceInstallationStore.js
@@ -106,6 +106,35 @@ const navigationItems = computed(() =>
     }),
 );
 
+const INSTALLED_STATUS_VALUES = new Set([
+    'installed',
+    'ready',
+    'healthy',
+    'running',
+    'complete',
+    'completed',
+]);
+
+function resolveInstalled(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return false;
+    }
+
+    if (entry.installed === true) {
+        return true;
+    }
+
+    const candidate = entry.installed ?? entry.status;
+    if (typeof candidate === 'string') {
+        const normalized = candidate.trim().toLowerCase();
+        if (INSTALLED_STATUS_VALUES.has(normalized)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 function normaliseServices(payload) {
     if (!payload || typeof payload !== 'object') {
         return [];
@@ -121,7 +150,7 @@ function normaliseServices(payload) {
 
         normalised.push({
             ...entry,
-            installed: entry.installed === true,
+            installed: resolveInstalled(entry),
         });
     }
 


### PR DESCRIPTION
## Summary
- accept string-based install indicators when normalizing services in the setup store
- cover the normalization with a vitest that exercises string "installed" and "ready" values

## Testing
- npm test (from services/moon)


------
https://chatgpt.com/codex/tasks/task_e_68e31ab7ef688331b1cf6d370571bd98