### PR TITLE
Revamp Raven setup step

### DIFF
--- a/services/moon/src/pages/__tests__/Setup.test.ts
+++ b/services/moon/src/pages/__tests__/Setup.test.ts
@@ -953,7 +953,7 @@ describe('Setup page', () => {
 
     const handshakeButton = wrapper
       .findAll('button')
-      .find((node) => node.text().includes('Run Raven Check'));
+      .find((node) => node.text().includes('Verify Raven'));
     expect(handshakeButton).toBeDefined();
 
     await handshakeButton!.trigger('click');
@@ -1022,7 +1022,7 @@ describe('Setup page', () => {
 
     const handshakeButton = wrapper
       .findAll('button')
-      .find((node) => node.text().includes('Run Raven Check'));
+      .find((node) => node.text().includes('Verify Raven'));
     expect(handshakeButton).toBeDefined();
 
     await handshakeButton!.trigger('click');
@@ -1032,7 +1032,7 @@ describe('Setup page', () => {
 
     expect(vm.$.setupState.ravenAction.success).toBe(false);
     expect(vm.$.setupState.ravenAction.completed).toBe(false);
-    expect(vm.$.setupState.ravenAction.message).toBe('');
+    expect(vm.$.setupState.ravenAction.message).toContain('Checking Raven configuration');
     expect(vm.$.setupState.ravenAction.error).toContain('Kavita data mount not detected automatically');
     expect(wrapper.text()).toContain('Kavita data mount not detected automatically');
 


### PR DESCRIPTION
## Summary
- add Raven-specific status tracking, dependency checks, and service constants to the setup workflow
- teach the wizard to fall back to installing Raven, auto-install when running the handshake, and provide a manual refresh option
- redesign the Raven step UI with status chips, contextual messaging, and updated vitest coverage for the new flow

## Testing
- npm test -- src/pages/__tests__/Setup.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e331559d548331a987e27c62b11589