### PR TITLE
Prioritize service endpoints to avoid setup console errors

### DIFF
--- a/services/moon/src/pages/__tests__/Setup.test.ts
+++ b/services/moon/src/pages/__tests__/Setup.test.ts
@@ -663,7 +663,11 @@ describe('Setup page', () => {
       .map(([arg]) => (typeof arg === 'string' ? arg : arg instanceof URL ? arg.toString() : ''))
       .filter((call) => call.includes('/installation/logs'));
 
-    expect(logRequestsAfterOpen).toContain('/api/setup/services/installation/logs?limit=3');
+    expect(logRequestsAfterOpen).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('/api/setup/services/installation/logs?limit=3'),
+      ]),
+    );
 
     const initialLogs = wrapper
       .find('.progress-logs__body')
@@ -690,7 +694,7 @@ describe('Setup page', () => {
       .filter((call) => call.includes('/installation/logs'));
 
     const lastLogRequest = logRequests[logRequests.length - 1];
-    expect(lastLogRequest).toBe('/api/setup/services/installation/logs?limit=3');
+    expect(lastLogRequest).toContain('/api/setup/services/installation/logs?limit=3');
 
     const updatedLogs = wrapper
       .find('.progress-logs__body')
@@ -773,13 +777,21 @@ describe('Setup page', () => {
       .map(([arg]) => (typeof arg === 'string' ? arg : arg instanceof URL ? arg.toString() : ''))
       .filter((call) => call.includes('/install/progress'));
 
-    expect(progressRequests).toContain('/api/services/install/progress');
+    expect(progressRequests).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('/api/services/install/progress'),
+      ]),
+    );
 
     const logRequests = fetchMock.mock.calls
       .map(([arg]) => (typeof arg === 'string' ? arg : arg instanceof URL ? arg.toString() : ''))
       .filter((call) => call.includes('/installation/logs'));
 
-    expect(logRequests).toContain('/api/services/installation/logs?limit=3');
+    expect(logRequests).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('/api/services/installation/logs?limit=3'),
+      ]),
+    );
 
     const initialLogs = wrapper
       .find('.progress-logs__body')
@@ -805,8 +817,9 @@ describe('Setup page', () => {
       .map(([arg]) => (typeof arg === 'string' ? arg : arg instanceof URL ? arg.toString() : ''))
       .filter((call) => call.includes('/installation/logs'));
 
-    const lastFallbackLogRequest = updatedLogRequests[updatedLogRequests.length - 1];
-    expect(lastFallbackLogRequest).toBe('/api/services/installation/logs?limit=3');
+    const lastFallbackLogRequest =
+      updatedLogRequests[updatedLogRequests.length - 1];
+    expect(lastFallbackLogRequest).toContain('/api/services/installation/logs?limit=3');
 
     const updatedLogs = wrapper
       .find('.progress-logs__body')

--- a/services/moon/src/utils/serviceEndpoints.test.js
+++ b/services/moon/src/utils/serviceEndpoints.test.js
@@ -1,0 +1,87 @@
+import {afterAll, afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+import {buildServiceEndpointCandidates} from './serviceEndpoints.js';
+
+const ORIGINAL_ENV_ENTRIES = Object.entries(import.meta.env).filter(([key]) =>
+  key.startsWith('VITE_'),
+);
+
+const ORIGINAL_HREF = typeof window !== 'undefined' ? window.location.href : '';
+
+const resetViteEnv = () => {
+  for (const key of Object.keys(import.meta.env)) {
+    if (key.startsWith('VITE_')) {
+      delete import.meta.env[key];
+    }
+  }
+
+  for (const [key, value] of ORIGINAL_ENV_ENTRIES) {
+    import.meta.env[key] = value;
+  }
+};
+
+describe('buildServiceEndpointCandidates', () => {
+  beforeEach(() => {
+    resetViteEnv();
+    if (typeof window !== 'undefined') {
+      window.location.href = ORIGINAL_HREF || 'http://localhost:4173/';
+    }
+  });
+
+  afterEach(() => {
+    resetViteEnv();
+    if (typeof window !== 'undefined') {
+      window.location.href = ORIGINAL_HREF || 'http://localhost:4173/';
+    }
+  });
+
+  afterAll(() => {
+    resetViteEnv();
+    if (typeof window !== 'undefined' && ORIGINAL_HREF) {
+      window.location.href = ORIGINAL_HREF;
+    }
+  });
+
+  it('prioritizes environment-provided base URLs before other candidates', () => {
+    import.meta.env.VITE_API_BASE = 'http://warden.local/api';
+
+    const candidates = buildServiceEndpointCandidates();
+
+    expect(candidates[0]).toBe('http://warden.local/api/setup/services');
+    expect(candidates[1]).toBe('http://warden.local/api/services?includeInstalled=false');
+    expect(candidates[2]).toBe('http://warden.local/api/services');
+  });
+
+  it('prefers backend-friendly localhost ports before same-origin fallbacks', () => {
+    if (typeof window !== 'undefined') {
+      window.location.href = 'http://localhost:3000/';
+    }
+
+    const candidates = buildServiceEndpointCandidates();
+
+    expect(candidates[0]).toBe('http://localhost:3004/api/setup/services');
+    expect(candidates[1]).toBe('http://localhost:3004/api/services?includeInstalled=false');
+
+    const relativeIndex = candidates.indexOf('/api/setup/services');
+    expect(relativeIndex).toBeGreaterThan(1);
+    expect(candidates.slice(-3)).toEqual([
+      '/api/setup/services',
+      '/api/services?includeInstalled=false',
+      '/api/services',
+    ]);
+  });
+
+  it('includes explicit service endpoints supplied via environment variables once', () => {
+    import.meta.env.VITE_WARDEN_SERVICES_URL =
+      'http://warden.local/api/services?includeInstalled=false';
+
+    const candidates = buildServiceEndpointCandidates();
+
+    const occurrences = candidates.filter((candidate) =>
+      candidate === 'http://warden.local/api/services?includeInstalled=false',
+    );
+
+    expect(occurrences).toHaveLength(1);
+    expect(candidates[0]).toBe('http://warden.local/api/services?includeInstalled=false');
+  });
+});


### PR DESCRIPTION
## Summary
- reprioritize service endpoint candidates so backend hosts are attempted before same-origin fallbacks
- add focused unit coverage for the service endpoint builder and relax setup tests to accept absolute API URLs

## Testing
- npm test (services/moon)


------
https://chatgpt.com/codex/tasks/task_e_68e3f5db9a108331b57dd1d5f1e4585c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Smarter auto-detection of service endpoints with prioritized, de-duplicated candidates.
  * Improved handling of environment-configured URLs and localhost ports for more reliable connections.

* **Bug Fixes**
  * Reduces incorrect or duplicate endpoint choices, improving stability across different origins and ports.

* **Tests**
  * Added comprehensive tests for endpoint candidate generation and prioritization.
  * Updated existing tests to use more flexible matchers for API call verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->