### PR TITLE
Allow Moon setup to progress without portal services

### DIFF
--- a/services/moon/src/pages/Setup.vue
+++ b/services/moon/src/pages/Setup.vue
@@ -756,6 +756,8 @@ const getStepServices = (stepKey) => {
     .filter(Boolean);
 };
 
+const hasPortalStepServices = computed(() => getStepServices('portal').length > 0);
+
 const arePortalStepServicesInstalled = () => {
   const services = getStepServices('portal');
   if (!services.length) {
@@ -2036,7 +2038,12 @@ const isStepInstalled = (stepKey) => {
 };
 
 const isStepActionComplete = (stepKey) => {
-  if (stepKey === 'portal') return portalAction.completed;
+  if (stepKey === 'portal') {
+    if (!hasPortalStepServices.value) {
+      return true;
+    }
+    return portalAction.completed;
+  }
   if (stepKey === 'raven') return ravenAction.completed;
   return true;
 };

--- a/services/moon/src/pages/__tests__/Setup.test.ts
+++ b/services/moon/src/pages/__tests__/Setup.test.ts
@@ -171,6 +171,37 @@ describe('Setup page', () => {
     expect(selects.length).toBeGreaterThan(0);
   });
 
+  it('keeps the portal step unlocked when services fail to load', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse({ services: [] }));
+
+    const wrapper = mount(SetupPage, {
+      global: { stubs },
+    });
+
+    await flushAsync();
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as {
+      $: {
+        setupState: {
+          activeStepIndex: number;
+        };
+      };
+    };
+
+    vm.$.setupState.activeStepIndex = 1;
+
+    await wrapper.vm.$nextTick();
+
+    const stepperItems = wrapper.findAll('.setup-stepper__item');
+    expect(stepperItems.length).toBeGreaterThan(1);
+    expect(stepperItems[1].classes()).toContain('setup-stepper__item--complete');
+
+    const nextButton = wrapper.find('button.setup-step__next');
+    expect(nextButton.exists()).toBe(true);
+    expect(nextButton.attributes('disabled')).toBeUndefined();
+  });
+
   it('requires Discord validation before unlocking portal resources', async () => {
     const discordPayload = {
       guild: { id: '123', name: 'Noona Guild' },


### PR DESCRIPTION
## Summary
- mark the portal setup step as complete when no services are returned from the setup API so the wizard can reach Raven
- add coverage that ensures the portal step remains unlocked when service discovery yields no entries

## Testing
- npm run test (services/moon)


------
https://chatgpt.com/codex/tasks/task_e_68e403d457d483318528eaf8ab964742

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Setup flow now keeps the portal step accessible when service data fails to load or no services are defined.
  * The portal step is automatically marked complete when no portal services are available, allowing users to proceed without interruption.

* **Tests**
  * Added test coverage to ensure the portal step remains unlocked and the next button is enabled when services fail to load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->