### PR TITLE
Fix Raven dependency detection on setup flow

### DIFF
--- a/services/moon/src/utils/__tests__/serviceStatus.test.ts
+++ b/services/moon/src/utils/__tests__/serviceStatus.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getInstalledStatusValues,
+  normalizeServiceList,
+  normalizeServiceEntry,
+  resolveServiceInstalled,
+} from '../../utils/serviceStatus.js';
+
+describe('serviceStatus', () => {
+  describe('resolveServiceInstalled', () => {
+    it('returns true for explicit boolean true', () => {
+      expect(resolveServiceInstalled({ installed: true })).toBe(true);
+    });
+
+    it('returns true for recognised status strings', () => {
+      for (const value of getInstalledStatusValues()) {
+        expect(resolveServiceInstalled({ status: value })).toBe(true);
+        expect(resolveServiceInstalled({ installed: value.toUpperCase() })).toBe(true);
+      }
+    });
+
+    it('returns false for unknown values', () => {
+      expect(resolveServiceInstalled({ installed: 'pending' })).toBe(false);
+      expect(resolveServiceInstalled({ status: 'waiting' })).toBe(false);
+      expect(resolveServiceInstalled({})).toBe(false);
+    });
+  });
+
+  describe('normalizeServiceEntry', () => {
+    it('returns null for invalid entries', () => {
+      expect(normalizeServiceEntry(null)).toBeNull();
+      expect(normalizeServiceEntry({})).toBeNull();
+      expect(normalizeServiceEntry({ name: '   ' })).toBeNull();
+    });
+
+    it('normalises name and installed flag', () => {
+      expect(
+        normalizeServiceEntry({ name: '  noona-raven  ', installed: 'ready' }),
+      ).toEqual({ name: 'noona-raven', installed: true });
+    });
+  });
+
+  describe('normalizeServiceList', () => {
+    it('normalises services from payload shape', () => {
+      const services = normalizeServiceList({
+        services: [
+          { name: 'noona-portal', installed: 'installed' },
+          { name: '  noona-raven  ', status: 'running' },
+          { name: 'invalid' },
+        ],
+      });
+
+      expect(services).toEqual([
+        { name: 'noona-portal', installed: true },
+        { name: 'noona-raven', status: 'running', installed: true },
+        { name: 'invalid', installed: false },
+      ]);
+    });
+
+    it('accepts raw arrays', () => {
+      const services = normalizeServiceList([
+        { name: 'noona-redis', installed: false },
+        { name: 'noona-mongo', status: 'complete' },
+      ]);
+
+      expect(services).toEqual([
+        { name: 'noona-redis', installed: false },
+        { name: 'noona-mongo', status: 'complete', installed: true },
+      ]);
+    });
+  });
+});

--- a/services/moon/src/utils/serviceSelection.js
+++ b/services/moon/src/utils/serviceSelection.js
@@ -1,3 +1,5 @@
+import { resolveServiceInstalled } from './serviceStatus.js';
+
 export function isServiceRequired(service) {
   return Boolean(service && service.required === true);
 }
@@ -15,7 +17,7 @@ export function mergeRequiredSelections(services = [], previousSelection = []) {
 
   for (const service of services) {
     const name = normalizeName(service);
-    if (!name || service?.installed === true) {
+    if (!name || resolveServiceInstalled(service)) {
       continue;
     }
 

--- a/services/moon/src/utils/serviceStatus.js
+++ b/services/moon/src/utils/serviceStatus.js
@@ -1,0 +1,86 @@
+const INSTALLED_STATUS_VALUES = new Set([
+  'installed',
+  'ready',
+  'healthy',
+  'running',
+  'complete',
+  'completed',
+  'success',
+  'successful',
+]);
+
+function normalizeName(name) {
+  if (typeof name !== 'string') {
+    return '';
+  }
+
+  return name.trim();
+}
+
+export function resolveServiceInstalled(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return false;
+  }
+
+  if (entry.installed === true) {
+    return true;
+  }
+
+  const candidate = entry.installed ?? entry.status;
+  if (typeof candidate === 'boolean') {
+    return candidate;
+  }
+
+  if (typeof candidate === 'string') {
+    const normalized = candidate.trim().toLowerCase();
+    if (normalized === 'true') {
+      return true;
+    }
+
+    if (INSTALLED_STATUS_VALUES.has(normalized)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function normalizeServiceEntry(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+
+  const name = normalizeName(entry.name);
+  if (!name) {
+    return null;
+  }
+
+  return {
+    ...entry,
+    name,
+    installed: resolveServiceInstalled(entry),
+  };
+}
+
+export function normalizeServiceList(payload) {
+  const raw = Array.isArray(payload?.services)
+    ? payload.services
+    : Array.isArray(payload)
+    ? payload
+    : [];
+
+  const normalized = [];
+
+  for (const entry of raw) {
+    const normalisedEntry = normalizeServiceEntry(entry);
+    if (normalisedEntry) {
+      normalized.push(normalisedEntry);
+    }
+  }
+
+  return normalized;
+}
+
+export function getInstalledStatusValues() {
+  return new Set(INSTALLED_STATUS_VALUES);
+}


### PR DESCRIPTION
## Summary
- add shared utilities to normalize service installation status responses
- update the setup flow to honour normalized statuses so Raven installs once Portal is ready
- reuse the helpers across the installation store and cover them with unit tests

## Testing
- npm test (from services/moon)


------
https://chatgpt.com/codex/tasks/task_e_68e32c6e908c833194ff837dee5b05a5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - More accurate detection of installed services, preventing already-installed items from appearing as installable.
  - Corrected step progression and completion in the setup flow based on reliable installation status.
  - “Installed” badges now display consistently with actual service states.

- Refactor
  - Unified service status normalization and checks across the setup experience for consistent behavior.

- Tests
  - Added comprehensive tests covering service status normalization and installed-state resolution, including edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->