### PR TITLE
Improve setup wizard completion flow

### DIFF
--- a/services/moon/src/pages/Setup.vue
+++ b/services/moon/src/pages/Setup.vue
@@ -260,6 +260,8 @@ const showProgressDetails = ref(false);
 const showStepInfo = ref(false);
 const progressLogsLoading = ref(false);
 const activeStepIndex = ref(0);
+const wizardComplete = ref(false);
+const wizardCompletionTimestamp = ref(0);
 
 const portalDiscordEndpointBase = computed(() => {
   const endpoint = activeServicesEndpoint.value;
@@ -1425,6 +1427,7 @@ const resetStepState = () => {
   portalAction.loading = false;
   portalAction.success = false;
   portalAction.error = '';
+  portalAction.completed = false;
 
   ravenAction.loading = false;
   ravenAction.success = false;
@@ -1450,6 +1453,7 @@ const refreshServices = async (options) => {
   const keepUi = options?.keepUi === true;
   const skipPortalReset = options?.skipPortalReset === true;
   const silent = options?.silent === true;
+  const preserveStep = keepUi || options?.preserveStep === true;
 
   if (!keepUi && !silent) {
     state.loading = true;
@@ -1490,6 +1494,7 @@ const refreshServices = async (options) => {
           services,
           Array.from(previousSelection),
         );
+        syncWizardStatus({ preserveStep });
         return;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -1505,6 +1510,7 @@ const refreshServices = async (options) => {
     } else {
       state.loadError = 'Unable to retrieve installable services.';
     }
+    syncWizardStatus({ preserveStep });
   } finally {
     if (!keepUi && !silent) {
       state.loading = false;
@@ -1975,6 +1981,11 @@ const runRavenHandshake = async () => {
       ravenAction.message = `Kavita data mount detected at ${detection.mountPath}.`;
       ravenAction.success = true;
       ravenAction.completed = true;
+      installSuccessMessageVisible.value = true;
+      const ravenStepIndex = STEP_DEFINITIONS.findIndex((step) => step.key === 'raven');
+      if (ravenStepIndex !== -1) {
+        activeStepIndex.value = ravenStepIndex;
+      }
       await refreshServices({ keepUi: true, silent: true, skipPortalReset: true });
       return;
     }
@@ -1986,6 +1997,11 @@ const runRavenHandshake = async () => {
       ravenAction.message = `Using manual Kavita data mount ${manualOverride.hostPath}${suffix}.`;
       ravenAction.success = true;
       ravenAction.completed = true;
+      installSuccessMessageVisible.value = true;
+      const ravenStepIndex = STEP_DEFINITIONS.findIndex((step) => step.key === 'raven');
+      if (ravenStepIndex !== -1) {
+        activeStepIndex.value = ravenStepIndex;
+      }
       await refreshServices({ keepUi: true, silent: true, skipPortalReset: true });
       return;
     }
@@ -2028,6 +2044,80 @@ const isStepActionComplete = (stepKey) => {
 const isStepComplete = (stepKey) =>
   isStepInstalled(stepKey) && isStepActionComplete(stepKey);
 
+const totalWizardSteps = STEP_DEFINITIONS.length;
+
+const completedStepCount = computed(() =>
+  STEP_DEFINITIONS.reduce(
+    (count, step) => (isStepComplete(step.key) ? count + 1 : count),
+    0,
+  ),
+);
+
+const wizardProgressPercent = computed(() => {
+  if (totalWizardSteps === 0) {
+    return 0;
+  }
+
+  return Math.round((completedStepCount.value / totalWizardSteps) * 100);
+});
+
+const wizardProgressLabel = computed(
+  () => `${completedStepCount.value} / ${totalWizardSteps} steps complete`,
+);
+
+const wizardCompletionMessage = computed(() => {
+  if (!wizardComplete.value) {
+    return '';
+  }
+
+  if (!wizardCompletionTimestamp.value) {
+    return 'Setup complete! All services are installed and verified.';
+  }
+
+  const finishedAt = new Date(wizardCompletionTimestamp.value);
+  if (Number.isNaN(finishedAt.getTime())) {
+    return 'Setup complete! All services are installed and verified.';
+  }
+
+  return `Setup complete! All services are installed and verified as of ${finishedAt.toLocaleTimeString()}.`;
+});
+
+const findFirstIncompleteStepIndex = () =>
+  STEP_DEFINITIONS.findIndex((step) => !isStepComplete(step.key));
+
+const syncWizardStatus = ({ preserveStep = false } = {}) => {
+  const incompleteIndex = findFirstIncompleteStepIndex();
+
+  if (incompleteIndex === -1) {
+    if (!wizardComplete.value) {
+      wizardCompletionTimestamp.value = Date.now();
+    }
+    wizardComplete.value = true;
+
+    if (!preserveStep) {
+      activeStepIndex.value = Math.max(0, STEP_DEFINITIONS.length - 1);
+    } else if (!isStepUnlocked(currentStep.value.key)) {
+      activeStepIndex.value = Math.max(0, STEP_DEFINITIONS.length - 1);
+    }
+
+    return;
+  }
+
+  if (wizardComplete.value) {
+    wizardCompletionTimestamp.value = 0;
+  }
+
+  wizardComplete.value = false;
+
+  if (!preserveStep) {
+    if (activeStepIndex.value !== incompleteIndex) {
+      activeStepIndex.value = incompleteIndex;
+    }
+  } else if (!isStepUnlocked(currentStep.value.key)) {
+    activeStepIndex.value = incompleteIndex;
+  }
+};
+
 const isStepUnlocked = (stepKey) => {
   const index = STEP_DEFINITIONS.findIndex((step) => step.key === stepKey);
   if (index <= 0) {
@@ -2040,11 +2130,14 @@ const isStepUnlocked = (stepKey) => {
 
 const goToStep = (index) => {
   if (index < 0 || index >= STEP_DEFINITIONS.length) return;
-  if (index === activeStepIndex.value) return;
   const targetStep = STEP_DEFINITIONS[index];
   if (!isStepUnlocked(targetStep.key)) return;
+
   resetStepState();
-  activeStepIndex.value = index;
+
+  if (index !== activeStepIndex.value) {
+    activeStepIndex.value = index;
+  }
 };
 
 const canGoToNextStep = computed(() => {
@@ -2082,6 +2175,14 @@ const hasStepInfo = computed(
   () => currentStepInfoEntries.value.length > 0 || hasPortalStatusMessage.value,
 );
 
+const portalOverviewMessage = computed(() => {
+  if (!portalAction.success) {
+    return '';
+  }
+
+  return 'Portal bot verified successfully.';
+});
+
 watch(
   activeStepIndex,
   (nextIndex, previousIndex) => {
@@ -2108,6 +2209,24 @@ watch(showProgressDetails, (value) => {
     progressLogsLoading.value = false;
   }
 });
+
+watch(serviceStatusSignature, () => {
+  syncWizardStatus({ preserveStep: true });
+});
+
+watch(
+  () => portalAction.completed,
+  () => {
+    syncWizardStatus({ preserveStep: true });
+  },
+);
+
+watch(
+  () => ravenAction.completed,
+  () => {
+    syncWizardStatus({ preserveStep: true });
+  },
+);
 
 watch(
   () => [portalAction.loading, portalAction.success, portalAction.error],
@@ -2203,6 +2322,45 @@ onMounted(() => {
               </v-alert>
 
               <div v-else>
+                <div class="wizard-overview mb-6">
+                  <div class="wizard-overview__progress">
+                    <v-progress-linear
+                      :model-value="wizardProgressPercent"
+                      height="8"
+                      color="primary"
+                      rounded
+                    />
+                    <div class="wizard-overview__label text-body-2 text-medium-emphasis mt-2">
+                      {{ wizardProgressLabel }}
+                    </div>
+                  </div>
+                  <v-alert
+                    v-if="wizardComplete"
+                    type="success"
+                    variant="tonal"
+                    border="start"
+                    class="wizard-overview__completion"
+                    data-test="wizard-complete"
+                  >
+                    <p class="wizard-overview__message mb-1 font-weight-medium">
+                      {{ wizardCompletionMessage }}
+                    </p>
+                    <p class="wizard-overview__hint mb-0 text-body-2 text-medium-emphasis">
+                      You can revisit any step if you need to review configuration details.
+                    </p>
+                  </v-alert>
+                  <v-alert
+                    v-else-if="portalOverviewMessage"
+                    type="success"
+                    variant="tonal"
+                    border="start"
+                    class="wizard-overview__portal"
+                    data-test="portal-overview-success"
+                  >
+                    {{ portalOverviewMessage }}
+                  </v-alert>
+                </div>
+
                 <div class="setup-stepper" role="tablist">
                   <v-btn
                     v-for="(step, index) in STEP_DEFINITIONS"
@@ -2921,6 +3079,30 @@ onMounted(() => {
 <style scoped>
 .setup-loading {
   width: 100%;
+}
+
+.wizard-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.wizard-overview__progress {
+  display: flex;
+  flex-direction: column;
+}
+
+.wizard-overview__completion {
+  margin-top: 4px;
+}
+
+.wizard-overview__portal {
+  margin-top: 4px;
+}
+
+.wizard-overview__message,
+.wizard-overview__hint {
+  line-height: 1.4;
 }
 
 .setup-stepper {

--- a/services/moon/src/pages/Setup.vue
+++ b/services/moon/src/pages/Setup.vue
@@ -1935,6 +1935,14 @@ const installServicesDirect = async (services) => {
   return Array.isArray(payload?.results) ? payload.results : [];
 };
 
+const advanceToRavenStep = () => {
+  installSuccessMessageVisible.value = true;
+  const ravenStepIndex = STEP_DEFINITIONS.findIndex((step) => step.key === 'raven');
+  if (ravenStepIndex !== -1) {
+    activeStepIndex.value = ravenStepIndex;
+  }
+};
+
 const runRavenHandshake = async () => {
   if (ravenAction.loading || installing.value) return;
 
@@ -1981,11 +1989,7 @@ const runRavenHandshake = async () => {
       ravenAction.message = `Kavita data mount detected at ${detection.mountPath}.`;
       ravenAction.success = true;
       ravenAction.completed = true;
-      installSuccessMessageVisible.value = true;
-      const ravenStepIndex = STEP_DEFINITIONS.findIndex((step) => step.key === 'raven');
-      if (ravenStepIndex !== -1) {
-        activeStepIndex.value = ravenStepIndex;
-      }
+      advanceToRavenStep();
       await refreshServices({ keepUi: true, silent: true, skipPortalReset: true });
       return;
     }
@@ -1997,11 +2001,7 @@ const runRavenHandshake = async () => {
       ravenAction.message = `Using manual Kavita data mount ${manualOverride.hostPath}${suffix}.`;
       ravenAction.success = true;
       ravenAction.completed = true;
-      installSuccessMessageVisible.value = true;
-      const ravenStepIndex = STEP_DEFINITIONS.findIndex((step) => step.key === 'raven');
-      if (ravenStepIndex !== -1) {
-        activeStepIndex.value = ravenStepIndex;
-      }
+      advanceToRavenStep();
       await refreshServices({ keepUi: true, silent: true, skipPortalReset: true });
       return;
     }

--- a/services/raven/src/main/java/com/paxkun/raven/service/LoggerService.java
+++ b/services/raven/src/main/java/com/paxkun/raven/service/LoggerService.java
@@ -212,7 +212,15 @@ public class LoggerService implements InitializingBean {
 
     private void logSystemEnvironment() {
         write("SYSTEM", "APPDATA", System.getenv("APPDATA"));
+        String kavitaMount = resolveKavitaDataMountEnv();
+        write("SYSTEM", "KAVITA_DATA_MOUNT", kavitaMount != null && !kavitaMount.isBlank() ? kavitaMount : "(not set)");
+        Path root = getDownloadsRoot();
+        write("SYSTEM", "DOWNLOADS_ROOT", root != null ? root.toAbsolutePath().toString() : "(unavailable)");
         write("SYSTEM", "USER", System.getProperty("user.name"));
         write("SYSTEM", "OS", System.getProperty("os.name") + " " + System.getProperty("os.version"));
+    }
+
+    protected String resolveKavitaDataMountEnv() {
+        return System.getenv("KAVITA_DATA_MOUNT");
     }
 }

--- a/services/raven/src/test/java/com/paxkun/raven/service/LoggerServiceTest.java
+++ b/services/raven/src/test/java/com/paxkun/raven/service/LoggerServiceTest.java
@@ -52,5 +52,28 @@ class LoggerServiceTest {
         assertThat(service.getDownloadsRoot()).isEqualTo(containerFallback);
         assertThat(output).contains("⚠️ Failed to create APPDATA downloads directory");
     }
+
+    @Test
+    void logsKavitaMountAndDownloadsRoot(CapturedOutput output) throws IOException {
+        Path tempRoot = Files.createTempDirectory("logger-service-env");
+
+        LoggerService service = new LoggerService() {
+            @Override
+            protected Path resolveAppDataDownloadsPath() {
+                return tempRoot;
+            }
+
+            @Override
+            protected String resolveKavitaDataMountEnv() {
+                return "/data/kavita";
+            }
+        };
+
+        service.afterPropertiesSet();
+
+        assertThat(output).contains("[SYSTEM] [KAVITA_DATA_MOUNT] /data/kavita");
+        assertThat(output)
+                .contains("[SYSTEM] [DOWNLOADS_ROOT] " + tempRoot.toAbsolutePath());
+    }
 }
 

--- a/services/raven/src/test/java/com/paxkun/raven/service/LoggerServiceTest.java
+++ b/services/raven/src/test/java/com/paxkun/raven/service/LoggerServiceTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Comparator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -56,24 +57,64 @@ class LoggerServiceTest {
     @Test
     void logsKavitaMountAndDownloadsRoot(CapturedOutput output) throws IOException {
         Path tempRoot = Files.createTempDirectory("logger-service-env");
+        try {
+            LoggerService service = new LoggerService() {
+                @Override
+                protected Path resolveAppDataDownloadsPath() {
+                    return tempRoot;
+                }
 
-        LoggerService service = new LoggerService() {
-            @Override
-            protected Path resolveAppDataDownloadsPath() {
-                return tempRoot;
-            }
+                @Override
+                protected String resolveKavitaDataMountEnv() {
+                    return "/data/kavita";
+                }
+            };
 
-            @Override
-            protected String resolveKavitaDataMountEnv() {
-                return "/data/kavita";
-            }
-        };
+            service.afterPropertiesSet();
 
-        service.afterPropertiesSet();
+            assertThat(output).contains("[SYSTEM] [KAVITA_DATA_MOUNT] /data/kavita");
+            assertThat(output)
+                    .contains("[SYSTEM] [DOWNLOADS_ROOT] " + tempRoot.toAbsolutePath());
+        } finally {
+            deleteRecursively(tempRoot);
+        }
+    }
 
-        assertThat(output).contains("[SYSTEM] [KAVITA_DATA_MOUNT] /data/kavita");
-        assertThat(output)
-                .contains("[SYSTEM] [DOWNLOADS_ROOT] " + tempRoot.toAbsolutePath());
+    @Test
+    void logsKavitaMountNotSetWhenBlank(CapturedOutput output) throws IOException {
+        Path tempRoot = Files.createTempDirectory("logger-service-env");
+        try {
+            LoggerService service = new LoggerService() {
+                @Override
+                protected Path resolveAppDataDownloadsPath() {
+                    return tempRoot;
+                }
+
+                @Override
+                protected String resolveKavitaDataMountEnv() {
+                    return null;
+                }
+            };
+
+            service.afterPropertiesSet();
+
+            assertThat(output).contains("[SYSTEM] [KAVITA_DATA_MOUNT] (not set)");
+        } finally {
+            deleteRecursively(tempRoot);
+        }
+    }
+
+    private static void deleteRecursively(Path root) {
+        try (var paths = Files.walk(root)) {
+            paths.sorted(Comparator.reverseOrder())
+                    .forEach(path -> {
+                        try {
+                            Files.delete(path);
+                        } catch (IOException ignored) {
+                        }
+                    });
+        } catch (IOException ignored) {
+        }
     }
 }
 

--- a/services/sage/shared/sageApp.mjs
+++ b/services/sage/shared/sageApp.mjs
@@ -358,15 +358,6 @@ export const createSageApp = ({
     app.get('/api/setup/services/installation/logs', async (req, res) => {
         try {
             const history = await setupClient.getInstallationLogs({ limit: req.query?.limit })
-            if (!history) {
-                res.json({
-                    service: 'installation',
-                    entries: [],
-                    summary: { status: 'idle', percent: null, detail: null, updatedAt: null },
-                })
-                return
-            }
-
             res.json(history)
         } catch (error) {
             logger.error(`[${serviceName}] ⚠️ Failed to load installation logs: ${error.message}`)


### PR DESCRIPTION
## Summary
- add wizard progress tracking, completion banner, and portal success overview to the setup wizard
- keep the active step aligned with install status by syncing wizard state on service refreshes and action completion
- update Raven handshake success to surface the install success message and retain the Raven step

## Testing
- npm test (from `services/moon`)


------
https://chatgpt.com/codex/tasks/task_e_68e3d27bab008331af7357117b374d27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Setup wizard adds an overall progress bar, completion message, clearer portal overview, and updated button labels.
  - New endpoint and client method to fetch installation logs with optional limit.

- Improvements
  - Wizard progress now stays synchronized across service refreshes and preserves the current step.
  - Step navigation reduced redundant updates and advances correctly after Raven/portal success.

- Tests
  - End-to-end tests for full install flow and new installation-logs scenarios; tests now drive steps programmatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->